### PR TITLE
Include label of whether subject is online or in-person for 2021 subject lists json files

### DIFF
--- a/subject-utils/scripts/subjectListScraper.ts
+++ b/subject-utils/scripts/subjectListScraper.ts
@@ -37,9 +37,13 @@ type BaseURL = string;
  */
 const getBaseURL = (year: number, studyPeriod: SubjectPeriod, online:boolean)  =>{
   // tslint:disable-next-line:max-line-length
+
+  //for all online subjects set URL attribute campus_and_attendance_mode[]=Online
   if(online){
     return `https://handbook.unimelb.edu.au/search?types[]=subject&year=${year}&subject_level_type[]=all&study_periods[]=${studyPeriod.toLowerCase()}&area_of_study[]=all&org_unit[]=all&campus_and_attendance_mode[]=Online&sort=external_code%7Casc`;
   }
+
+  //otherwise set URL attribute campus_and_attendance_mode[]=Dual-Delivery&campus_and_attendance_mode[]=Off+Campus
   else {
     return `https://handbook.unimelb.edu.au/search?types[]=subject&year=${year}&subject_level_type[]=all&study_periods[]=${studyPeriod.toLowerCase()}&area_of_study[]=all&org_unit[]=all&campus_and_attendance_mode[]=Dual-Delivery&campus_and_attendance_mode[]=Off+Campus&sort=external_code%7Casc`;
   }
@@ -187,7 +191,7 @@ years.forEach((year) => {
 
     // first scrape all subjects that are only offline ("Dual-Deliver", "Off+Campus") subjects,
     // then scrape all subjects that are online ("Online"),
-    // then merge them into one file
+    // then concat subject lists into one array
     // alternative: if we want separate online/offline subject json files, make an outer for each loop through [true,false]
     scrapeSubjects(year, period, false).then((offlineSubjects) => {
       scrapeSubjects(year, period, true).then((onlineSubjects) => {

--- a/subject-utils/scripts/subjectListScraper.ts
+++ b/subject-utils/scripts/subjectListScraper.ts
@@ -36,19 +36,33 @@ type BaseURL = string;
  * @param online Whether the subject is online only
  */
 const getBaseURL = (year: number, studyPeriod: SubjectPeriod, online:boolean)  =>{
-  // tslint:disable-next-line:max-line-length
 
-  //for all online subjects set URL attribute campus_and_attendance_mode[]=Online
-  if(online){
-    return `https://handbook.unimelb.edu.au/search?types[]=subject&year=${year}&subject_level_type[]=all&study_periods[]=${studyPeriod.toLowerCase()}&area_of_study[]=all&org_unit[]=all&campus_and_attendance_mode[]=Online&sort=external_code%7Casc`;
-  }
+  let queryParameters = [
+    'types[]=subject',
+    `year=${year}`,
+    `study_periods[]=${studyPeriod.toLowerCase()}`,
+    'subject_level_type[]=all',
+    'area_of_study[]=all',
+    'org_unit[]=all',
+  ];
+  // not necessary to include the =all parameters
 
-  //otherwise set URL attribute campus_and_attendance_mode[]=Dual-Delivery&campus_and_attendance_mode[]=Off+Campus
-  else {
-    return `https://handbook.unimelb.edu.au/search?types[]=subject&year=${year}&subject_level_type[]=all&study_periods[]=${studyPeriod.toLowerCase()}&area_of_study[]=all&org_unit[]=all&campus_and_attendance_mode[]=Dual-Delivery&campus_and_attendance_mode[]=Off+Campus&sort=external_code%7Casc`;
-  }
+  const campusAttendanceModes = online ? ['Online'] :
+      ['Dual-Delivery', 'Off+Campus'];
+
+  // now make it a valid query param
+  campusAttendanceModes.map(mode => 'campus_and_attendance_mode[]=' + mode);
+
+  // and append the attendance mode params to the initial array of parameters
+  queryParameters = queryParameters.concat(campusAttendanceModes);
+
+  // now construct final URI by joining all the parameters
+  return 'https://handbook.unimelb.edu.au/search?' +
+      queryParameters.reduce((acc, param) => acc + '&' + param);
+
 };
-  /**
+
+/**
  * Returns the number of pages given a base search URL
  */
 const getPageCount = async (baseURL: BaseURL) => {

--- a/subject-utils/subject-lists/subjects_2021_april.json
+++ b/subject-utils/subject-lists/subjects_2021_april.json
@@ -1,87 +1,27 @@
 [
  {
-  "code": "BUSA90001",
-  "name": "Financial Accounting",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90014",
-  "name": "Brand Management",
-  "offered": [
-   "summer_term",
-   "april",
-   "june"
-  ]
- },
- {
-  "code": "BUSA90026",
-  "name": "Business Strategy",
-  "offered": [
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90060",
-  "name": "Data Analysis",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90074",
-  "name": "Global Business Economics",
-  "offered": [
-   "january",
-   "april",
-   "june"
-  ]
- },
- {
-  "code": "BUSA90090",
-  "name": "Financial Institutions",
+  "code": "LAWS70176",
+  "name": "Construction Law",
   "offered": [
    "april"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90093",
-  "name": "Finance",
+  "code": "SOCI90004",
+  "name": "Contemporary Social Problems",
   "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
+   "april"
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90193",
-  "name": "Managerial Economics",
+  "code": "CUMC90005",
+  "name": "Conservation Assessment and Treatment 2",
   "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90201",
-  "name": "Managerial Project",
-  "offered": [
-   "summer_term",
-   "april",
-   "may",
-   "june"
-  ]
+   "april"
+  ],
+  "online": false
  },
  {
   "code": "BUSA90224",
@@ -91,17 +31,55 @@
    "april",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90227",
-  "name": "Operations",
+  "code": "LAWS70203",
+  "name": "Transfer Pricing: Practice and Problems",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90522",
+  "name": "Applied Analytics Lab",
+  "offered": [
+   "january",
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90479",
+  "name": "MBA Internship",
+  "offered": [
+   "january",
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "REHB90012",
+  "name": "Rehabilitation Professional Project",
+  "offered": [
+   "semester_1",
+   "april",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90060",
+  "name": "Data Analysis",
   "offered": [
    "january",
    "april",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90243",
@@ -111,162 +89,47 @@
    "april",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90261",
-  "name": "Marketing Strategy",
-  "offered": [
-   "april",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90270",
-  "name": "Mergers and Acquisitions",
-  "offered": [
-   "april",
-   "june"
-  ]
- },
- {
-  "code": "BUSA90273",
-  "name": "Negotiations",
-  "offered": [
-   "february",
-   "april",
-   "june"
-  ]
- },
- {
-  "code": "BUSA90341",
-  "name": "Supply Chain Management",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "BUSA90479",
-  "name": "MBA Internship",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "BUSA90481",
-  "name": "Managerial Ethics & Business Environment",
+  "code": "BUSA90201",
+  "name": "Managerial Project",
   "offered": [
    "summer_term",
+   "january",
    "april",
-   "march",
+   "may",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90093",
+  "name": "Finance",
+  "offered": [
+   "january",
+   "april",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90491",
-  "name": "Game Theory for Business Strategy",
+  "code": "PADM90019",
+  "name": "Democracy, Power and the Public Service",
   "offered": [
    "april"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90498",
-  "name": "Leading in Transformational Times",
+  "code": "EVSC90022",
+  "name": "Bushfire Urban Planning",
   "offered": [
    "april"
-  ]
- },
- {
-  "code": "BUSA90505",
-  "name": "Executive Management 1",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "BUSA90519",
-  "name": "Internet Marketing & Electronic Commerce",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "BUSA90522",
-  "name": "Applied Analytics Lab",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "CHEM90042",
-  "name": "Automatic Chemical Analysis",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "CHEM90044",
-  "name": "Synchrotron & NMR Structural Techniques",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "CLRS90028",
-  "name": "Advanced Clinical Trial Design",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "CLRS90029",
-  "name": "Research Development and Translation",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "CLRS90031",
-  "name": "Research Development & Translation Pt 2",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "CUMC90005",
-  "name": "Conservation Assessment and Treatment 2",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "CUMC90027",
-  "name": "RESPECT",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "EDUC90140",
-  "name": "Curriculum Leadership and Management",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "EDUC90505",
-  "name": "Listening and the Learning Environment",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "EDUC90683",
-  "name": "Reading Texts: Selection to Response",
-  "offered": [
-   "april"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90846",
@@ -274,47 +137,8 @@
   "offered": [
    "april",
    "september"
-  ]
- },
- {
-  "code": "EDUC90987",
-  "name": "Clinical Teaching Practice (EC&P) 4",
-  "offered": [
-   "semester_1",
-   "april"
-  ]
- },
- {
-  "code": "EDUC91024",
-  "name": "Professional Pedagogical Practices (P3)",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "ENST90034",
-  "name": "Adapting to Climate Change",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "EVSC90022",
-  "name": "Bushfire Urban Planning",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "FINA20033",
-  "name": "Introduction to Printmaking Processes",
-  "offered": [
-   "summer_term",
-   "march",
-   "april",
-   "june",
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "FINA20045",
@@ -326,272 +150,64 @@
    "winter_term",
    "june",
    "september"
-  ]
- },
- {
-  "code": "FRST90022",
-  "name": "Ecosystem Processes of Water and Soil",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "GEOL90048",
-  "name": "Sedimentary Basins and Resource Analysis",
-  "offered": [
-   "april"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "HIST90038",
   "name": "Enlightenment and Revolutions 1750-1820",
   "offered": [
    "april"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "HLTH90004",
-  "name": "Health & Human Services Research Project",
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
   "offered": [
-   "april"
-  ]
- },
- {
-  "code": "INDG90003",
-  "name": "Disruption and Change",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "LAWS70024",
-  "name": "Corporate Tax A",
-  "offered": [
+   "summer_term",
    "april",
-   "semester_2"
-  ]
- },
- {
-  "code": "LAWS70100",
-  "name": "Environmental Law",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "LAWS70176",
-  "name": "Construction Law",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "LAWS70203",
-  "name": "Transfer Pricing: Practice and Problems",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "LAWS70308",
-  "name": "International Economic Law",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "LAWS70421",
-  "name": "Law and Emerging Health Technologies",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "LAWS90103",
-  "name": "Private Law and Government",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "LAWS90168",
-  "name": "Animal Law and Policy",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "LAWS90205",
-  "name": "Digital Technologies and Labour Law",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "LAWS90208",
-  "name": "Law of Construction Delay and Disruption",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "MEDI90019",
-  "name": "Clinical Research Proposal",
-  "offered": [
-   "april",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90107",
-  "name": "Disaster Medicine Principles & Responses",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "MGMT90182",
-  "name": "Innovation and Entrepreneurship Strategy",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "MGMT90255",
-  "name": "Designing Supply Chains",
-  "offered": [
-   "april",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90272",
-  "name": "Procurement and Supply Management",
-  "offered": [
-   "february",
-   "april",
+   "march",
    "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90273",
-  "name": "Service Supply Chain Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90274",
-  "name": "Supply Chain Finance and Contracts",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90275",
-  "name": "Sustainable Supply Chain Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90276",
-  "name": "Logistics and Transportation Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90277",
-  "name": "Supply Chain Intelligence",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90278",
-  "name": "Supply Chain Strategy",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90279",
-  "name": "Supply Chain Technologies",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MKTG90039",
-  "name": "Marketing Analytics",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "PADM90009",
-  "name": "Working Ethically",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "PADM90019",
-  "name": "Democracy, Power and the Public Service",
-  "offered": [
-   "april"
-  ]
- },
- {
-  "code": "PHIL90022",
-  "name": "Thinking and Acting Ethically",
-  "offered": [
-   "april"
-  ]
+   "september"
+  ],
+  "online": false
  },
  {
   "code": "POPH90112",
   "name": "Infectious Disease Epidemiology",
   "offered": [
    "april"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PSYT90097",
-  "name": "Engaging and Assessing Young People",
+  "code": "GEOL90048",
+  "name": "Sedimentary Basins and Resource Analysis",
   "offered": [
    "april"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PSYT90101",
-  "name": "Early Intervention in Mental Health",
+  "code": "BUSA90479",
+  "name": "MBA Internship",
   "offered": [
+   "january",
    "april"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90243",
+  "name": "Marketing",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
   "code": "REHB90012",
@@ -600,7 +216,157 @@
    "semester_1",
    "april",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90201",
+  "name": "Managerial Project",
+  "offered": [
+   "summer_term",
+   "january",
+   "april",
+   "may",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20045",
+  "name": "Introduction to Screenprinting",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "winter_term",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90093",
+  "name": "Finance",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90019",
+  "name": "Democracy, Power and the Public Service",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "EVSC90022",
+  "name": "Bushfire Urban Planning",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90846",
+  "name": "Learning Intervention 2",
+  "offered": [
+   "april",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90168",
+  "name": "Animal Law and Policy",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70421",
+  "name": "Law and Emerging Health Technologies",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90341",
+  "name": "Supply Chain Management",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91024",
+  "name": "Professional Pedagogical Practices (P3)",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90101",
+  "name": "Early Intervention in Mental Health",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90205",
+  "name": "Digital Technologies and Labour Law",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90090",
+  "name": "Financial Institutions",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70100",
+  "name": "Environmental Law",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90071",
+  "name": "Social Work Research Project",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLRS90031",
+  "name": "Research Development & Translation Pt 2",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90498",
+  "name": "Leading in Transformational Times",
+  "offered": [
+   "april"
+  ],
+  "online": false
  },
  {
   "code": "SCWK90049",
@@ -610,7 +376,585 @@
    "april",
    "june",
    "october"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90255",
+  "name": "Designing Supply Chains",
+  "offered": [
+   "april",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST90022",
+  "name": "Ecosystem Processes of Water and Soil",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90009",
+  "name": "Working Ethically",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90261",
+  "name": "Marketing Strategy",
+  "offered": [
+   "april",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90193",
+  "name": "Managerial Economics",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90505",
+  "name": "Executive Management 1",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90019",
+  "name": "Clinical Research Proposal",
+  "offered": [
+   "april",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90039",
+  "name": "Marketing Analytics",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90107",
+  "name": "Disaster Medicine Principles & Responses",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90505",
+  "name": "Listening and the Learning Environment",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90276",
+  "name": "Logistics and Transportation Management",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90491",
+  "name": "Game Theory for Business Strategy",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90519",
+  "name": "Internet Marketing & Electronic Commerce",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG90003",
+  "name": "Disruption and Change",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90067",
+  "name": "Special Topics in Finance D",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90097",
+  "name": "Engaging and Assessing Young People",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90279",
+  "name": "Supply Chain Technologies",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90027",
+  "name": "RESPECT",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90276",
+  "name": "Logistics and Transportation Management",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90009",
+  "name": "Working Ethically",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90193",
+  "name": "Managerial Economics",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90261",
+  "name": "Marketing Strategy",
+  "offered": [
+   "april",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90505",
+  "name": "Executive Management 1",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90019",
+  "name": "Clinical Research Proposal",
+  "offered": [
+   "april",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90039",
+  "name": "Marketing Analytics",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG90003",
+  "name": "Disruption and Change",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90097",
+  "name": "Engaging and Assessing Young People",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90279",
+  "name": "Supply Chain Technologies",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90067",
+  "name": "Special Topics in Finance D",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90027",
+  "name": "RESPECT",
+  "offered": [
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90048",
+  "name": "Sedimentary Basins and Resource Analysis",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90074",
+  "name": "Global Business Economics",
+  "offered": [
+   "january",
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90270",
+  "name": "Mergers and Acquisitions",
+  "offered": [
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70024",
+  "name": "Corporate Tax A",
+  "offered": [
+   "april",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90208",
+  "name": "Law of Construction Delay and Disruption",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90038",
+  "name": "Enlightenment and Revolutions 1750-1820",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
+  "offered": [
+   "summer_term",
+   "april",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90112",
+  "name": "Infectious Disease Epidemiology",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "HLTH90004",
+  "name": "Health & Human Services Research Project",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90042",
+  "name": "Automatic Chemical Analysis",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90026",
+  "name": "Business Strategy",
+  "offered": [
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70308",
+  "name": "International Economic Law",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20033",
+  "name": "Introduction to Printmaking Processes",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70176",
+  "name": "Construction Law",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI90004",
+  "name": "Contemporary Social Problems",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90224",
+  "name": "Managing People",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70203",
+  "name": "Transfer Pricing: Practice and Problems",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90522",
+  "name": "Applied Analytics Lab",
+  "offered": [
+   "january",
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90060",
+  "name": "Data Analysis",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90005",
+  "name": "Conservation Assessment and Treatment 2",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90074",
+  "name": "Global Business Economics",
+  "offered": [
+   "january",
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90270",
+  "name": "Mergers and Acquisitions",
+  "offered": [
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70024",
+  "name": "Corporate Tax A",
+  "offered": [
+   "april",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90208",
+  "name": "Law of Construction Delay and Disruption",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90042",
+  "name": "Automatic Chemical Analysis",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70308",
+  "name": "International Economic Law",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "HLTH90004",
+  "name": "Health & Human Services Research Project",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90026",
+  "name": "Business Strategy",
+  "offered": [
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20033",
+  "name": "Introduction to Printmaking Processes",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90044",
+  "name": "Synchrotron & NMR Structural Techniques",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLRS90028",
+  "name": "Advanced Clinical Trial Design",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL90022",
+  "name": "Thinking and Acting Ethically",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90034",
+  "name": "Adapting to Climate Change",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90087",
+  "name": "Transboundary Animal Diseases",
+  "offered": [
+   "april"
+  ],
+  "online": true
  },
  {
   "code": "SCWK90051",
@@ -620,27 +964,334 @@
    "april",
    "june",
    "october"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCWK90071",
-  "name": "Social Work Research Project",
+  "code": "LAWS90103",
+  "name": "Private Law and Government",
   "offered": [
    "april"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SOCI90004",
-  "name": "Contemporary Social Problems",
+  "code": "EDUC90140",
+  "name": "Curriculum Leadership and Management",
   "offered": [
    "april"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS90087",
-  "name": "Transboundary Animal Diseases",
+  "code": "BUSA90273",
+  "name": "Negotiations",
+  "offered": [
+   "february",
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90683",
+  "name": "Reading Texts: Selection to Response",
   "offered": [
    "april"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "CLRS90029",
+  "name": "Research Development and Translation",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90049",
+  "name": "Supervised Field Placement 1B",
+  "offered": [
+   "summer_term",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90255",
+  "name": "Designing Supply Chains",
+  "offered": [
+   "april",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90022",
+  "name": "Ecosystem Processes of Water and Soil",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90009",
+  "name": "Working Ethically",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90261",
+  "name": "Marketing Strategy",
+  "offered": [
+   "april",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90193",
+  "name": "Managerial Economics",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90505",
+  "name": "Executive Management 1",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90019",
+  "name": "Clinical Research Proposal",
+  "offered": [
+   "april",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90039",
+  "name": "Marketing Analytics",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90107",
+  "name": "Disaster Medicine Principles & Responses",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90505",
+  "name": "Listening and the Learning Environment",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90276",
+  "name": "Logistics and Transportation Management",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90491",
+  "name": "Game Theory for Business Strategy",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90519",
+  "name": "Internet Marketing & Electronic Commerce",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG90003",
+  "name": "Disruption and Change",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90067",
+  "name": "Special Topics in Finance D",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90097",
+  "name": "Engaging and Assessing Young People",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90279",
+  "name": "Supply Chain Technologies",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90027",
+  "name": "RESPECT",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90276",
+  "name": "Logistics and Transportation Management",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90009",
+  "name": "Working Ethically",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90193",
+  "name": "Managerial Economics",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90261",
+  "name": "Marketing Strategy",
+  "offered": [
+   "april",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90505",
+  "name": "Executive Management 1",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90019",
+  "name": "Clinical Research Proposal",
+  "offered": [
+   "april",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90039",
+  "name": "Marketing Analytics",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG90003",
+  "name": "Disruption and Change",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90097",
+  "name": "Engaging and Assessing Young People",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90279",
+  "name": "Supply Chain Technologies",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90067",
+  "name": "Special Topics in Finance D",
+  "offered": [
+   "april"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90027",
+  "name": "RESPECT",
+  "offered": [
+   "april"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_august.json
+++ b/subject-utils/subject-lists/subjects_2021_august.json
@@ -1,147 +1,36 @@
 [
  {
-  "code": "ABPL90355",
-  "name": "Issues and Techniques in Global Heritage",
+  "code": "LAWS70314",
+  "name": "Principles of Construction Law",
   "offered": [
+   "march",
    "august"
-  ]
- },
- {
-  "code": "ANSC90006",
-  "name": "Genetics and Animal Breeding",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "ANTH30019",
-  "name": "Innovation, Design, and Society",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "BUSA90482",
-  "name": "General Management 1",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "BUSA90501",
-  "name": "Advanced Business Analytics",
-  "offered": [
-   "may",
-   "august"
-  ]
- },
- {
-  "code": "BUSA90502",
-  "name": "Analytics Lab",
-  "offered": [
-   "august",
-   "october"
-  ]
- },
- {
-  "code": "BUSA90504",
-  "name": "Individual Research Project",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "BUSA90507",
-  "name": "Executive Management 3",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "BUSA90524",
-  "name": "Fintech: Blockchain in the New Economy",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "CHEM90040",
-  "name": "Biological and Medicinal Chemistry",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "CHEM90041",
-  "name": "Exciton Science",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "CHEM90049",
-  "name": "Advanced Materials & Characterisation",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "CLRS90010",
-  "name": "Data Analysis in Clinical Research",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "CRIM90010",
-  "name": "Crime Prevention: Critical Approaches",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "CUMC90032",
-  "name": "Technical Examination and Documentation",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "DEVT90062",
-  "name": "Development and Inequality",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "ECON20010",
-  "name": "TDM International Negotiation",
-  "offered": [
-   "january",
-   "august"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90482",
   "name": "Linguistics and Sociolinguistics of CLIL",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90508",
-  "name": "Language & Literacy Intervention",
+  "code": "FRST90034",
+  "name": "Ecological Restoration",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90587",
-  "name": "Grammar for Language Teachers",
+  "code": "LAWS50042",
+  "name": "Jessup Moot",
   "offered": [
-   "march",
    "august"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90631",
@@ -149,282 +38,128 @@
   "offered": [
    "march",
    "august"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90504",
+  "name": "Individual Research Project",
+  "offered": [
+   "august"
+  ],
+  "online": false
  },
  {
   "code": "EDUC90642",
   "name": "Critical Thinking and Curriculum",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90728",
-  "name": "Innovative Spaces and Pedagogy",
+  "code": "PADM90002",
+  "name": "Managing Effectively",
   "offered": [
-   "semester_1",
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90752",
-  "name": "Researching Leadership Practice",
+  "code": "PPMN90010",
+  "name": "Professional Practice in Policy Research",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90801",
   "name": "Clinical Education Modules",
   "offered": [
    "august"
-  ]
- },
- {
-  "code": "EDUC90802",
-  "name": "Research in Clinical Education",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "EDUC90805",
-  "name": "Clinical Simulation",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "EDUC90877",
-  "name": "Clinical Teaching Practice (Prim) 1",
-  "offered": [
-   "semester_1",
-   "august"
-  ]
- },
- {
-  "code": "EDUC90878",
-  "name": "Clinical Teaching Practice (Prim) 2",
-  "offered": [
-   "semester_1",
-   "august"
-  ]
- },
- {
-  "code": "EDUC90881",
-  "name": "Diverse and Inclusive Classrooms (Prim)",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "EDUC90884",
-  "name": "Integrating Clinical Practice (Prim)",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "EDUC90892",
-  "name": "Clinical Teaching Practice (EC) 1",
-  "offered": [
-   "semester_1",
-   "august"
-  ]
- },
- {
-  "code": "EDUC90893",
-  "name": "Clinical Teaching Practice (EC) 2",
-  "offered": [
-   "semester_1",
-   "august"
-  ]
- },
- {
-  "code": "EDUC90894",
-  "name": "Clinical Teaching Practice (EC) 3",
-  "offered": [
-   "semester_1",
-   "august"
-  ]
- },
- {
-  "code": "EDUC90936",
-  "name": "Communities of Arts Practices",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "EDUC91006",
-  "name": "Clinical Teaching Practice (Prim) 1 PT",
-  "offered": [
-   "semester_1",
-   "august"
-  ]
- },
- {
-  "code": "ERTH90060",
-  "name": "Spatial Data Analytics and Geoprocessing",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "FLTV20021",
-  "name": "Melbourne Film Festival Studio",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "FRST90034",
-  "name": "Ecological Restoration",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "GEOL90046",
-  "name": "Environmental Geology Field Techniques",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "GEOL90049",
-  "name": "Introduction to Structural Geology",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "INDG90005",
-  "name": "Indigenous Leadership",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS50042",
-  "name": "Jessup Moot",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS70025",
-  "name": "Equality and Discrimination at Work",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS70028",
-  "name": "International Trade Law",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS70061",
-  "name": "Interpretation and Validity of Patents",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS70111",
-  "name": "Debt Capital Markets",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS70133",
-  "name": "Construction Dispute Resolution",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS70161",
-  "name": "International Petroleum Transactions",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS70219",
-  "name": "International Environmental Law",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS70314",
-  "name": "Principles of Construction Law",
-  "offered": [
-   "march",
-   "august"
-  ]
- },
- {
-  "code": "LAWS70336",
-  "name": "Advanced Commercial Law: Current Issues",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS70371",
-  "name": "Principles of Employment Law",
-  "offered": [
-   "march",
-   "august"
-  ]
- },
- {
-  "code": "LAWS70402",
-  "name": "Remedies in Commercial Law",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS70423",
-  "name": "International Mineral Law",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "LAWS90125",
-  "name": "Fundamentals of Intellectual Property",
-  "offered": [
-   "august"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS90174",
   "name": "Human Rights in Australia",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90126",
-  "name": "Budgets and Financial Management",
+  "code": "PSYT90024",
+  "name": "Consultation Liaison Psychiatry",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90244",
-  "name": "Leading in Data Driven Organisations",
+  "code": "EDUC90805",
+  "name": "Clinical Simulation",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70133",
+  "name": "Construction Dispute Resolution",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90242",
+  "name": "Epidemiology 2",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90058",
+  "name": "Conflict, Security and Development",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90355",
+  "name": "Issues and Techniques in Global Heritage",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC90006",
+  "name": "Genetics and Animal Breeding",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90272",
+  "name": "Procurement and Supply Management",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90936",
+  "name": "Communities of Arts Practices",
+  "offered": [
+   "august"
+  ],
+  "online": false
  },
  {
   "code": "MGMT90257",
@@ -432,21 +167,165 @@
   "offered": [
    "march",
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MULT90056",
-  "name": "Digital Archives: Tools and Methods",
+  "code": "CLRS90010",
+  "name": "Data Analysis in Clinical Research",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MULT90058",
-  "name": "Conflict, Security and Development",
+  "code": "EDUC90508",
+  "name": "Language & Literacy Intervention",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90093",
+  "name": "Psychiatric Research Project",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90003",
+  "name": "Managing Public Finances",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM90049",
+  "name": "Advanced Materials & Characterisation",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90884",
+  "name": "Integrating Clinical Practice (Prim)",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90014",
+  "name": "Leading Healthcare Change for Impact",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH30019",
+  "name": "Innovation, Design, and Society",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM90040",
+  "name": "Biological and Medicinal Chemistry",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70161",
+  "name": "International Petroleum Transactions",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90892",
+  "name": "Clinical Teaching Practice (EC) 1",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90894",
+  "name": "Clinical Teaching Practice (EC) 3",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90046",
+  "name": "Persuasion for Policymakers",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "ERTH90060",
+  "name": "Spatial Data Analytics and Geoprocessing",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90050",
+  "name": "Supervised Field Placement 2A",
+  "offered": [
+   "february",
+   "may",
+   "august",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90209",
+  "name": "Comparative Health Systems",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90126",
+  "name": "Budgets and Financial Management",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70111",
+  "name": "Debt Capital Markets",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90049",
+  "name": "Introduction to Structural Geology",
+  "offered": [
+   "august"
+  ],
+  "online": false
  },
  {
   "code": "ORAL30003",
@@ -459,84 +338,73 @@
    "june",
    "june",
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PADM90002",
-  "name": "Managing Effectively",
+  "code": "ECON20010",
+  "name": "TDM International Negotiation",
   "offered": [
+   "january",
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PADM90003",
-  "name": "Managing Public Finances",
+  "code": "LAWS70025",
+  "name": "Equality and Discrimination at Work",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PADM90014",
-  "name": "Leading Healthcare Change for Impact",
+  "code": "LAWS70336",
+  "name": "Advanced Commercial Law: Current Issues",
   "offered": [
    "august"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV20021",
+  "name": "Melbourne Film Festival Studio",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90802",
+  "name": "Research in Clinical Education",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "ERTH90060",
+  "name": "Spatial Data Analytics and Geoprocessing",
+  "offered": [
+   "august"
+  ],
+  "online": false
  },
  {
   "code": "POPH90209",
   "name": "Comparative Health Systems",
   "offered": [
    "august"
-  ]
- },
- {
-  "code": "POPH90242",
-  "name": "Epidemiology 2",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "PPMN90010",
-  "name": "Professional Practice in Policy Research",
-  "offered": [
-   "august"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "PPMN90046",
   "name": "Persuasion for Policymakers",
   "offered": [
    "august"
-  ]
- },
- {
-  "code": "PPMN90048",
-  "name": "Crisis Management",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "PSYT90024",
-  "name": "Consultation Liaison Psychiatry",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "PSYT90093",
-  "name": "Psychiatric Research Project",
-  "offered": [
-   "august"
-  ]
- },
- {
-  "code": "PSYT90094",
-  "name": "Special Topics in Psychiatry",
-  "offered": [
-   "august"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "SCWK90050",
@@ -546,6 +414,874 @@
    "may",
    "august",
    "november"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90126",
+  "name": "Budgets and Financial Management",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90062",
+  "name": "Development and Inequality",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70111",
+  "name": "Debt Capital Markets",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90501",
+  "name": "Advanced Business Analytics",
+  "offered": [
+   "may",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91006",
+  "name": "Clinical Teaching Practice (Prim) 1 PT",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90049",
+  "name": "Introduction to Structural Geology",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90244",
+  "name": "Leading in Data Driven Organisations",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90881",
+  "name": "Diverse and Inclusive Classrooms (Prim)",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90046",
+  "name": "Environmental Geology Field Techniques",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90273",
+  "name": "Service Supply Chain Management",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70061",
+  "name": "Interpretation and Validity of Patents",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90125",
+  "name": "Fundamentals of Intellectual Property",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70402",
+  "name": "Remedies in Commercial Law",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90507",
+  "name": "Executive Management 3",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90728",
+  "name": "Innovative Spaces and Pedagogy",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90010",
+  "name": "Crime Prevention: Critical Approaches",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90752",
+  "name": "Researching Leadership Practice",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90524",
+  "name": "Fintech: Blockchain in the New Economy",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20010",
+  "name": "TDM International Negotiation",
+  "offered": [
+   "january",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70336",
+  "name": "Advanced Commercial Law: Current Issues",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV20021",
+  "name": "Melbourne Film Festival Studio",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90056",
+  "name": "Digital Archives: Tools and Methods",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70025",
+  "name": "Equality and Discrimination at Work",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90587",
+  "name": "Grammar for Language Teachers",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70028",
+  "name": "International Trade Law",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90048",
+  "name": "Crisis Management",
+  "offered": [
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM90049",
+  "name": "Advanced Materials & Characterisation",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90884",
+  "name": "Integrating Clinical Practice (Prim)",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90014",
+  "name": "Leading Healthcare Change for Impact",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLRS90010",
+  "name": "Data Analysis in Clinical Research",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90508",
+  "name": "Language & Literacy Intervention",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90093",
+  "name": "Psychiatric Research Project",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90003",
+  "name": "Managing Public Finances",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH30019",
+  "name": "Innovation, Design, and Society",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70161",
+  "name": "International Petroleum Transactions",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90040",
+  "name": "Biological and Medicinal Chemistry",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90894",
+  "name": "Clinical Teaching Practice (EC) 3",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90892",
+  "name": "Clinical Teaching Practice (EC) 1",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70314",
+  "name": "Principles of Construction Law",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90482",
+  "name": "Linguistics and Sociolinguistics of CLIL",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50042",
+  "name": "Jessup Moot",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90631",
+  "name": "Second Language Acquisition and Teaching",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90642",
+  "name": "Critical Thinking and Curriculum",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90002",
+  "name": "Managing Effectively",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90010",
+  "name": "Professional Practice in Policy Research",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90805",
+  "name": "Clinical Simulation",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90257",
+  "name": "Supply Chain Challenges & Opportunities",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90049",
+  "name": "Advanced Materials & Characterisation",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90884",
+  "name": "Integrating Clinical Practice (Prim)",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90014",
+  "name": "Leading Healthcare Change for Impact",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLRS90010",
+  "name": "Data Analysis in Clinical Research",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90508",
+  "name": "Language & Literacy Intervention",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90093",
+  "name": "Psychiatric Research Project",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90003",
+  "name": "Managing Public Finances",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH30019",
+  "name": "Innovation, Design, and Society",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70161",
+  "name": "International Petroleum Transactions",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90040",
+  "name": "Biological and Medicinal Chemistry",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90894",
+  "name": "Clinical Teaching Practice (EC) 3",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90892",
+  "name": "Clinical Teaching Practice (EC) 1",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90010",
+  "name": "Crime Prevention: Critical Approaches",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90752",
+  "name": "Researching Leadership Practice",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90056",
+  "name": "Digital Archives: Tools and Methods",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90048",
+  "name": "Crisis Management",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90587",
+  "name": "Grammar for Language Teachers",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70028",
+  "name": "International Trade Law",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90524",
+  "name": "Fintech: Blockchain in the New Economy",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90062",
+  "name": "Development and Inequality",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90802",
+  "name": "Research in Clinical Education",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90244",
+  "name": "Leading in Data Driven Organisations",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90501",
+  "name": "Advanced Business Analytics",
+  "offered": [
+   "may",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90881",
+  "name": "Diverse and Inclusive Classrooms (Prim)",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91006",
+  "name": "Clinical Teaching Practice (Prim) 1 PT",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90046",
+  "name": "Environmental Geology Field Techniques",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90482",
+  "name": "General Management 1",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90273",
+  "name": "Service Supply Chain Management",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG90005",
+  "name": "Indigenous Leadership",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90893",
+  "name": "Clinical Teaching Practice (EC) 2",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90032",
+  "name": "Technical Examination and Documentation",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90041",
+  "name": "Exciton Science",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90094",
+  "name": "Special Topics in Psychiatry",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70423",
+  "name": "International Mineral Law",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90502",
+  "name": "Analytics Lab",
+  "offered": [
+   "august",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90878",
+  "name": "Clinical Teaching Practice (Prim) 2",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70371",
+  "name": "Principles of Employment Law",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70219",
+  "name": "International Environmental Law",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90877",
+  "name": "Clinical Teaching Practice (Prim) 1",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70061",
+  "name": "Interpretation and Validity of Patents",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90125",
+  "name": "Fundamentals of Intellectual Property",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70402",
+  "name": "Remedies in Commercial Law",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90507",
+  "name": "Executive Management 3",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90728",
+  "name": "Innovative Spaces and Pedagogy",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90010",
+  "name": "Crime Prevention: Critical Approaches",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90752",
+  "name": "Researching Leadership Practice",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90524",
+  "name": "Fintech: Blockchain in the New Economy",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON20010",
+  "name": "TDM International Negotiation",
+  "offered": [
+   "january",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70336",
+  "name": "Advanced Commercial Law: Current Issues",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20021",
+  "name": "Melbourne Film Festival Studio",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90056",
+  "name": "Digital Archives: Tools and Methods",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70025",
+  "name": "Equality and Discrimination at Work",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90587",
+  "name": "Grammar for Language Teachers",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70028",
+  "name": "International Trade Law",
+  "offered": [
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90048",
+  "name": "Crisis Management",
+  "offered": [
+   "august"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_february.json
+++ b/subject-utils/subject-lists/subjects_2021_february.json
@@ -1,264 +1,27 @@
 [
  {
-  "code": "ABPL90394",
-  "name": "ZEMCH Sustainable Design Workshop",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "ABPL90404",
-  "name": "Place Making for The Built Environment",
-  "offered": [
-   "february",
-   "winter_term"
-  ]
- },
- {
-  "code": "ABPL90419",
-  "name": "Contemporary Architectural Archives",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "AGRI10039",
-  "name": "Australia in the Wine World",
-  "offered": [
-   "february",
-   "june",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI20027",
-  "name": "Vine to Wine",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "AGRI20030",
-  "name": "Wine & Spirits:An Australian Perspective",
-  "offered": [
-   "february",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "AGRI30043",
-  "name": "Resource Management Economics",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "AGRI90088",
-  "name": "Business Strategy",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "AGRI90090",
-  "name": "Leadership",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "AMGT90029",
-  "name": "Applied Research Methods",
-  "offered": [
-   "february",
-   "winter_term"
-  ]
- },
- {
-  "code": "ASIA90015",
-  "name": "Conflict and Terrorism in Southeast Asia",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "ATOC90015",
-  "name": "Data Assimilation and Model Improvement",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "BIOM40001",
-  "name": "Introduction To Biomedical Research",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "BLAW20002",
-  "name": "Regulating Digital Platforms",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "BUSA90273",
-  "name": "Negotiations",
-  "offered": [
-   "february",
-   "april",
-   "june"
-  ]
- },
- {
-  "code": "CLRS90027",
-  "name": "Principles of Clinical Research",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "CVEN90069",
-  "name": "Dredging Engineering",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "CVEN90070",
-  "name": "Port and Harbour Engineering",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC20069",
-  "name": "Deafness and Communication",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC20078",
-  "name": "Pop-up Theatre: Performance in Community",
-  "offered": [
-   "february",
-   "june"
-  ]
- },
- {
-  "code": "EDUC30065",
-  "name": "Ethics, gender and the family",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90258",
-  "name": "Student Wellbeing: Current Approaches",
-  "offered": [
-   "february",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90287",
-  "name": "Promoting Positive Learning",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90367",
-  "name": "Foundational English Literacy",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90419",
-  "name": "Education Research Methodology",
-  "offered": [
-   "february",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90563",
-  "name": "Engaging Children in the Arts",
-  "offered": [
-   "february",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90579",
-  "name": "Interpersonal and Group Processes",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90619",
-  "name": "Leading Educational Ideas",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90628",
-  "name": "Relationship Skills for Educators 1",
-  "offered": [
-   "february",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90629",
-  "name": "Leading Change for Student Wellbeing",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90684",
-  "name": "21st Century Literacies: Policy & Praxis",
-  "offered": [
-   "february"
-  ]
- },
- {
   "code": "EDUC90705",
   "name": "Language & Literacy Learning in Children",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90741",
-  "name": "Effective Clinical Teaching",
+  "code": "SCWK90053",
+  "name": "Counselling and Interviewing Skills",
   "offered": [
-   "february",
-   "semester_2"
-  ]
+   "february"
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90742",
-  "name": "Effective Clinical Supervision",
+  "code": "LAWS50091",
+  "name": "International Investment Law",
   "offered": [
-   "february",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC90743",
-  "name": "Clinical Education in Practice",
-  "offered": [
-   "february",
-   "june"
-  ]
+   "february"
+  ],
+  "online": false
  },
  {
   "code": "EDUC90744",
@@ -266,149 +29,72 @@
   "offered": [
    "february",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90750",
-  "name": "Leading Schools Through Leading Self",
+  "code": "EDUC90287",
+  "name": "Promoting Positive Learning",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90755",
-  "name": "Evidence for Learning and Teaching",
+  "code": "SCWK90065",
+  "name": "Social Policy for Social Work Practice",
   "offered": [
    "february"
-  ]
- },
- {
-  "code": "EDUC90759",
-  "name": "Education Research Project",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90778",
-  "name": "Primary Mathematics Education 1",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90806",
-  "name": "Introduction to Positive Education",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90837",
-  "name": "Clinical Education Research Proposal",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90845",
-  "name": "Learning Intervention 1",
-  "offered": [
-   "february",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90872",
-  "name": "Foundations of the Science of Learning",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90875",
-  "name": "Literacy for the Primary Years",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90880",
-  "name": "Becoming a Clinical Practitioner (Prim)",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90889",
-  "name": "Scientific and Environmental Learning",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90891",
-  "name": "Becoming a Clinical Practitioner (EC)",
-  "offered": [
-   "february",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC90895",
-  "name": "Educational Foundations (EC)",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90896",
-  "name": "Educational Leadership (EC & Prim)",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90897",
-  "name": "Infant & Toddler Learning & Development",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90898",
-  "name": "Introduction to Clinical Practice (EC)",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90903",
-  "name": "Contemporary Education Debates",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90905",
-  "name": "Becoming a Clinical Practitioner (Sec)",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "EDUC90907",
-  "name": "Inclusive Language, Literacy & Numeracy",
-  "offered": [
-   "february"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90938",
   "name": "Quality Assessment Design",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90394",
+  "name": "ZEMCH Sustainable Design Workshop",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST30001",
+  "name": "Forest Systems",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST90025",
+  "name": "Patterns and Processes of Landscape Fire",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50106",
+  "name": "Murder",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLRS90027",
+  "name": "Principles of Clinical Research",
+  "offered": [
+   "february"
+  ],
+  "online": false
  },
  {
   "code": "EDUC90942",
@@ -416,49 +102,279 @@
   "offered": [
    "february",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90977",
-  "name": "Diverse and Inclusive Classrooms (EC&P)",
+  "code": "PHTY90013",
+  "name": "Paediatric Physiotherapy Theory",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC91001",
-  "name": "Science, Tech (Digital & Design) (EC&P)",
+  "code": "EDUC90742",
+  "name": "Effective Clinical Supervision",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90004",
+  "name": "Psychiatry of Old Age",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90806",
+  "name": "Introduction to Positive Education",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90859",
+  "name": "Autism Intervention",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90404",
+  "name": "Place Making for The Built Environment",
+  "offered": [
+   "february",
+   "winter_term"
+  ],
+  "online": false
  },
  {
   "code": "EDUC91002",
   "name": "Health and Physical Education (EC&P)",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20078",
+  "name": "Pop-up Theatre: Performance in Community",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20036",
+  "name": "Under Camera Animation",
+  "offered": [
+   "summer_term",
+   "february",
+   "winter_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "THTR20023",
+  "name": "The Artist's Toolbox",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20163",
+  "name": "Samba Band",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90579",
+  "name": "Interpersonal and Group Processes",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDS90035",
+  "name": "MD Research Skills 1",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90367",
+  "name": "Foundational English Literacy",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90086",
+  "name": "Epidemiology of Epidemics",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90258",
+  "name": "Student Wellbeing: Current Approaches",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90898",
+  "name": "Introduction to Clinical Practice (EC)",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50064",
+  "name": "Employment Law",
+  "offered": [
+   "february",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90563",
+  "name": "Engaging Children in the Arts",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90200",
+  "name": "Principles of Social Research Design",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90057",
+  "name": "Working with Groups and Communities",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90903",
+  "name": "Contemporary Education Debates",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90778",
+  "name": "Primary Mathematics Education 1",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90750",
+  "name": "Leading Schools Through Leading Self",
+  "offered": [
+   "february"
+  ],
+  "online": false
  },
  {
   "code": "EVSC90025",
   "name": "Water Sensitive Urban Design",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA10030",
-  "name": "Related Studies Photography",
+  "code": "EDUC90759",
+  "name": "Education Research Project",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA10039",
-  "name": "Related Studies Drawing & Printmedia",
+  "code": "EDUC90896",
+  "name": "Educational Leadership (EC & Prim)",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70468",
+  "name": "Negotiation Skills",
+  "offered": [
+   "february",
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90889",
+  "name": "Scientific and Environmental Learning",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90046",
+  "name": "Fundamentals of Palliative Care",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90064",
+  "name": "Lifespan Risk and Resilience",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM40001",
+  "name": "Introduction To Biomedical Research",
+  "offered": [
+   "february"
+  ],
+  "online": false
  },
  {
   "code": "FINA20026",
@@ -470,275 +386,189 @@
    "winter_term",
    "june",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA20036",
-  "name": "Under Camera Animation",
+  "code": "THTR30042",
+  "name": "Hashtag Cyberstar",
   "offered": [
    "summer_term",
    "february",
    "winter_term",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA20044",
-  "name": "Art and the Botanical",
+  "code": "ZOOL30008",
+  "name": "Experimental Marine Biology",
   "offered": [
-   "summer_term",
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90629",
+  "name": "Leading Change for Student Wellbeing",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90891",
+  "name": "Becoming a Clinical Practitioner (EC)",
+  "offered": [
    "february",
-   "semester_1",
-   "winter_term",
-   "june",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FRST30001",
-  "name": "Forest Systems",
+  "code": "SCWK90050",
+  "name": "Supervised Field Placement 2A",
   "offered": [
-   "february"
-  ]
+   "february",
+   "may",
+   "august",
+   "november"
+  ],
+  "online": false
  },
  {
-  "code": "FRST90025",
-  "name": "Patterns and Processes of Landscape Fire",
+  "code": "EDUC90977",
+  "name": "Diverse and Inclusive Classrooms (EC&P)",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "RADI90010",
+  "name": "Radiology for Physiotherapists",
+  "offered": [
+   "february"
+  ],
+  "online": false
  },
  {
   "code": "GEND40005",
   "name": "Gender Studies Research Methods",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOG30023",
-  "name": "Global Climate Change in Context",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "GEOG90029",
-  "name": "Research Methods in Geography",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "HORT90041",
-  "name": "Tree Growth and Function",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "LAWS20011",
-  "name": "Sport and the Law",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "LAWS50064",
-  "name": "Employment Law",
+  "code": "SCWK90048",
+  "name": "Supervised Field Placement 1A",
   "offered": [
    "february",
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50091",
-  "name": "International Investment Law",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "LAWS50106",
-  "name": "Murder",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "LAWS50128",
-  "name": "Intellectual Property & Popular Culture",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "LAWS70270",
-  "name": "Construction Contract Analysis, Drafting",
-  "offered": [
-   "february",
+   "may",
+   "september",
    "november"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70387",
-  "name": "Fundamentals of Patent Drafting",
+  "code": "PADM90016",
+  "name": "Public Sector Governance",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91001",
+  "name": "Science, Tech (Digital & Design) (EC&P)",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90273",
+  "name": "Negotiations",
+  "offered": [
+   "february",
+   "april",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90872",
+  "name": "Foundations of the Science of Learning",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90905",
+  "name": "Becoming a Clinical Practitioner (Sec)",
+  "offered": [
+   "february"
+  ],
+  "online": false
  },
  {
   "code": "LAWS70401",
   "name": "Regulation of Health Practitioners",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70468",
-  "name": "Negotiation Skills",
-  "offered": [
-   "february",
-   "march"
-  ]
- },
- {
-  "code": "LAWS90157",
-  "name": "Esports and the Law",
+  "code": "HORT90041",
+  "name": "Tree Growth and Function",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM20012",
-  "name": "Analysing Professional Communication",
+  "code": "EDUC90741",
+  "name": "Effective Clinical Teaching",
   "offered": [
    "february",
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "MEDS90035",
-  "name": "MD Research Skills 1",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "MGMT90272",
-  "name": "Procurement and Supply Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90273",
-  "name": "Service Supply Chain Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90274",
-  "name": "Supply Chain Finance and Contracts",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90275",
-  "name": "Sustainable Supply Chain Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90276",
-  "name": "Logistics and Transportation Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90277",
-  "name": "Supply Chain Intelligence",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90278",
-  "name": "Supply Chain Strategy",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90279",
-  "name": "Supply Chain Technologies",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MULT20013",
-  "name": "Australia Now",
-  "offered": [
-   "february",
-   "winter_term"
-  ]
- },
- {
-  "code": "MUSI20163",
-  "name": "Samba Band",
-  "offered": [
-   "february",
-   "semester_1",
-   "june",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20164",
-  "name": "Free Play New Music Improvisation Ensem",
-  "offered": [
-   "february",
-   "semester_1",
-   "june",
-   "semester_2"
-  ]
- },
- {
-  "code": "NURS90046",
-  "name": "Fundamentals of Palliative Care",
+  "code": "CVEN90069",
+  "name": "Dredging Engineering",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "ATOC90015",
+  "name": "Data Assimilation and Model Improvement",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90895",
+  "name": "Educational Foundations (EC)",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90007",
+  "name": "US Foreign Policy",
+  "offered": [
+   "february"
+  ],
+  "online": false
  },
  {
   "code": "ORAL30003",
@@ -751,99 +581,100 @@
    "june",
    "june",
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PADM90001",
-  "name": "Administrative Challenges in Practice",
+  "code": "EDUC90880",
+  "name": "Becoming a Clinical Practitioner (Prim)",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PADM90007",
-  "name": "The World of Public Administration",
-  "offered": [
-   "february",
-   "june"
-  ]
- },
- {
-  "code": "PADM90016",
-  "name": "Public Sector Governance",
+  "code": "FINA10030",
+  "name": "Related Studies Photography",
   "offered": [
    "february"
-  ]
- },
- {
-  "code": "PHTY90013",
-  "name": "Paediatric Physiotherapy Theory",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "POLS40013",
-  "name": "Social Science Research Seminar",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "POLS90007",
-  "name": "US Foreign Policy",
-  "offered": [
-   "february"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "POPH90189",
   "name": "Health Program Design & Implementation",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POPH90200",
-  "name": "Principles of Social Research Design",
+  "code": "LAWS20011",
+  "name": "Sport and the Law",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POPH90217",
-  "name": "Foundations of Public Health",
+  "code": "EDUC90907",
+  "name": "Inclusive Language, Literacy & Numeracy",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PSYC90093",
-  "name": "Introduction to Positive Psychology",
+  "code": "EDUC90419",
+  "name": "Education Research Methodology",
   "offered": [
-   "february"
-  ]
+   "february",
+   "june"
+  ],
+  "online": false
  },
  {
-  "code": "PSYT90004",
-  "name": "Psychiatry of Old Age",
+  "code": "AGRI10039",
+  "name": "Australia in the Wine World",
   "offered": [
-   "february"
-  ]
+   "february",
+   "june",
+   "semester_2"
+  ],
+  "online": false
  },
  {
-  "code": "PSYT90006",
-  "name": "Child and Adolescent Psychiatry",
+  "code": "EDUC90977",
+  "name": "Diverse and Inclusive Classrooms (EC&P)",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90891",
+  "name": "Becoming a Clinical Practitioner (EC)",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90629",
+  "name": "Leading Change for Student Wellbeing",
+  "offered": [
+   "february"
+  ],
+  "online": false
  },
  {
   "code": "RADI90010",
   "name": "Radiology for Physiotherapists",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "SCWK90048",
@@ -853,7 +684,8 @@
    "may",
    "september",
    "november"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "SCWK90050",
@@ -863,79 +695,493 @@
    "may",
    "august",
    "november"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCWK90053",
-  "name": "Counselling and Interviewing Skills",
+  "code": "GEND40005",
+  "name": "Gender Studies Research Methods",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCWK90057",
-  "name": "Working with Groups and Communities",
+  "code": "PADM90016",
+  "name": "Public Sector Governance",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCWK90058",
-  "name": "Researching Social Work Practice 2",
+  "code": "EDUC91001",
+  "name": "Science, Tech (Digital & Design) (EC&P)",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90905",
+  "name": "Becoming a Clinical Practitioner (Sec)",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90872",
+  "name": "Foundations of the Science of Learning",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90273",
+  "name": "Negotiations",
+  "offered": [
+   "february",
+   "april",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90845",
+  "name": "Learning Intervention 1",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70387",
+  "name": "Fundamentals of Patent Drafting",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "SCWK90059",
   "name": "Engaging with Families",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCWK90060",
-  "name": "Advanced Narrative Skills Development",
+  "code": "POLS40013",
+  "name": "Social Science Research Seminar",
   "offered": [
    "february"
-  ]
- },
- {
-  "code": "SCWK90063",
-  "name": "Social Work Practice: Indigenous Peoples",
-  "offered": [
-   "february",
-   "september"
-  ]
- },
- {
-  "code": "SCWK90064",
-  "name": "Lifespan Risk and Resilience",
-  "offered": [
-   "february"
-  ]
- },
- {
-  "code": "SCWK90065",
-  "name": "Social Policy for Social Work Practice",
-  "offered": [
-   "february"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "SCWK90066",
   "name": "Social Work Theory and Practice",
   "offered": [
    "february"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "THTR20023",
-  "name": "The Artist's Toolbox",
+  "code": "MECM20012",
+  "name": "Analysing Professional Communication",
+  "offered": [
+   "february",
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20069",
+  "name": "Deafness and Communication",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC30065",
+  "name": "Ethics, gender and the family",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "BLAW20002",
+  "name": "Regulating Digital Platforms",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90006",
+  "name": "Dilemmas in Journalism: Law and Ethics",
   "offered": [
    "february",
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90029",
+  "name": "Applied Research Methods",
+  "offered": [
+   "february",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90060",
+  "name": "Advanced Narrative Skills Development",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90755",
+  "name": "Evidence for Learning and Teaching",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90007",
+  "name": "The World of Public Administration",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90837",
+  "name": "Clinical Education Research Proposal",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90029",
+  "name": "Applied Research Methods",
+  "offered": [
+   "february",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90060",
+  "name": "Advanced Narrative Skills Development",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90276",
+  "name": "Logistics and Transportation Management",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90217",
+  "name": "Foundations of Public Health",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90419",
+  "name": "Contemporary Architectural Archives",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90628",
+  "name": "Relationship Skills for Educators 1",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50128",
+  "name": "Intellectual Property & Popular Culture",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90619",
+  "name": "Leading Educational Ideas",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30043",
+  "name": "Resource Management Economics",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90684",
+  "name": "21st Century Literacies: Policy & Praxis",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90279",
+  "name": "Supply Chain Technologies",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI20027",
+  "name": "Vine to Wine",
+  "offered": [
+   "february"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20164",
+  "name": "Free Play New Music Improvisation Ensem",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20013",
+  "name": "Australia Now",
+  "offered": [
+   "february",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90898",
+  "name": "Introduction to Clinical Practice (EC)",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50064",
+  "name": "Employment Law",
+  "offered": [
+   "february",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90563",
+  "name": "Engaging Children in the Arts",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90200",
+  "name": "Principles of Social Research Design",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90057",
+  "name": "Working with Groups and Communities",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90579",
+  "name": "Interpersonal and Group Processes",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS90035",
+  "name": "MD Research Skills 1",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90367",
+  "name": "Foundational English Literacy",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90086",
+  "name": "Epidemiology of Epidemics",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90258",
+  "name": "Student Wellbeing: Current Approaches",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70468",
+  "name": "Negotiation Skills",
+  "offered": [
+   "february",
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90759",
+  "name": "Education Research Project",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90903",
+  "name": "Contemporary Education Debates",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90778",
+  "name": "Primary Mathematics Education 1",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC90025",
+  "name": "Water Sensitive Urban Design",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90750",
+  "name": "Leading Schools Through Leading Self",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90064",
+  "name": "Lifespan Risk and Resilience",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90889",
+  "name": "Scientific and Environmental Learning",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90046",
+  "name": "Fundamentals of Palliative Care",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90896",
+  "name": "Educational Leadership (EC & Prim)",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM40001",
+  "name": "Introduction To Biomedical Research",
+  "offered": [
+   "february"
+  ],
+  "online": true
  },
  {
   "code": "THTR30042",
@@ -945,20 +1191,824 @@
    "february",
    "winter_term",
    "june"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS90086",
-  "name": "Epidemiology of Epidemics",
+  "code": "FINA20026",
+  "name": "Painting Techniques",
   "offered": [
-   "february"
-  ]
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
  },
  {
   "code": "ZOOL30008",
   "name": "Experimental Marine Biology",
   "offered": [
    "february"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90705",
+  "name": "Language & Literacy Learning in Children",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90053",
+  "name": "Counselling and Interviewing Skills",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50091",
+  "name": "International Investment Law",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90744",
+  "name": "Assessing Clinical Learners",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90394",
+  "name": "ZEMCH Sustainable Design Workshop",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90287",
+  "name": "Promoting Positive Learning",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90065",
+  "name": "Social Policy for Social Work Practice",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90938",
+  "name": "Quality Assessment Design",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST30001",
+  "name": "Forest Systems",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90025",
+  "name": "Patterns and Processes of Landscape Fire",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50106",
+  "name": "Murder",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLRS90027",
+  "name": "Principles of Clinical Research",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90942",
+  "name": "Managing the Educational Organisation",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91002",
+  "name": "Health and Physical Education (EC&P)",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90742",
+  "name": "Effective Clinical Supervision",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90004",
+  "name": "Psychiatry of Old Age",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70468",
+  "name": "Negotiation Skills",
+  "offered": [
+   "february",
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90889",
+  "name": "Scientific and Environmental Learning",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90046",
+  "name": "Fundamentals of Palliative Care",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90064",
+  "name": "Lifespan Risk and Resilience",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM40001",
+  "name": "Introduction To Biomedical Research",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20026",
+  "name": "Painting Techniques",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR30042",
+  "name": "Hashtag Cyberstar",
+  "offered": [
+   "summer_term",
+   "february",
+   "winter_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ZOOL30008",
+  "name": "Experimental Marine Biology",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90286",
+  "name": "Construction Methods A",
+  "offered": [
+   "february",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90063",
+  "name": "Social Work Practice: Indigenous Peoples",
+  "offered": [
+   "february",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA10039",
+  "name": "Related Studies Drawing & Printmedia",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90006",
+  "name": "Child and Adolescent Psychiatry",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90875",
+  "name": "Literacy for the Primary Years",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA90015",
+  "name": "Conflict and Terrorism in Southeast Asia",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90070",
+  "name": "Port and Harbour Engineering",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90743",
+  "name": "Clinical Education in Practice",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90157",
+  "name": "Esports and the Law",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90058",
+  "name": "Researching Social Work Practice 2",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90897",
+  "name": "Infant & Toddler Learning & Development",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70270",
+  "name": "Construction Contract Analysis, Drafting",
+  "offered": [
+   "february",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70401",
+  "name": "Regulation of Health Practitioners",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90041",
+  "name": "Tree Growth and Function",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90741",
+  "name": "Effective Clinical Teaching",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90069",
+  "name": "Dredging Engineering",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC90015",
+  "name": "Data Assimilation and Model Improvement",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90895",
+  "name": "Educational Foundations (EC)",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90007",
+  "name": "US Foreign Policy",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90880",
+  "name": "Becoming a Clinical Practitioner (Prim)",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA10030",
+  "name": "Related Studies Photography",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90189",
+  "name": "Health Program Design & Implementation",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS20011",
+  "name": "Sport and the Law",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90907",
+  "name": "Inclusive Language, Literacy & Numeracy",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90419",
+  "name": "Education Research Methodology",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10039",
+  "name": "Australia in the Wine World",
+  "offered": [
+   "february",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90977",
+  "name": "Diverse and Inclusive Classrooms (EC&P)",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90891",
+  "name": "Becoming a Clinical Practitioner (EC)",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90629",
+  "name": "Leading Change for Student Wellbeing",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "RADI90010",
+  "name": "Radiology for Physiotherapists",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90048",
+  "name": "Supervised Field Placement 1A",
+  "offered": [
+   "february",
+   "may",
+   "september",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90419",
+  "name": "Contemporary Architectural Archives",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90628",
+  "name": "Relationship Skills for Educators 1",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50128",
+  "name": "Intellectual Property & Popular Culture",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90619",
+  "name": "Leading Educational Ideas",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30043",
+  "name": "Resource Management Economics",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90684",
+  "name": "21st Century Literacies: Policy & Praxis",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90279",
+  "name": "Supply Chain Technologies",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20027",
+  "name": "Vine to Wine",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20164",
+  "name": "Free Play New Music Improvisation Ensem",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20013",
+  "name": "Australia Now",
+  "offered": [
+   "february",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90286",
+  "name": "Construction Methods A",
+  "offered": [
+   "february",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90063",
+  "name": "Social Work Practice: Indigenous Peoples",
+  "offered": [
+   "february",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90070",
+  "name": "Port and Harbour Engineering",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90157",
+  "name": "Esports and the Law",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA10030",
+  "name": "Related Studies Photography",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90741",
+  "name": "Effective Clinical Teaching",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90875",
+  "name": "Literacy for the Primary Years",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA10039",
+  "name": "Related Studies Drawing & Printmedia",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90880",
+  "name": "Becoming a Clinical Practitioner (Prim)",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90189",
+  "name": "Health Program Design & Implementation",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90007",
+  "name": "US Foreign Policy",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA90015",
+  "name": "Conflict and Terrorism in Southeast Asia",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90006",
+  "name": "Child and Adolescent Psychiatry",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90743",
+  "name": "Clinical Education in Practice",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC90015",
+  "name": "Data Assimilation and Model Improvement",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90895",
+  "name": "Educational Foundations (EC)",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90041",
+  "name": "Tree Growth and Function",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70401",
+  "name": "Regulation of Health Practitioners",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90897",
+  "name": "Infant & Toddler Learning & Development",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90069",
+  "name": "Dredging Engineering",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70270",
+  "name": "Construction Contract Analysis, Drafting",
+  "offered": [
+   "february",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90058",
+  "name": "Researching Social Work Practice 2",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS20011",
+  "name": "Sport and the Law",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90907",
+  "name": "Inclusive Language, Literacy & Numeracy",
+  "offered": [
+   "february"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90419",
+  "name": "Education Research Methodology",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10039",
+  "name": "Australia in the Wine World",
+  "offered": [
+   "february",
+   "june",
+   "semester_2"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_january.json
+++ b/subject-utils/subject-lists/subjects_2021_january.json
@@ -1,75 +1,45 @@
 [
  {
-  "code": "ABPL90360",
-  "name": "MUCH Heritage Industry Internship",
-  "offered": [
-   "january",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ANAT90008",
-  "name": "Surgical Anatomy",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "BUSA90001",
-  "name": "Financial Accounting",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90046",
-  "name": "Corporate Finance",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "BUSA90060",
-  "name": "Data Analysis",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
   "code": "BUSA90074",
   "name": "Global Business Economics",
   "offered": [
    "january",
    "april",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90093",
-  "name": "Finance",
+  "code": "PPMN90031",
+  "name": "Public Policy Lobbying Strategies",
   "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
+   "january"
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90193",
-  "name": "Managerial Economics",
+  "code": "EDUC90584",
+  "name": "Learning and Teaching Contexts 2",
   "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
+   "january"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT90008",
+  "name": "Surgical Anatomy",
+  "offered": [
+   "january"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL90007",
+  "name": "Oral Health Sciences 4 (Part 2)",
+  "offered": [
+   "january"
+  ],
+  "online": false
  },
  {
   "code": "BUSA90224",
@@ -79,17 +49,46 @@
    "april",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90227",
-  "name": "Operations",
+  "code": "BUSA90522",
+  "name": "Applied Analytics Lab",
+  "offered": [
+   "january",
+   "april"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90060",
+  "name": "Data Analysis",
   "offered": [
    "january",
    "april",
    "june",
    "september"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90128",
+  "name": "Intensive Care Nursing Practice",
+  "offered": [
+   "january",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90479",
+  "name": "MBA Internship",
+  "offered": [
+   "january",
+   "april"
+  ],
+  "online": false
  },
  {
   "code": "BUSA90243",
@@ -99,22 +98,36 @@
    "april",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90248",
   "name": "Marketing Communications",
   "offered": [
    "january"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90322",
-  "name": "Special Topics in Management",
+  "code": "BUSA90201",
+  "name": "Managerial Project",
   "offered": [
+   "summer_term",
    "january",
-   "march"
-  ]
+   "april",
+   "may",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90531",
+  "name": "Analytics for Strategic Management",
+  "offered": [
+   "january"
+  ],
+  "online": false
  },
  {
   "code": "BUSA90485",
@@ -122,80 +135,51 @@
   "offered": [
    "january",
    "november"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90492",
-  "name": "Financial Analysis and Valuation",
+  "code": "BUSA90093",
+  "name": "Finance",
   "offered": [
-   "january"
-  ]
- },
- {
-  "code": "BUSA90521",
-  "name": "Supply Chain Analytics",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "BUSA90531",
-  "name": "Analytics for Strategic Management",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "DENT90120",
-  "name": "Dental Practice 2",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "DENT90121",
-  "name": "Oral Medicine, Surgery and Special Needs",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "DENT90122",
-  "name": "Principles of Dental Practice 2",
-  "offered": [
-   "january"
-  ]
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
   "code": "DENT90125",
   "name": "Clinical Practice 4",
   "offered": [
    "january"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "DENT90126",
   "name": "Intro to Dental Medicine and Surgery",
   "offered": [
    "january"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "DEVT90008",
-  "name": "International Internship in Development",
+  "code": "EDUC90630",
+  "name": "Relationship Skills for Educators 2",
   "offered": [
-   "january",
-   "semester_1",
-   "semester_2"
-  ]
+   "january"
+  ],
+  "online": false
  },
  {
-  "code": "ECON20010",
-  "name": "TDM International Negotiation",
+  "code": "DENT90122",
+  "name": "Principles of Dental Practice 2",
   "offered": [
-   "january",
-   "august"
-  ]
+   "january"
+  ],
+  "online": false
  },
  {
   "code": "EDUC90126",
@@ -203,50 +187,16 @@
   "offered": [
    "january",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90137",
-  "name": "Personal and Interpersonal Leadership",
-  "offered": [
-   "january",
-   "september"
-  ]
- },
- {
-  "code": "EDUC90582",
-  "name": "Evidence Based Learning and Teaching 2",
+  "code": "ORAL90009",
+  "name": "Oral Path & Adult Oral Function (Part 2)",
   "offered": [
    "january"
-  ]
- },
- {
-  "code": "EDUC90584",
-  "name": "Learning and Teaching Contexts 2",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "EDUC90630",
-  "name": "Relationship Skills for Educators 2",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "EDUC90822",
-  "name": "Connecting and Engaging Students",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "EDUC91032",
-  "name": "Primary Humanities Education (EC&P)",
-  "offered": [
-   "january"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS50059",
@@ -257,65 +207,168 @@
    "june",
    "semester_2",
    "november"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDS90006",
-  "name": "Context of Surgical Education",
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
   "offered": [
-   "january"
-  ]
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
-  "code": "MEDS90007",
-  "name": "Learning & Teaching in Surgical Practice",
+  "code": "ABPL90360",
+  "name": "MUCH Heritage Industry Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL90005",
+  "name": "Oral Health Practice 4 (Part 2)",
   "offered": [
    "january"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90121",
+  "name": "Oral Medicine, Surgery and Special Needs",
+  "offered": [
+   "january"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90137",
+  "name": "Personal and Interpersonal Leadership",
+  "offered": [
+   "january",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90193",
+  "name": "Managerial Economics",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90521",
+  "name": "Supply Chain Analytics",
+  "offered": [
+   "january"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91032",
+  "name": "Primary Humanities Education (EC&P)",
+  "offered": [
+   "january"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90492",
+  "name": "Financial Analysis and Valuation",
+  "offered": [
+   "january"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20010",
+  "name": "TDM International Negotiation",
+  "offered": [
+   "january",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90120",
+  "name": "Dental Practice 2",
+  "offered": [
+   "january"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90046",
+  "name": "Corporate Finance",
+  "offered": [
+   "january"
+  ],
+  "online": false
  },
  {
   "code": "MEDS90010",
   "name": "Minor Thesis - Surgical Education",
   "offered": [
    "january"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDS90011",
-  "name": "Research Methods in Surgical Education",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "MEDS90013",
-  "name": "Teaching Professionalism in Surgery",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "MEDS90015",
-  "name": "Simulation in Surgical Education",
-  "offered": [
-   "january"
-  ]
- },
- {
-  "code": "MEDS90029",
-  "name": "Minor Thesis Part 1",
+  "code": "BUSA90227",
+  "name": "Operations",
   "offered": [
    "january",
-   "semester_2"
-  ]
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
-  "code": "MEDS90030",
-  "name": "Minor Thesis Part 2",
+  "code": "EDUC90582",
+  "name": "Evidence Based Learning and Teaching 2",
+  "offered": [
+   "january"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90822",
+  "name": "Connecting and Engaging Students",
+  "offered": [
+   "january"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL90007",
+  "name": "Oral Health Sciences 4 (Part 2)",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90224",
+  "name": "Managing People",
   "offered": [
    "january",
-   "semester_2"
-  ]
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
  },
  {
   "code": "NURS90128",
@@ -323,34 +376,331 @@
   "offered": [
    "january",
    "june"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "ORAL90005",
-  "name": "Oral Health Practice 4 (Part 2)",
+  "code": "BUSA90522",
+  "name": "Applied Analytics Lab",
   "offered": [
-   "january"
-  ]
+   "january",
+   "april"
+  ],
+  "online": true
  },
  {
-  "code": "ORAL90007",
-  "name": "Oral Health Sciences 4 (Part 2)",
+  "code": "BUSA90479",
+  "name": "MBA Internship",
   "offered": [
-   "january"
-  ]
+   "january",
+   "april"
+  ],
+  "online": true
  },
  {
-  "code": "ORAL90009",
-  "name": "Oral Path & Adult Oral Function (Part 2)",
+  "code": "BUSA90248",
+  "name": "Marketing Communications",
   "offered": [
    "january"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90531",
+  "name": "Analytics for Strategic Management",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90060",
+  "name": "Data Analysis",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90243",
+  "name": "Marketing",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90201",
+  "name": "Managerial Project",
+  "offered": [
+   "summer_term",
+   "january",
+   "april",
+   "may",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90126",
+  "name": "Intro to Dental Medicine and Surgery",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90485",
+  "name": "Global Business Practicum",
+  "offered": [
+   "january",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90093",
+  "name": "Finance",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90125",
+  "name": "Clinical Practice 4",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90074",
+  "name": "Global Business Economics",
+  "offered": [
+   "january",
+   "april",
+   "june"
+  ],
+  "online": true
  },
  {
   "code": "PPMN90031",
   "name": "Public Policy Lobbying Strategies",
   "offered": [
    "january"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90584",
+  "name": "Learning and Teaching Contexts 2",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90008",
+  "name": "Surgical Anatomy",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90120",
+  "name": "Dental Practice 2",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS90010",
+  "name": "Minor Thesis - Surgical Education",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90046",
+  "name": "Corporate Finance",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON20010",
+  "name": "TDM International Negotiation",
+  "offered": [
+   "january",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90227",
+  "name": "Operations",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90582",
+  "name": "Evidence Based Learning and Teaching 2",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90822",
+  "name": "Connecting and Engaging Students",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90630",
+  "name": "Relationship Skills for Educators 2",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL90009",
+  "name": "Oral Path & Adult Oral Function (Part 2)",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90122",
+  "name": "Principles of Dental Practice 2",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90126",
+  "name": "School Effectiveness and Improvement",
+  "offered": [
+   "january",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50059",
+  "name": "Legal Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "june",
+   "semester_2",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL90005",
+  "name": "Oral Health Practice 4 (Part 2)",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90121",
+  "name": "Oral Medicine, Surgery and Special Needs",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90360",
+  "name": "MUCH Heritage Industry Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90193",
+  "name": "Managerial Economics",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90521",
+  "name": "Supply Chain Analytics",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90137",
+  "name": "Personal and Interpersonal Leadership",
+  "offered": [
+   "january",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91032",
+  "name": "Primary Humanities Education (EC&P)",
+  "offered": [
+   "january"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90492",
+  "name": "Financial Analysis and Valuation",
+  "offered": [
+   "january"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_july.json
+++ b/subject-utils/subject-lists/subjects_2021_july.json
@@ -1,193 +1,11 @@
 [
  {
-  "code": "ABPL90279",
-  "name": "Cities Without Slums",
+  "code": "SCRN90006",
+  "name": "Film Festival Cultures",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "ABPL90311",
-  "name": "Studies in Building Cultures and Markets",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ABPL90321",
-  "name": "Building the Brief: People Process Place",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ABPL90332",
-  "name": "Labour in Construction",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ABPL90337",
-  "name": "Managing Urban Landscapes",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ABPL90385",
-  "name": "Applied Heritage Conservation Techniques",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ABPL90406",
-  "name": "Financial Engineering in Property",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ACCT90015",
-  "name": "Legal Issues for Business",
-  "offered": [
-   "semester_1",
-   "june",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI10039",
-  "name": "Australia in the Wine World",
-  "offered": [
-   "february",
-   "june",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI20030",
-  "name": "Wine & Spirits:An Australian Perspective",
-  "offered": [
-   "february",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "AGRI30011",
-  "name": "Innovation Change & Knowledge Transfer",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "AGRI30040",
-  "name": "Agribusiness Marketing & Value Chains",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "AGRI90016",
-  "name": "Managing Risk",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "AGRI90057",
-  "name": "Climate Change:Agric.Impacts&Adaptation",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ANSC90002",
-  "name": "Nutrition and Feed Science",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ARTS90001",
-  "name": "Melancholy and the Sweetness of Sorrow",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ARTS90022",
-  "name": "Research Ethics in & beyond the Academy",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ARTS90028",
-  "name": "Environmentalism and Ecocriticism",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "BIOL90002",
-  "name": "Biometry",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "BUSA90001",
-  "name": "Financial Accounting",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90026",
-  "name": "Business Strategy",
-  "offered": [
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90042",
-  "name": "Consumer Behaviour",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "BUSA90053",
-  "name": "Corporate Strategy",
-  "offered": [
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90060",
-  "name": "Data Analysis",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90061",
-  "name": "Data Analysis",
-  "offered": [
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90074",
@@ -196,74 +14,40 @@
    "january",
    "april",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90093",
-  "name": "Finance",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90193",
-  "name": "Managerial Economics",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90201",
-  "name": "Managerial Project",
-  "offered": [
-   "summer_term",
-   "april",
-   "may",
-   "june"
-  ]
- },
- {
-  "code": "BUSA90224",
-  "name": "Managing People",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90227",
-  "name": "Operations",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90243",
-  "name": "Marketing",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90245",
-  "name": "Marketing",
+  "code": "EDUC90543",
+  "name": "Languages for Young Learners",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90278",
+  "name": "Learners and Learning Difficulties",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90061",
+  "name": "Psychopharmacology",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70446",
+  "name": "International Equality Law",
+  "offered": [
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "BUSA90270",
@@ -271,23 +55,25 @@
   "offered": [
    "april",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90273",
-  "name": "Negotiations",
+  "code": "EDUC90996",
+  "name": "Supervised Teaching-Adult (Second Lang)",
   "offered": [
-   "february",
-   "april",
+   "march",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90360",
-  "name": "Business Law",
+  "code": "EDUC90886",
+  "name": "Leading Literacy in Primary Schools",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90481",
@@ -298,233 +84,24 @@
    "march",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90490",
-  "name": "Integrative Business Capstone",
-  "offered": [
-   "summer_term",
-   "june",
-   "winter_term",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90493",
-  "name": "Business Analytics",
+  "code": "ARTS90028",
+  "name": "Environmentalism and Ecocriticism",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "CHEM90048",
-  "name": "Lasers in Chemistry",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "CHEM90054",
-  "name": "Radical Chemistry",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "CRIM90016",
-  "name": "Industry Project: Crime and Justice",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "CRIM90037",
-  "name": "Disability, Crime and Justice",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "CUMC90003",
-  "name": "Conservation Intensive",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "CUMC90033",
-  "name": "Cultural Materials Conservation Science",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "CVEN90067",
-  "name": "Port Structural Design",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "DEVT90035",
-  "name": "Monitoring and Evaluation in Development",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "DEVT90040",
-  "name": "Gender Issues in Development",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "DEVT90056",
-  "name": "The Anthropology of Development",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "DEVT90058",
-  "name": "Disaster and Humanitarian Aid",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "DNCE20031",
-  "name": "Dancing the Dance 2: Create & Perform",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "DNCE20033",
-  "name": "Dancing the Dance 3: Dance for Video",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "DRAM30020",
-  "name": "Acting for Camera",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ECON90025",
-  "name": "Cooperation and Conflict in World Trade",
-  "offered": [
-   "march",
-   "june"
-  ]
- },
- {
-  "code": "EDUC20075",
-  "name": "Youth Leading Change",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC20078",
-  "name": "Pop-up Theatre: Performance in Community",
-  "offered": [
-   "february",
-   "june"
-  ]
- },
- {
-  "code": "EDUC20081",
-  "name": "Literacy, Power and Learning",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC30071",
-  "name": "Expertise and Your Professional Career",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC30073",
-  "name": "Sport, Leadership and the Community",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90048",
-  "name": "Second Language Teaching Methodology",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90050",
-  "name": "Supervised Teaching (Second Language)",
-  "offered": [
-   "march",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90096",
-  "name": "Supervised Observation (Second Language)",
-  "offered": [
-   "march",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90109",
-  "name": "Curriculum Design in a Multilingual Era",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90126",
-  "name": "School Effectiveness and Improvement",
-  "offered": [
-   "january",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90194",
-  "name": "Specific Learning Difficulties: Numeracy",
-  "offered": [
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90220",
   "name": "Research Methods",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "EDUC90226",
-  "name": "Learning Processes and Problems",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90227",
-  "name": "Working with Groups",
-  "offered": [
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90258",
@@ -532,44 +109,98 @@
   "offered": [
    "february",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90278",
-  "name": "Learners and Learning Difficulties",
+  "code": "BUSA90053",
+  "name": "Corporate Strategy",
   "offered": [
-   "june"
-  ]
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90373",
-  "name": "Primary Humanities Education",
+  "code": "FINA30026",
+  "name": "Global Travelling Studio",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90419",
-  "name": "Education Research Methodology",
+  "code": "EDUC90861",
+  "name": "Leading Mathematics Across the School",
   "offered": [
-   "february",
    "june"
-  ]
- },
- {
-  "code": "EDUC90422",
-  "name": "Foundations of English Teaching",
-  "offered": [
-   "summer_term",
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90425",
   "name": "Australian Indigenous Education",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90005",
+  "name": "The Nature of Governing",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90873",
+  "name": "Brain, Mind and Education",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90041",
+  "name": "Customer Experience Design",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM90054",
+  "name": "Radical Chemistry",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90096",
+  "name": "Supervised Observation (Second Language)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90109",
+  "name": "Curriculum Design in a Multilingual Era",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM90007",
+  "name": "Contemporary Middle East and South Asia",
+  "offered": [
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "EDUC90426",
@@ -577,218 +208,47 @@
   "offered": [
    "june",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90428",
-  "name": "Promoting Student Wellbeing",
-  "offered": [
-   "june",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90481",
-  "name": "Content and Language Integrated Pedagogy",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90493",
-  "name": "Arts and Artistry: Studio to Classroom",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90504",
-  "name": "Leadership in Educational Settings",
-  "offered": [
-   "summer_term",
-   "june",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90543",
-  "name": "Languages for Young Learners",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90608",
-  "name": "Identity, Culture and the Arts",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90628",
-  "name": "Relationship Skills for Educators 1",
-  "offered": [
-   "february",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90680",
-  "name": "Teaching Writing & Creating Texts",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90711",
-  "name": "Physical Education Pedagogy",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90727",
-  "name": "Teaching Global Perspectives",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90740",
-  "name": "Historical Thinking",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90754",
-  "name": "Leading Assessment",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90776",
-  "name": "Primary Mathematics Education 3",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90777",
-  "name": "Literacy Assessment and Learning",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90794",
-  "name": "Science in the Integrated Curriculum",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90835",
-  "name": "Primary Mathematics Education3 Extension",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90845",
-  "name": "Learning Intervention 1",
-  "offered": [
-   "february",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90861",
-  "name": "Leading Mathematics Across the School",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90867",
-  "name": "Writing a Literature Review",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90873",
-  "name": "Brain, Mind and Education",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90876",
-  "name": "Mathematics for the Primary Years",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90883",
-  "name": "Inquiry Learning in the Humanities",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90885",
-  "name": "Introduction to Clinical Practice (Prim)",
+  "code": "LAWS70173",
+  "name": "International Law",
   "offered": [
    "march",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90886",
-  "name": "Leading Literacy in Primary Schools",
+  "code": "BUSA90060",
+  "name": "Data Analysis",
   "offered": [
-   "june"
-  ]
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90888",
-  "name": "Primary Arts Education 2",
+  "code": "BUSA90243",
+  "name": "Marketing",
   "offered": [
-   "june"
-  ]
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90908",
-  "name": "Clinical Teaching Practice (Sec) 1",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90909",
-  "name": "Clinical Teaching Practice (Sec) 2",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90939",
-  "name": "Using Data to Improve Learning",
+  "code": "ANSC90002",
+  "name": "Nutrition and Feed Science",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "EDUC90940",
-  "name": "Education Policy and Reform",
-  "offered": [
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90942",
@@ -796,79 +256,424 @@
   "offered": [
    "february",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90944",
-  "name": "Leading for Teacher Quality",
+  "code": "BUSA90042",
+  "name": "Consumer Behaviour",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90947",
-  "name": "Mathematics: Building Teacher Capacity",
+  "code": "BUSA90201",
+  "name": "Managerial Project",
   "offered": [
+   "summer_term",
+   "january",
+   "april",
+   "may",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90953",
-  "name": "Interdisciplinary Science Education",
+  "code": "IBUS90004",
+  "name": "Cross Cultural Management and Teamwork",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90067",
+  "name": "Port Structural Design",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90093",
+  "name": "Finance",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90035",
+  "name": "Monitoring and Evaluation in Development",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC40002",
+  "name": "Current Topics in Social Psychology",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90608",
+  "name": "Identity, Culture and the Arts",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90274",
+  "name": "Supply Chain Finance and Contracts",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90859",
+  "name": "Autism Intervention",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90194",
+  "name": "Specific Learning Difficulties: Numeracy",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90022",
+  "name": "Indigenous Research",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90048",
+  "name": "Second Language Teaching Methodology",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90939",
+  "name": "Using Data to Improve Learning",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90102",
+  "name": "Psychosocial Interventions with Youth",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90332",
+  "name": "Labour in Construction",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90227",
+  "name": "Working with Groups",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90025",
+  "name": "Cooperation and Conflict in World Trade",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90062",
+  "name": "Business Negotiations and Deal-Making",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90224",
+  "name": "Managing People",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90016",
+  "name": "Managing Risk",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90060",
+  "name": "Data Analysis",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70173",
+  "name": "International Law",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90003",
+  "name": "Orchestral Conducting",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90909",
+  "name": "Clinical Teaching Practice (Sec) 2",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90057",
+  "name": "Climate Change:Agric.Impacts&Adaptation",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90426",
+  "name": "Foundations of Mathematics Teaching",
+  "offered": [
+   "june",
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "EDUC90954",
   "name": "Science Communication and Technology",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90971",
-  "name": "Teaching in, through and across the Arts",
+  "code": "BUSA90243",
+  "name": "Marketing",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC90002",
+  "name": "Nutrition and Feed Science",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90974",
-  "name": "Teaching Critical and Creative Thinking",
+  "code": "EDUC90258",
+  "name": "Student Wellbeing: Current Approaches",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90053",
+  "name": "Corporate Strategy",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30026",
+  "name": "Global Travelling Studio",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90861",
+  "name": "Leading Mathematics Across the School",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90425",
+  "name": "Australian Indigenous Education",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90005",
+  "name": "The Nature of Governing",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90873",
+  "name": "Brain, Mind and Education",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90041",
+  "name": "Customer Experience Design",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90794",
+  "name": "Science in the Integrated Curriculum",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90026",
+  "name": "Business Strategy",
+  "offered": [
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50071",
+  "name": "Global Lawyer",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90022",
+  "name": "Research Ethics in & beyond the Academy",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90226",
+  "name": "Learning Processes and Problems",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30032",
+  "name": "Risk Management and Citizen Science",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30040",
+  "name": "Agribusiness Marketing & Value Chains",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST20016",
+  "name": "Musicals & Society: Oklahoma to Hamilton",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90256",
+  "name": "Supply Chain Frameworks",
   "offered": [
    "summer_term",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90996",
-  "name": "Supervised Teaching-Adult (Second Lang)",
+  "code": "THTR30042",
+  "name": "Hashtag Cyberstar",
   "offered": [
-   "march",
+   "summer_term",
+   "february",
+   "winter_term",
    "june"
-  ]
- },
- {
-  "code": "EDUC91018",
-  "name": "Learning from Evidence (EC&P)",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EURO20009",
-  "name": "Wines of the World",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EURO30008",
-  "name": "Wines of the World",
-  "offered": [
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "FINA20026",
@@ -880,7 +685,16 @@
    "winter_term",
    "june",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30011",
+  "name": "Innovation Change & Knowledge Transfer",
+  "offered": [
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "FINA20033",
@@ -891,392 +705,19 @@
    "april",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA20035",
-  "name": "Drawing with Anatomy",
-  "offered": [
-   "winter_term",
-   "june"
-  ]
- },
- {
-  "code": "FINA20036",
-  "name": "Under Camera Animation",
+  "code": "THTR30042",
+  "name": "Hashtag Cyberstar",
   "offered": [
    "summer_term",
    "february",
    "winter_term",
    "june"
-  ]
- },
- {
-  "code": "FINA20044",
-  "name": "Art and the Botanical",
-  "offered": [
-   "summer_term",
-   "february",
-   "semester_1",
-   "winter_term",
-   "june",
-   "semester_2"
-  ]
- },
- {
-  "code": "FINA20045",
-  "name": "Introduction to Screenprinting",
-  "offered": [
-   "summer_term",
-   "march",
-   "april",
-   "winter_term",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "FINA30026",
-  "name": "Global Travelling Studio",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "FOOD90032",
-  "name": "Food Packaging Design",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "FRST20014",
-  "name": "Forests in a Global Context",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "GEND40003",
-  "name": "Gender in Cross-Cultural Perspective",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "GEOG30032",
-  "name": "Risk Management and Citizen Science",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "GEOL90033",
-  "name": "Mine Safety and Engineering",
-  "offered": [
-   "june",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90015",
-  "name": "Spatial Data Infrastructure",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "HORT90048",
-  "name": "Urban Horticulture Issues & Perspectives",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "IBUS90004",
-  "name": "Cross Cultural Management and Teamwork",
-  "offered": [
-   "summer_term",
-   "june",
-   "november"
-  ]
- },
- {
-  "code": "INTS90007",
-  "name": "Rising China in the Globalised World",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ISLM20003",
-  "name": "The Qur'an: An Introduction",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ISLM30019",
-  "name": "Islam, Human Rights and Muslim States",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ISLM90007",
-  "name": "Contemporary Middle East and South Asia",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ISYS90069",
-  "name": "Digital Transformation of Health",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "LAWS50037",
-  "name": "Evidence and Proof",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "LAWS50041",
-  "name": "Public International Law",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS50071",
-  "name": "Global Lawyer",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS70068",
-  "name": "Environmental Law",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS70173",
-  "name": "International Law",
-  "offered": [
-   "march",
-   "june"
-  ]
- },
- {
-  "code": "LAWS70217",
-  "name": "Fundamentals of the Common Law",
-  "offered": [
-   "march",
-   "may",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "LAWS70264",
-  "name": "International Human Rights Law",
-  "offered": [
-   "march",
-   "june"
-  ]
- },
- {
-  "code": "LAWS70322",
-  "name": "WTO Law and Dispute Settlement",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS70446",
-  "name": "International Equality Law",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS90035",
-  "name": "Trade Mark Practice",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS90062",
-  "name": "Business Negotiations and Deal-Making",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS90088",
-  "name": "Disaster Law and Climate Adaptation",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS90099",
-  "name": "Major Project Delivery: Legal Interfaces",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS90107",
-  "name": "New Technology Law",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS90108",
-  "name": "Start-Up Law",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS90200",
-  "name": "Independent Legal Research",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "MEDI90108",
-  "name": "Terror Medicine Principles & Responses",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "MEDS30004",
-  "name": "Advanced Medical Science 1",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "MGMT90160",
-  "name": "The Secret Life of Organisations",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "MGMT90254",
-  "name": "Indigenous Business Leadership",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "MGMT90256",
-  "name": "Supply Chain Frameworks",
-  "offered": [
-   "summer_term",
-   "june"
-  ]
- },
- {
-  "code": "MGMT90272",
-  "name": "Procurement and Supply Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90273",
-  "name": "Service Supply Chain Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90274",
-  "name": "Supply Chain Finance and Contracts",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90275",
-  "name": "Sustainable Supply Chain Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90276",
-  "name": "Logistics and Transportation Management",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90277",
-  "name": "Supply Chain Intelligence",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90278",
-  "name": "Supply Chain Strategy",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MGMT90279",
-  "name": "Supply Chain Technologies",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
- },
- {
-  "code": "MKTG90041",
-  "name": "Customer Experience Design",
-  "offered": [
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MULT90004",
@@ -1284,70 +725,137 @@
   "offered": [
    "semester_1",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MULT90022",
-  "name": "Indigenous Research",
+  "code": "ABPL90279",
+  "name": "Cities Without Slums",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MULT90041",
-  "name": "Translation in Research",
+  "code": "POPH90144",
+  "name": "Regression Methods in Health Research",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MULT90044",
-  "name": "The Art & Practice of the Personal Essay",
+  "code": "POPH90131",
+  "name": "Primary Health Care and Global Health",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90003",
-  "name": "Orchestral Conducting",
+  "code": "GEOM90015",
+  "name": "Spatial Data Infrastructure",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90016",
+  "name": "Industry Project: Crime and Justice",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90040",
+  "name": "Gender Issues in Development",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90061",
+  "name": "Data Analysis",
+  "offered": [
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "MUSI90012",
   "name": "Teaching Aural Musicianship",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90160",
-  "name": "Opera Performance Practicum 1",
+  "code": "EDUC90944",
+  "name": "Leading for Teacher Quality",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90171",
-  "name": "Opera Performance Practicum 3",
+  "code": "PUBL90010",
+  "name": "Print Production and Design",
   "offered": [
+   "semester_1",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUST20016",
-  "name": "Musicals & Society: Oklahoma to Hamilton",
+  "code": "MEDI90108",
+  "name": "Terror Medicine Principles & Responses",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "NURS90047",
-  "name": "Adult Palliative Care",
+  "code": "BUSA90360",
+  "name": "Business Law",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50041",
+  "name": "Public International Law",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90037",
+  "name": "Disability, Crime and Justice",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90247",
+  "name": "Non Communicable Disease & Global Health",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90107",
+  "name": "New Technology Law",
+  "offered": [
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "ORAL30003",
@@ -1360,22 +868,16 @@
    "june",
    "june",
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PADM90005",
-  "name": "The Nature of Governing",
+  "code": "EDUC90776",
+  "name": "Primary Mathematics Education 3",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "PADM90007",
-  "name": "The World of Public Administration",
-  "offered": [
-   "february",
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "PHTY90093",
@@ -1383,162 +885,162 @@
   "offered": [
    "semester_1",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POLS30028",
-  "name": "On Country Learning: Indigenous Studies",
+  "code": "LAWS70068",
+  "name": "Environmental Law",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POLS40023",
-  "name": "Communicating Social Science Research",
+  "code": "EDUC90876",
+  "name": "Mathematics for the Primary Years",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POLS90011",
-  "name": "The EU in International Affairs",
+  "code": "DEVT90058",
+  "name": "Disaster and Humanitarian Aid",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POLS90022",
-  "name": "International Security",
+  "code": "BUSA90227",
+  "name": "Operations",
   "offered": [
-   "june"
-  ]
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
-  "code": "POLS90062",
-  "name": "Strategic Political Communication",
+  "code": "EDUC90428",
+  "name": "Promoting Student Wellbeing",
   "offered": [
+   "june",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POPH90131",
-  "name": "Primary Health Care and Global Health",
+  "code": "GEND40003",
+  "name": "Gender in Cross-Cultural Perspective",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POPH90144",
-  "name": "Regression Methods in Health Research",
+  "code": "LAWS90035",
+  "name": "Trade Mark Practice",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POPH90247",
-  "name": "Non Communicable Disease & Global Health",
+  "code": "LAWS70217",
+  "name": "Fundamentals of the Common Law",
   "offered": [
-   "june"
-  ]
+   "march",
+   "may",
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
-  "code": "POPH90274",
-  "name": "Prioritising & Planning in Public Health",
+  "code": "FOOD90032",
+  "name": "Food Packaging Design",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PSYC40002",
-  "name": "Current Topics in Social Psychology",
+  "code": "MEDS30004",
+  "name": "Advanced Medical Science 1",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "PSYC40004",
-  "name": "Behavioural & Cognitive Neuroscience",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PSYT90010",
-  "name": "Research Methods in Psychiatry",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PSYT90014",
-  "name": "Transcultural Mental Health",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PSYT90061",
-  "name": "Psychopharmacology",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PSYT90090",
-  "name": "Psychodynamic Therapy in Psychiatry",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PSYT90098",
-  "name": "Development in Young People",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PSYT90102",
-  "name": "Psychosocial Interventions with Youth",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PSYT90110",
-  "name": "Youth Mental Health Services",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PSYT90112",
-  "name": "Early Psychosis in Young People",
-  "offered": [
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "PSYT90114",
   "name": "Managing Youth Self-harm and Suicide 1",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PUBL90010",
-  "name": "Print Production and Design",
+  "code": "VETS90092",
+  "name": "Disease Investigation at Farm Level",
   "offered": [
-   "semester_1",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCRN90006",
-  "name": "Film Festival Cultures",
+  "code": "PSYT90014",
+  "name": "Transcultural Mental Health",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI40009",
+  "name": "Writing Sociology",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL90002",
+  "name": "Biometry",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90419",
+  "name": "Education Research Methodology",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90275",
+  "name": "Sustainable Supply Chain Management",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI10039",
+  "name": "Australia in the Wine World",
+  "offered": [
+   "february",
+   "june",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "SCWK90049",
@@ -1548,24 +1050,1125 @@
    "april",
    "june",
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCWK90051",
-  "name": "Supervised Field Placement 2B",
+  "code": "EDUC90835",
+  "name": "Primary Mathematics Education3 Extension",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90845",
+  "name": "Learning Intervention 1",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS40023",
+  "name": "Communicating Social Science Research",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90099",
+  "name": "Major Project Delivery: Legal Interfaces",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90493",
+  "name": "Business Analytics",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90373",
+  "name": "Primary Humanities Education",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90056",
+  "name": "The Anthropology of Development",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90160",
+  "name": "Opera Performance Practicum 1",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90490",
+  "name": "Integrative Business Capstone",
+  "offered": [
+   "summer_term",
+   "june",
+   "winter_term",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90193",
+  "name": "Managerial Economics",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90007",
+  "name": "The World of Public Administration",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90108",
+  "name": "Start-Up Law",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90481",
+  "name": "Content and Language Integrated Pedagogy",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90422",
+  "name": "Foundations of English Teaching",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90888",
+  "name": "Primary Arts Education 2",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90274",
+  "name": "Prioritising & Planning in Public Health",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90504",
+  "name": "Leadership in Educational Settings",
+  "offered": [
+   "summer_term",
+   "june",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90777",
+  "name": "Literacy Assessment and Learning",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90015",
+  "name": "Legal Issues for Business",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM90048",
+  "name": "Lasers in Chemistry",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "INTS90007",
+  "name": "Rising China in the Globalised World",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90885",
+  "name": "Introduction to Clinical Practice (Prim)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90049",
+  "name": "Supervised Field Placement 1B",
   "offered": [
    "summer_term",
    "april",
    "june",
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SOCI40009",
-  "name": "Writing Sociology",
+  "code": "EDUC90050",
+  "name": "Supervised Teaching (Second Language)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90883",
+  "name": "Inquiry Learning in the Humanities",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90126",
+  "name": "School Effectiveness and Improvement",
+  "offered": [
+   "january",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90110",
+  "name": "Youth Mental Health Services",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90001",
+  "name": "Melancholy and the Sweetness of Sorrow",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90041",
+  "name": "Translation in Research",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90406",
+  "name": "Financial Engineering in Property",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90337",
+  "name": "Managing Urban Landscapes",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90727",
+  "name": "Teaching Global Perspectives",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90867",
+  "name": "Writing a Literature Review",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90940",
+  "name": "Education Policy and Reform",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90090",
+  "name": "Psychodynamic Therapy in Psychiatry",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90385",
+  "name": "Applied Heritage Conservation Techniques",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90254",
+  "name": "Indigenous Business Leadership",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90033",
+  "name": "Mine Safety and Engineering",
+  "offered": [
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90273",
+  "name": "Negotiations",
+  "offered": [
+   "february",
+   "april",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90835",
+  "name": "Primary Mathematics Education3 Extension",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90088",
+  "name": "Financial Management",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90069",
+  "name": "Digital Transformation of Health",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91018",
+  "name": "Learning from Evidence (EC&P)",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90845",
+  "name": "Learning Intervention 1",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90321",
+  "name": "Building the Brief: People Process Place",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90493",
+  "name": "Arts and Artistry: Studio to Classroom",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90953",
+  "name": "Interdisciplinary Science Education",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90628",
+  "name": "Relationship Skills for Educators 1",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90010",
+  "name": "Research Methods in Psychiatry",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90011",
+  "name": "The EU in International Affairs",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90056",
+  "name": "The Anthropology of Development",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90373",
+  "name": "Primary Humanities Education",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS40023",
+  "name": "Communicating Social Science Research",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90171",
+  "name": "Opera Performance Practicum 3",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90947",
+  "name": "Mathematics: Building Teacher Capacity",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90276",
+  "name": "Logistics and Transportation Management",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90493",
+  "name": "Business Analytics",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90099",
+  "name": "Major Project Delivery: Legal Interfaces",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70322",
+  "name": "WTO Law and Dispute Settlement",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90193",
+  "name": "Managerial Economics",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90711",
+  "name": "Physical Education Pedagogy",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90481",
+  "name": "Content and Language Integrated Pedagogy",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90490",
+  "name": "Integrative Business Capstone",
+  "offered": [
+   "summer_term",
+   "june",
+   "winter_term",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90422",
+  "name": "Foundations of English Teaching",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90888",
+  "name": "Primary Arts Education 2",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90007",
+  "name": "The World of Public Administration",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90108",
+  "name": "Start-Up Law",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90274",
+  "name": "Prioritising & Planning in Public Health",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90504",
+  "name": "Leadership in Educational Settings",
+  "offered": [
+   "summer_term",
+   "june",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90022",
+  "name": "International Security",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90003",
+  "name": "Conservation Intensive",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90160",
+  "name": "The Secret Life of Organisations",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90160",
+  "name": "Opera Performance Practicum 1",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90279",
+  "name": "Supply Chain Technologies",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30028",
+  "name": "On Country Learning: Indigenous Studies",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO30008",
+  "name": "Wines of the World",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE20031",
+  "name": "Dancing the Dance 2: Create & Perform",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC30073",
+  "name": "Sport, Leadership and the Community",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC40004",
+  "name": "Behavioural & Cognitive Neuroscience",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN90006",
+  "name": "Film Festival Cultures",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90074",
+  "name": "Global Business Economics",
+  "offered": [
+   "january",
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90543",
+  "name": "Languages for Young Learners",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90278",
+  "name": "Learners and Learning Difficulties",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90061",
+  "name": "Psychopharmacology",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70446",
+  "name": "International Equality Law",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90270",
+  "name": "Mergers and Acquisitions",
+  "offered": [
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90996",
+  "name": "Supervised Teaching-Adult (Second Lang)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90886",
+  "name": "Leading Literacy in Primary Schools",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
+  "offered": [
+   "summer_term",
+   "april",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90028",
+  "name": "Environmentalism and Ecocriticism",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90220",
+  "name": "Research Methods",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90258",
+  "name": "Student Wellbeing: Current Approaches",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90053",
+  "name": "Corporate Strategy",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30026",
+  "name": "Global Travelling Studio",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90861",
+  "name": "Leading Mathematics Across the School",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90425",
+  "name": "Australian Indigenous Education",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90005",
+  "name": "The Nature of Governing",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90873",
+  "name": "Brain, Mind and Education",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90041",
+  "name": "Customer Experience Design",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90054",
+  "name": "Radical Chemistry",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90096",
+  "name": "Supervised Observation (Second Language)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90109",
+  "name": "Curriculum Design in a Multilingual Era",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM90007",
+  "name": "Contemporary Middle East and South Asia",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90426",
+  "name": "Foundations of Mathematics Teaching",
+  "offered": [
+   "june",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70173",
+  "name": "International Law",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90060",
+  "name": "Data Analysis",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90243",
+  "name": "Marketing",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC90002",
+  "name": "Nutrition and Feed Science",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90942",
+  "name": "Managing the Educational Organisation",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90042",
+  "name": "Consumer Behaviour",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90201",
+  "name": "Managerial Project",
+  "offered": [
+   "summer_term",
+   "january",
+   "april",
+   "may",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90004",
+  "name": "Cross Cultural Management and Teamwork",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90067",
+  "name": "Port Structural Design",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90093",
+  "name": "Finance",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90035",
+  "name": "Monitoring and Evaluation in Development",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC40002",
+  "name": "Current Topics in Social Psychology",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90608",
+  "name": "Identity, Culture and the Arts",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90274",
+  "name": "Supply Chain Finance and Contracts",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90859",
+  "name": "Autism Intervention",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90274",
+  "name": "Supply Chain Finance and Contracts",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90859",
+  "name": "Autism Intervention",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50037",
+  "name": "Evidence and Proof",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20036",
+  "name": "Under Camera Animation",
+  "offered": [
+   "summer_term",
+   "february",
+   "winter_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20078",
+  "name": "Pop-up Theatre: Performance in Community",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
  },
  {
   "code": "THTR20023",
@@ -1573,7 +2176,311 @@
   "offered": [
    "february",
    "june"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20075",
+  "name": "Youth Leading Change",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE20033",
+  "name": "Dancing the Dance 3: Dance for Video",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90886",
+  "name": "Leading Literacy in Primary Schools",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
+  "offered": [
+   "summer_term",
+   "april",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90028",
+  "name": "Environmentalism and Ecocriticism",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90220",
+  "name": "Research Methods",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90258",
+  "name": "Student Wellbeing: Current Approaches",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90053",
+  "name": "Corporate Strategy",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30026",
+  "name": "Global Travelling Studio",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN90006",
+  "name": "Film Festival Cultures",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90074",
+  "name": "Global Business Economics",
+  "offered": [
+   "january",
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90543",
+  "name": "Languages for Young Learners",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90061",
+  "name": "Psychopharmacology",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90278",
+  "name": "Learners and Learning Difficulties",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70446",
+  "name": "International Equality Law",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90270",
+  "name": "Mergers and Acquisitions",
+  "offered": [
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90996",
+  "name": "Supervised Teaching-Adult (Second Lang)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90861",
+  "name": "Leading Mathematics Across the School",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90425",
+  "name": "Australian Indigenous Education",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90794",
+  "name": "Science in the Integrated Curriculum",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90041",
+  "name": "Customer Experience Design",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90005",
+  "name": "The Nature of Governing",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90226",
+  "name": "Learning Processes and Problems",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90022",
+  "name": "Research Ethics in & beyond the Academy",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30032",
+  "name": "Risk Management and Citizen Science",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90026",
+  "name": "Business Strategy",
+  "offered": [
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50071",
+  "name": "Global Lawyer",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90873",
+  "name": "Brain, Mind and Education",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUST20016",
+  "name": "Musicals & Society: Oklahoma to Hamilton",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30040",
+  "name": "Agribusiness Marketing & Value Chains",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90256",
+  "name": "Supply Chain Frameworks",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20030",
+  "name": "Wine & Spirits:An Australian Perspective",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20026",
+  "name": "Painting Techniques",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30011",
+  "name": "Innovation Change & Knowledge Transfer",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20033",
+  "name": "Introduction to Printmaking Processes",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
  },
  {
   "code": "THTR30042",
@@ -1583,13 +2490,1053 @@
    "february",
    "winter_term",
    "june"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90004",
+  "name": "Sustainability Governance and Leadership",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90279",
+  "name": "Cities Without Slums",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90144",
+  "name": "Regression Methods in Health Research",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90131",
+  "name": "Primary Health Care and Global Health",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90015",
+  "name": "Spatial Data Infrastructure",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90016",
+  "name": "Industry Project: Crime and Justice",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90040",
+  "name": "Gender Issues in Development",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90061",
+  "name": "Data Analysis",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90012",
+  "name": "Teaching Aural Musicianship",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90944",
+  "name": "Leading for Teacher Quality",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90010",
+  "name": "Print Production and Design",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90108",
+  "name": "Terror Medicine Principles & Responses",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90360",
+  "name": "Business Law",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50041",
+  "name": "Public International Law",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90037",
+  "name": "Disability, Crime and Justice",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90247",
+  "name": "Non Communicable Disease & Global Health",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90107",
+  "name": "New Technology Law",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90245",
+  "name": "Marketing",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90051",
+  "name": "Supervised Field Placement 2B",
+  "offered": [
+   "summer_term",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90971",
+  "name": "Teaching in, through and across the Arts",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90940",
+  "name": "Education Policy and Reform",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90777",
+  "name": "Literacy Assessment and Learning",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90385",
+  "name": "Applied Heritage Conservation Techniques",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90015",
+  "name": "Legal Issues for Business",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90885",
+  "name": "Introduction to Clinical Practice (Prim)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90273",
+  "name": "Negotiations",
+  "offered": [
+   "february",
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90727",
+  "name": "Teaching Global Perspectives",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91018",
+  "name": "Learning from Evidence (EC&P)",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90069",
+  "name": "Digital Transformation of Health",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90088",
+  "name": "Financial Management",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90254",
+  "name": "Indigenous Business Leadership",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90033",
+  "name": "Mine Safety and Engineering",
+  "offered": [
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90041",
+  "name": "Translation in Research",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90406",
+  "name": "Financial Engineering in Property",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90337",
+  "name": "Managing Urban Landscapes",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90048",
+  "name": "Lasers in Chemistry",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "INTS90007",
+  "name": "Rising China in the Globalised World",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90049",
+  "name": "Supervised Field Placement 1B",
+  "offered": [
+   "summer_term",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90835",
+  "name": "Primary Mathematics Education3 Extension",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90845",
+  "name": "Learning Intervention 1",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS40023",
+  "name": "Communicating Social Science Research",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90099",
+  "name": "Major Project Delivery: Legal Interfaces",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90493",
+  "name": "Business Analytics",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90373",
+  "name": "Primary Humanities Education",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90056",
+  "name": "The Anthropology of Development",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90160",
+  "name": "Opera Performance Practicum 1",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90490",
+  "name": "Integrative Business Capstone",
+  "offered": [
+   "summer_term",
+   "june",
+   "winter_term",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90193",
+  "name": "Managerial Economics",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90007",
+  "name": "The World of Public Administration",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90108",
+  "name": "Start-Up Law",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90481",
+  "name": "Content and Language Integrated Pedagogy",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90422",
+  "name": "Foundations of English Teaching",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90888",
+  "name": "Primary Arts Education 2",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90274",
+  "name": "Prioritising & Planning in Public Health",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90504",
+  "name": "Leadership in Educational Settings",
+  "offered": [
+   "summer_term",
+   "june",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90777",
+  "name": "Literacy Assessment and Learning",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90015",
+  "name": "Legal Issues for Business",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90048",
+  "name": "Lasers in Chemistry",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "INTS90007",
+  "name": "Rising China in the Globalised World",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90885",
+  "name": "Introduction to Clinical Practice (Prim)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90049",
+  "name": "Supervised Field Placement 1B",
+  "offered": [
+   "summer_term",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90050",
+  "name": "Supervised Teaching (Second Language)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90883",
+  "name": "Inquiry Learning in the Humanities",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90126",
+  "name": "School Effectiveness and Improvement",
+  "offered": [
+   "january",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90110",
+  "name": "Youth Mental Health Services",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90001",
+  "name": "Melancholy and the Sweetness of Sorrow",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90041",
+  "name": "Translation in Research",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90406",
+  "name": "Financial Engineering in Property",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90337",
+  "name": "Managing Urban Landscapes",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90727",
+  "name": "Teaching Global Perspectives",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90867",
+  "name": "Writing a Literature Review",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90940",
+  "name": "Education Policy and Reform",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90090",
+  "name": "Psychodynamic Therapy in Psychiatry",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90385",
+  "name": "Applied Heritage Conservation Techniques",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90254",
+  "name": "Indigenous Business Leadership",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90033",
+  "name": "Mine Safety and Engineering",
+  "offered": [
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90273",
+  "name": "Negotiations",
+  "offered": [
+   "february",
+   "april",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90835",
+  "name": "Primary Mathematics Education3 Extension",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90088",
+  "name": "Financial Management",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90069",
+  "name": "Digital Transformation of Health",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91018",
+  "name": "Learning from Evidence (EC&P)",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90845",
+  "name": "Learning Intervention 1",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90321",
+  "name": "Building the Brief: People Process Place",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90493",
+  "name": "Arts and Artistry: Studio to Classroom",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90953",
+  "name": "Interdisciplinary Science Education",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90628",
+  "name": "Relationship Skills for Educators 1",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90010",
+  "name": "Research Methods in Psychiatry",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90011",
+  "name": "The EU in International Affairs",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90056",
+  "name": "The Anthropology of Development",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90373",
+  "name": "Primary Humanities Education",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS40023",
+  "name": "Communicating Social Science Research",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90171",
+  "name": "Opera Performance Practicum 3",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90947",
+  "name": "Mathematics: Building Teacher Capacity",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90360",
+  "name": "Business Law",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90876",
+  "name": "Mathematics for the Primary Years",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS30004",
+  "name": "Advanced Medical Science 1",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90114",
+  "name": "Managing Youth Self-harm and Suicide 1",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90776",
+  "name": "Primary Mathematics Education 3",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90108",
+  "name": "Terror Medicine Principles & Responses",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90247",
+  "name": "Non Communicable Disease & Global Health",
+  "offered": [
+   "june"
+  ],
+  "online": true
  },
  {
   "code": "VETS90092",
   "name": "Disease Investigation at Farm Level",
   "offered": [
    "june"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90227",
+  "name": "Operations",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90014",
+  "name": "Transcultural Mental Health",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90944",
+  "name": "Leading for Teacher Quality",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90010",
+  "name": "Print Production and Design",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI40009",
+  "name": "Writing Sociology",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90275",
+  "name": "Sustainable Supply Chain Management",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90419",
+  "name": "Education Research Methodology",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL90002",
+  "name": "Biometry",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20081",
+  "name": "Literacy, Power and Learning",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC30071",
+  "name": "Expertise and Your Professional Career",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10039",
+  "name": "Australia in the Wine World",
+  "offered": [
+   "february",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST20014",
+  "name": "Forests in a Global Context",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO20009",
+  "name": "Wines of the World",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM30020",
+  "name": "Acting for Camera",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM20003",
+  "name": "The Qur'an: An Introduction",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20035",
+  "name": "Drawing with Anatomy",
+  "offered": [
+   "winter_term",
+   "june"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_june.json
+++ b/subject-utils/subject-lists/subjects_2021_june.json
@@ -1,76 +1,55 @@
 [
  {
-  "code": "ABPL90322",
-  "name": "Human Environments Relations",
+  "code": "EDUC90744",
+  "name": "Assessing Clinical Learners",
   "offered": [
+   "february",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ACCT40007",
-  "name": "Behavioural Accounting Research",
+  "code": "PUBL90004",
+  "name": "Business and Professional Communications",
   "offered": [
+   "semester_1",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ACCT90039",
-  "name": "Behavioural Research in Accounting",
+  "code": "NURS90115",
+  "name": "Nursing Practice 2",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AGRI20003",
-  "name": "Sustainable Food Systems",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "AGRI30016",
-  "name": "Irrigation and Water Management",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "AIND10003",
-  "name": "Ancient & Contemporary Indigenous Arts",
+  "code": "NURS90126",
+  "name": "Intensive Care Nursing 1",
   "offered": [
    "summer_term",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ANCW20015",
-  "name": "Classical Mythology",
+  "code": "NURS90128",
+  "name": "Intensive Care Nursing Practice",
   "offered": [
-   "semester_1",
+   "january",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ARCH30003",
-  "name": "Environmental Design- Commercial",
+  "code": "NURS90119",
+  "name": "Mental Health Nursing Practice 2",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "ARTS90006",
-  "name": "Introductory Academic Program",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "BCMB40009",
-  "name": "Biochemistry Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90013",
@@ -78,61 +57,97 @@
   "offered": [
    "summer_term",
    "june"
-  ]
- },
- {
-  "code": "BUSA90014",
-  "name": "Brand Management",
-  "offered": [
-   "summer_term",
-   "april",
-   "june"
-  ]
- },
- {
-  "code": "BUSA90133",
-  "name": "Industry Studies in Asia",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "BUSA90480",
-  "name": "Leadership",
-  "offered": [
-   "summer_term",
-   "march",
-   "june",
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90506",
   "name": "Executive Management 2",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDS90022",
+  "name": "Student Conference 3",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90426",
+  "name": "Foundations of Mathematics Teaching",
+  "offered": [
+   "june",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90034",
+  "name": "Practical Igneous Petrology",
+  "offered": [
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "CRIM90022",
   "name": "Introduction to Offender Management",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "CUMC90034",
-  "name": "Ngarranggarni: Gija Art and Country",
+  "code": "LAWS70329",
+  "name": "Residential Construction Law",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "DPSS30011",
-  "name": "Design and Production Melbourne x Berlin",
+  "code": "FNCE90051",
+  "name": "Fundamentals of Portfolio Management",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90116",
+  "name": "Nursing Practice 2 (Renal)",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90093",
+  "name": "Advanced Therapeutic Skills",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90028",
+  "name": "Digital Methods",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90006",
+  "name": "Introductory Academic Program",
+  "offered": [
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "DRAM10026",
@@ -141,62 +156,19 @@
    "semester_1",
    "june",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC20062",
-  "name": "Youth Culture and the Arts",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC20076",
-  "name": "AUSLAN and Visual Communication",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "EDUC90426",
-  "name": "Foundations of Mathematics Teaching",
-  "offered": [
-   "june",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90428",
-  "name": "Promoting Student Wellbeing",
-  "offered": [
-   "june",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90504",
-  "name": "Leadership in Educational Settings",
-  "offered": [
-   "summer_term",
-   "june",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90563",
-  "name": "Engaging Children in the Arts",
+  "code": "MUSI20163",
+  "name": "Samba Band",
   "offered": [
    "february",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90743",
-  "name": "Clinical Education in Practice",
-  "offered": [
-   "february",
-   "june"
-  ]
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "EDUC90744",
@@ -204,120 +176,275 @@
   "offered": [
    "february",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90919",
-  "name": "Place Based Elective (Indigenous)",
+  "code": "PUBL90004",
+  "name": "Business and Professional Communications",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90115",
+  "name": "Nursing Practice 2",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90976",
-  "name": "Positive Learning Environments",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ENEN90037",
-  "name": "International River Basin Management",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "ERTH90034",
-  "name": "Advanced Hydrogeology",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "FINA30027",
-  "name": "Travelling Studio",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "FNCE90051",
-  "name": "Fundamentals of Portfolio Management",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "FNCE90057",
-  "name": "Ethics In Finance",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "FOOD90031",
-  "name": "Food Packaging Materials and Processes",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "GEOG30033",
-  "name": "Arid Australia Field Class",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "GEOL20004",
-  "name": "Field Mapping and Sedimentary Geology",
+  "code": "NURS90126",
+  "name": "Intensive Care Nursing 1",
   "offered": [
    "summer_term",
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90128",
+  "name": "Intensive Care Nursing Practice",
+  "offered": [
+   "january",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDS90022",
+  "name": "Student Conference 3",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90426",
+  "name": "Foundations of Mathematics Teaching",
+  "offered": [
+   "june",
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "GEOL90034",
   "name": "Practical Igneous Petrology",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "HORT90011",
-  "name": "Therapeutic Landscapes",
+  "code": "CRIM90022",
+  "name": "Introduction to Offender Management",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "HORT90042",
-  "name": "Managing Urban Trees",
+  "code": "NURS90119",
+  "name": "Mental Health Nursing Practice 2",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "INDG90004",
-  "name": "Collaborative Fieldwork",
+  "code": "BUSA90013",
+  "name": "Brand Management",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70329",
+  "name": "Residential Construction Law",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90506",
+  "name": "Executive Management 2",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90051",
+  "name": "Fundamentals of Portfolio Management",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90006",
+  "name": "Introductory Academic Program",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90116",
+  "name": "Nursing Practice 2 (Renal)",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90028",
+  "name": "Digital Methods",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90093",
+  "name": "Advanced Therapeutic Skills",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM10026",
+  "name": "Up Close and Personal with MTC",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW20015",
+  "name": "Classical Mythology",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20163",
+  "name": "Samba Band",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90055",
+  "name": "Advanced Qualitative Methods",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90031",
+  "name": "Food Packaging Materials and Processes",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDS90024",
+  "name": "Student Conference 4",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90230",
+  "name": "Planetary and Global Health",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90034",
+  "name": "Ngarranggarni: Gija Art and Country",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHTY90030",
+  "name": "Clinical Paediatric Physiotherapy",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90111",
+  "name": "Nursing Specialty 2 (Renal)",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90133",
+  "name": "Industry Studies in Asia",
+  "offered": [
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "ISYS90070",
   "name": "Information Security Consulting",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "JOUR90006",
-  "name": "Dilemmas in Journalism: Law and Ethics",
+  "code": "LAWS70460",
+  "name": "Regulatory Policy and Practice",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30027",
+  "name": "Travelling Studio",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90120",
+  "name": "Evidence in Practice",
+  "offered": [
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "LAWS50059",
@@ -328,77 +455,16 @@
    "june",
    "semester_2",
    "november"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70059",
-  "name": "Sports Industry and the Law",
+  "code": "INDG90004",
+  "name": "Collaborative Fieldwork",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "LAWS70060",
-  "name": "Patent Practice",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS70093",
-  "name": "International Law and Development",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS70146",
-  "name": "Tax Treaties",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS70329",
-  "name": "Residential Construction Law",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS70331",
-  "name": "Taxation of Mergers and Acquisitions",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS70335",
-  "name": "Contract Interpretation",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS70460",
-  "name": "Regulatory Policy and Practice",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS90126",
-  "name": "Digital Trade",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "LAWS90149",
-  "name": "Corruption: A Global Approach",
-  "offered": [
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MECM20012",
@@ -407,89 +473,259 @@
    "february",
    "semester_1",
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90006",
+  "name": "Dilemmas in Journalism: Law and Ethics",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90179",
+  "name": "Evidence-Based Performance Teaching",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90480",
+  "name": "Leadership",
+  "offered": [
+   "summer_term",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70335",
+  "name": "Contract Interpretation",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHTY90030",
+  "name": "Clinical Paediatric Physiotherapy",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90230",
+  "name": "Planetary and Global Health",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90111",
+  "name": "Nursing Specialty 2 (Renal)",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70460",
+  "name": "Regulatory Policy and Practice",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30027",
+  "name": "Travelling Studio",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90120",
+  "name": "Evidence in Practice",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50059",
+  "name": "Legal Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "june",
+   "semester_2",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG90004",
+  "name": "Collaborative Fieldwork",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM20012",
+  "name": "Analysing Professional Communication",
+  "offered": [
+   "february",
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90179",
+  "name": "Evidence-Based Performance Teaching",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90006",
+  "name": "Dilemmas in Journalism: Law and Ethics",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT40007",
+  "name": "Behavioural Accounting Research",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90322",
+  "name": "Human Environments Relations",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90037",
+  "name": "International River Basin Management",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90480",
+  "name": "Leadership",
+  "offered": [
+   "summer_term",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90039",
+  "name": "Behavioural Research in Accounting",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70335",
+  "name": "Contract Interpretation",
+  "offered": [
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30033",
+  "name": "Arid Australia Field Class",
+  "offered": [
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "MECM90015",
   "name": "Perspectives on Digital Platforms",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM90028",
-  "name": "Digital Methods",
+  "code": "EDUC90504",
+  "name": "Leadership in Educational Settings",
+  "offered": [
+   "summer_term",
+   "june",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90014",
+  "name": "Brand Management",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDS90003",
-  "name": "Student Conference 1",
+  "code": "LAWS90126",
+  "name": "Digital Trade",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDS90005",
-  "name": "Student Conference 2",
+  "code": "HORT90042",
+  "name": "Managing Urban Trees",
   "offered": [
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDS90022",
-  "name": "Student Conference 3",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "MEDS90024",
-  "name": "Student Conference 4",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "MIIM40005",
-  "name": "Micro & Immuno Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "MULT20014",
-  "name": "Community Volunteering - Global",
+  "code": "NURS90076",
+  "name": "Applied Pathophysiology",
   "offered": [
    "summer_term",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MULT30021",
-  "name": "Community Volunteering - Global",
+  "code": "AIND10003",
+  "name": "Ancient & Contemporary Indigenous Arts",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "MULT90055",
-  "name": "Advanced Qualitative Methods",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "MUSI20163",
-  "name": "Samba Band",
-  "offered": [
-   "february",
-   "semester_1",
-   "june",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MUSI20164",
@@ -499,79 +735,24 @@
    "semester_1",
    "june",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "NURS90093",
-  "name": "Advanced Therapeutic Skills",
+  "code": "MULT30021",
+  "name": "Community Volunteering - Global",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "NURS90111",
-  "name": "Nursing Specialty 2 (Renal)",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "NURS90113",
-  "name": "Nursing Specialty 2",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "NURS90115",
-  "name": "Nursing Practice 2",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "NURS90116",
-  "name": "Nursing Practice 2 (Renal)",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "NURS90119",
-  "name": "Mental Health Nursing Practice 2",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "NURS90120",
-  "name": "Evidence in Practice",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "NURS90126",
-  "name": "Intensive Care Nursing 1",
-  "offered": [
-   "summer_term",
-   "june"
-  ]
- },
- {
-  "code": "NURS90128",
-  "name": "Intensive Care Nursing Practice",
-  "offered": [
-   "january",
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "NURS90143",
   "name": "Emergency Nursing 1",
   "offered": [
    "june"
-  ]
+  ],
+  "online": true
  },
  {
   "code": "NURS90145",
@@ -579,7 +760,646 @@
   "offered": [
    "semester_1",
    "june"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL90001",
+  "name": "Oral Health Practice 4",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90057",
+  "name": "Ethics In Finance",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90563",
+  "name": "Engaging Children in the Arts",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90113",
+  "name": "Nursing Specialty 2",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70093",
+  "name": "International Law and Development",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL90002",
+  "name": "Oral Pathology and Adult Oral Function",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90919",
+  "name": "Place Based Elective (Indigenous)",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90011",
+  "name": "Therapeutic Landscapes",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90054",
+  "name": "Global Issues in Indigenous Governance",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90976",
+  "name": "Positive Learning Environments",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH90034",
+  "name": "Advanced Hydrogeology",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS90005",
+  "name": "Student Conference 2",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS90003",
+  "name": "Student Conference 1",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR20043",
+  "name": "Design and the Moving Image",
+  "offered": [
+   "june",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL20004",
+  "name": "Field Mapping and Sedimentary Geology",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS30011",
+  "name": "Design and Production Melbourne x Berlin",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30017",
+  "name": "Global Management Consulting",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20003",
+  "name": "Sustainable Food Systems",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20015",
+  "name": "Classical Mythology",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70093",
+  "name": "International Law and Development",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL90002",
+  "name": "Oral Pathology and Adult Oral Function",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90919",
+  "name": "Place Based Elective (Indigenous)",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90011",
+  "name": "Therapeutic Landscapes",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90054",
+  "name": "Global Issues in Indigenous Governance",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90143",
+  "name": "Emergency Nursing 1",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90145",
+  "name": "Emergency Nursing Practice",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL90001",
+  "name": "Oral Health Practice 4",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90057",
+  "name": "Ethics In Finance",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90563",
+  "name": "Engaging Children in the Arts",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90113",
+  "name": "Nursing Specialty 2",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90976",
+  "name": "Positive Learning Environments",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH90034",
+  "name": "Advanced Hydrogeology",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS90003",
+  "name": "Student Conference 1",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS90005",
+  "name": "Student Conference 2",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR20043",
+  "name": "Design and the Moving Image",
+  "offered": [
+   "june",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30017",
+  "name": "Global Management Consulting",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL20004",
+  "name": "Field Mapping and Sedimentary Geology",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20003",
+  "name": "Sustainable Food Systems",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS30011",
+  "name": "Design and Production Melbourne x Berlin",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90055",
+  "name": "Advanced Qualitative Methods",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90031",
+  "name": "Food Packaging Materials and Processes",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS90024",
+  "name": "Student Conference 4",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90230",
+  "name": "Planetary and Global Health",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90034",
+  "name": "Ngarranggarni: Gija Art and Country",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHTY90030",
+  "name": "Clinical Paediatric Physiotherapy",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90111",
+  "name": "Nursing Specialty 2 (Renal)",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90133",
+  "name": "Industry Studies in Asia",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90070",
+  "name": "Information Security Consulting",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70460",
+  "name": "Regulatory Policy and Practice",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30027",
+  "name": "Travelling Studio",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90120",
+  "name": "Evidence in Practice",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50059",
+  "name": "Legal Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "june",
+   "semester_2",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG90004",
+  "name": "Collaborative Fieldwork",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM20012",
+  "name": "Analysing Professional Communication",
+  "offered": [
+   "february",
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90006",
+  "name": "Dilemmas in Journalism: Law and Ethics",
+  "offered": [
+   "february",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90179",
+  "name": "Evidence-Based Performance Teaching",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90480",
+  "name": "Leadership",
+  "offered": [
+   "summer_term",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70335",
+  "name": "Contract Interpretation",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90014",
+  "name": "Brand Management",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30033",
+  "name": "Arid Australia Field Class",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90015",
+  "name": "Perspectives on Digital Platforms",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90504",
+  "name": "Leadership in Educational Settings",
+  "offered": [
+   "summer_term",
+   "june",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90322",
+  "name": "Human Environments Relations",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN90037",
+  "name": "International River Basin Management",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT40007",
+  "name": "Behavioural Accounting Research",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90039",
+  "name": "Behavioural Research in Accounting",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90126",
+  "name": "Digital Trade",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90042",
+  "name": "Managing Urban Trees",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90076",
+  "name": "Applied Pathophysiology",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20164",
+  "name": "Free Play New Music Improvisation Ensem",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30021",
+  "name": "Community Volunteering - Global",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "AIND10003",
+  "name": "Ancient & Contemporary Indigenous Arts",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70331",
+  "name": "Taxation of Mergers and Acquisitions",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70060",
+  "name": "Patent Practice",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70059",
+  "name": "Sports Industry and the Law",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90428",
+  "name": "Promoting Student Wellbeing",
+  "offered": [
+   "june",
+   "june"
+  ],
+  "online": true
  },
  {
   "code": "ORAL30003",
@@ -592,82 +1412,75 @@
    "june",
    "june",
    "august"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "PATH40001",
-  "name": "Pathology Research Project Part 1",
+  "code": "ORAL90003",
+  "name": "Oral Health Sciences 4",
   "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90014",
+  "name": "Brand Management",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90126",
+  "name": "Digital Trade",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90042",
+  "name": "Managing Urban Trees",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90076",
+  "name": "Applied Pathophysiology",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "AIND10003",
+  "name": "Ancient & Contemporary Indigenous Arts",
+  "offered": [
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20164",
+  "name": "Free Play New Music Improvisation Ensem",
+  "offered": [
+   "february",
    "semester_1",
    "june",
    "semester_2"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "PHRM40001",
-  "name": "Pharmacology Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "PHTY90002",
-  "name": "The Pelvic Floor:Function&Dysfunction",
+  "code": "MULT30021",
+  "name": "Community Volunteering - Global",
   "offered": [
    "june"
-  ]
- },
- {
-  "code": "PHTY90003",
-  "name": "Advanced Practice in Pelvic Floor Physio",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PHTY90030",
-  "name": "Clinical Paediatric Physiotherapy",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PHYS40005",
-  "name": "Physiology Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "POPH90230",
-  "name": "Planetary and Global Health",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PPMN90054",
-  "name": "Global Issues in Indigenous Governance",
-  "offered": [
-   "june"
-  ]
- },
- {
-  "code": "PUBL90004",
-  "name": "Business and Professional Communications",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "THTR20043",
-  "name": "Design and the Moving Image",
-  "offered": [
-   "june",
-   "winter_term"
-  ]
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_march.json
+++ b/subject-utils/subject-lists/subjects_2021_march.json
@@ -1,311 +1,44 @@
 [
  {
-  "code": "ABPL90282",
-  "name": "Principles of Heritage and Conservation",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "ABPL90323",
-  "name": "Construction Scheduling",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "AGRI90013",
-  "name": "Financial Management for Agribusiness",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "ANSC90004",
-  "name": "Monogastric Science",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "ANTH40012",
-  "name": "Explanation and Understanding",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "ARTS90005",
-  "name": "Intensive Research Workshop",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "BUSA90094",
-  "name": "Finance",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "BUSA90271",
-  "name": "Mergers and Acquisitions",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "BUSA90322",
-  "name": "Special Topics in Management",
-  "offered": [
-   "january",
-   "march"
-  ]
- },
- {
-  "code": "BUSA90480",
-  "name": "Leadership",
-  "offered": [
-   "summer_term",
-   "march",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90481",
-  "name": "Managerial Ethics & Business Environment",
-  "offered": [
-   "summer_term",
-   "april",
-   "march",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90488",
-  "name": "Business in Complex Environments",
-  "offered": [
-   "march"
-  ]
- },
- {
   "code": "BUSA90499",
   "name": "Introduction to Business Problems",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90514",
-  "name": "Industry Studies in Europe",
+  "code": "GEND90013",
+  "name": "Research in Gender",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90517",
-  "name": "Social Entrepreneur Consulting Practicum",
+  "code": "NURS90099",
+  "name": "Critical Care Nursing Practice",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90526",
-  "name": "Strategic Consulting for Social Impact",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "CHEM90047",
-  "name": "Organic Electronics",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "CHEM90053",
-  "name": "Interfacial Chemistry and Sonochemistry",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "CLRS90011",
-  "name": "Study Design in Clinical Research",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "CRIM90012",
-  "name": "Introduction to Forensic Disability",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "CRIM90036",
-  "name": "Data in Criminology Policy and Practice",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "CUMC90026",
-  "name": "Conservation Professional Practices",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "CUMC90028",
-  "name": "Introduction to Conservation Treatment",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "DEVT90001",
-  "name": "Development Project Management & Design",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "DEVT90041",
-  "name": "Development Research Design & Assessment",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "DEVT90074",
-  "name": "Contemporary Development",
-  "offered": [
-   "march",
-   "september"
-  ]
- },
- {
-  "code": "DEVT90078",
-  "name": "Development, Culture and Conflict",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "DRAM90018",
-  "name": "Creating a Project Vision",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "ECON90025",
-  "name": "Cooperation and Conflict in World Trade",
-  "offered": [
-   "march",
-   "june"
-  ]
- },
- {
-  "code": "EDUC30076",
-  "name": "Wakanda: African Futures in Education",
-  "offered": [
-   "march",
-   "winter_term"
-  ]
- },
- {
-  "code": "EDUC90006",
-  "name": "Environmental Education",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90050",
-  "name": "Supervised Teaching (Second Language)",
-  "offered": [
-   "march",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90096",
-  "name": "Supervised Observation (Second Language)",
-  "offered": [
-   "march",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90195",
-  "name": "Specific Learning Difficulties: Literacy",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90222",
-  "name": "Intervention in Problems of Young People",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90223",
-  "name": "Exceptionality:Assessment & Intervention",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90224",
-  "name": "Counselling Skills for Ed. Psychologists",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90225",
-  "name": "Psychological Tests",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90506",
-  "name": "Language & Literacy Development",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90507",
-  "name": "Oral Language, Literacy & Learning",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90587",
-  "name": "Grammar for Language Teachers",
+  "code": "LAWS70314",
+  "name": "Principles of Construction Law",
   "offered": [
    "march",
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90615",
-  "name": "Mathematics: Teaching with Technology",
+  "code": "LAWS90043",
+  "name": "Mineral and Petroleum Law",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90631",
@@ -313,94 +46,133 @@
   "offered": [
    "march",
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90638",
-  "name": "Education, Knowledge and Power",
+  "code": "ECON90025",
+  "name": "Cooperation and Conflict in World Trade",
   "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90803",
-  "name": "Pedagogy into Practice",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90804",
-  "name": "Clinical Assessment & Course Evaluation",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90836",
-  "name": "Leadership in Clinical Education",
-  "offered": [
-   "march"
-  ]
+   "march",
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "EDUC90870",
   "name": "Laying the Foundations for Your Research",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90882",
-  "name": "Educational Foundations (Prim)",
+  "code": "NURS90083",
+  "name": "Rural Critical Care Nursing 1",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90885",
-  "name": "Introduction to Clinical Practice (Prim)",
+  "code": "NURS90114",
+  "name": "Nursing Practice 1",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90028",
+  "name": "Geochronology and Thermochronology",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90079",
+  "name": "Neonatal Intensive Care  1",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70173",
+  "name": "International Law",
   "offered": [
    "march",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90946",
-  "name": "Mathematics Across the Curriculum",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90950",
-  "name": "Globalisation and Education Policy",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90952",
-  "name": "Informal Science Communication",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "EDUC90988",
-  "name": "Clinical Teaching Practice (EC&P) 5",
+  "code": "MULT90005",
+  "name": "Interdisciplinarity and the Environment",
   "offered": [
    "march",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90996",
-  "name": "Supervised Teaching-Adult (Second Lang)",
+  "code": "DEVT90041",
+  "name": "Development Research Design & Assessment",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90074",
+  "name": "Contemporary Development",
   "offered": [
    "march",
-   "june"
-  ]
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90027",
+  "name": "Advanced Structural Mapping",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90013",
+  "name": "Leadership in Clinical Settings",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90127",
+  "name": "Intensive Care Nursing 2",
+  "offered": [
+   "march",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90100",
+  "name": "Inference Methods in Biostatistics",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90105",
+  "name": "Practice-based Research Methods",
+  "offered": [
+   "march"
+  ],
+  "online": false
  },
  {
   "code": "FINA20033",
@@ -411,144 +183,32 @@
    "april",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA20045",
-  "name": "Introduction to Screenprinting",
-  "offered": [
-   "summer_term",
-   "march",
-   "april",
-   "winter_term",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "FINA90002",
-  "name": "Research Methods",
-  "offered": [
-   "march",
-   "semester_1"
-  ]
- },
- {
-  "code": "FNCE90043",
-  "name": "Special Topics in Finance A",
+  "code": "BUSA90499",
+  "name": "Introduction to Business Problems",
   "offered": [
    "march"
-  ]
- },
- {
-  "code": "GEND90006",
-  "name": "Gender, Globalisation and Development",
-  "offered": [
-   "march"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "GEND90013",
   "name": "Research in Gender",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOG30031",
-  "name": "Law Space: Geographies of Justice",
+  "code": "NURS90099",
+  "name": "Critical Care Nursing Practice",
   "offered": [
    "march"
-  ]
- },
- {
-  "code": "GEOL90027",
-  "name": "Advanced Structural Mapping",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "GEOL90028",
-  "name": "Geochronology and Thermochronology",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "GEOL90029",
-  "name": "Geology of Gold",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "GEOL90047",
-  "name": "Basin Evolution & Sequence Stratigraphy",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "IBUS90005",
-  "name": "Business in Asia",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS70009",
-  "name": "Comparative Corporate Tax",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS70021",
-  "name": "Patent Law",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS70110",
-  "name": "International Financial System",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS70113",
-  "name": "Public Private Partnerships Law",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS70173",
-  "name": "International Law",
-  "offered": [
-   "march",
-   "june"
-  ]
- },
- {
-  "code": "LAWS70217",
-  "name": "Fundamentals of the Common Law",
-  "offered": [
-   "march",
-   "may",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "LAWS70264",
-  "name": "International Human Rights Law",
-  "offered": [
-   "march",
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS70314",
@@ -556,115 +216,83 @@
   "offered": [
    "march",
    "august"
-  ]
- },
- {
-  "code": "LAWS70323",
-  "name": "Foundations of Tax Law",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS70371",
-  "name": "Principles of Employment Law",
-  "offered": [
-   "march",
-   "august"
-  ]
- },
- {
-  "code": "LAWS70380",
-  "name": "Australian Consumer Law",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS70385",
-  "name": "White Collar Crime",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS70468",
-  "name": "Negotiation Skills",
-  "offered": [
-   "february",
-   "march"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS90043",
   "name": "Mineral and Petroleum Law",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS90049",
-  "name": "Reimagining Human Rights Law",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS90144",
-  "name": "International Sustainable Finance",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS90145",
-  "name": "Artificial Intelligence and the Law",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "LAWS90199",
-  "name": "Pandemic Law and Practice",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "MAST90100",
-  "name": "Inference Methods in Biostatistics",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "MEDS90036",
-  "name": "MD Research Skills 2",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "MGMT90127",
-  "name": "Leadership Theory & Practice",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "MGMT90231",
-  "name": "BioDesign Innovation",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "MGMT90257",
-  "name": "Supply Chain Challenges & Opportunities",
+  "code": "EDUC90631",
+  "name": "Second Language Acquisition and Teaching",
   "offered": [
    "march",
    "august"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90025",
+  "name": "Cooperation and Conflict in World Trade",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90870",
+  "name": "Laying the Foundations for Your Research",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90083",
+  "name": "Rural Critical Care Nursing 1",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90114",
+  "name": "Nursing Practice 1",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90028",
+  "name": "Geochronology and Thermochronology",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90079",
+  "name": "Neonatal Intensive Care  1",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70173",
+  "name": "International Law",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "MULT90005",
@@ -672,84 +300,155 @@
   "offered": [
    "march",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90179",
-  "name": "Evidence-Based Performance Teaching",
+  "code": "DEVT90041",
+  "name": "Development Research Design & Assessment",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90074",
+  "name": "Contemporary Development",
+  "offered": [
+   "march",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90027",
+  "name": "Advanced Structural Mapping",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90013",
+  "name": "Leadership in Clinical Settings",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90323",
+  "name": "Construction Scheduling",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLRS90011",
+  "name": "Study Design in Clinical Research",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90231",
+  "name": "BioDesign Innovation",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70021",
+  "name": "Patent Law",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90043",
+  "name": "Special Topics in Finance A",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90996",
+  "name": "Supervised Teaching-Adult (Second Lang)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL90024",
+  "name": "Philosophy Methods",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90095",
+  "name": "Economic Evaluation 2",
+  "offered": [
+   "march"
+  ],
+  "online": false
  },
  {
   "code": "NURS90018",
   "name": "Consumer Perspective: Theory & Practice",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "NURS90078",
-  "name": "Assessment in Mental Health Nursing",
+  "code": "EDUC90506",
+  "name": "Language & Literacy Development",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "NURS90079",
-  "name": "Neonatal Intensive Care  1",
+  "code": "IBUS90005",
+  "name": "Business in Asia",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "NURS90082",
-  "name": "Cancer and Palliative Care Nursing 1",
+  "code": "EDUC90950",
+  "name": "Globalisation and Education Policy",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "NURS90083",
-  "name": "Rural Critical Care Nursing 1",
+  "code": "LAWS70468",
+  "name": "Negotiation Skills",
   "offered": [
+   "february",
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "NURS90084",
-  "name": "Paediatric Nursing 1",
+  "code": "LAWS90144",
+  "name": "International Sustainable Finance",
   "offered": [
    "march"
-  ]
- },
- {
-  "code": "NURS90085",
-  "name": "Paediatric Intensive Care Nursing 1",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "NURS90099",
-  "name": "Critical Care Nursing Practice",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "NURS90112",
-  "name": "Nursing Specialty 1",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "NURS90114",
-  "name": "Nursing Practice 1",
-  "offered": [
-   "march"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "NURS90122",
@@ -757,15 +456,117 @@
   "offered": [
    "march",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "NURS90127",
-  "name": "Intensive Care Nursing 2",
+  "code": "PSYT90105",
+  "name": "Practice-based Research Methods",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20033",
+  "name": "Introduction to Printmaking Processes",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90094",
+  "name": "Finance",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90507",
+  "name": "Oral Language, Literacy & Learning",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90615",
+  "name": "Mathematics: Teaching with Technology",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90082",
+  "name": "Cancer and Palliative Care Nursing 1",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90587",
+  "name": "Grammar for Language Teachers",
   "offered": [
    "march",
-   "september"
-  ]
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90199",
+  "name": "Pandemic Law and Practice",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90224",
+  "name": "Counselling Skills for Ed. Psychologists",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90946",
+  "name": "Mathematics Across the Curriculum",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90488",
+  "name": "Business in Complex Environments",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90243",
+  "name": "Epidemiology 3",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90222",
+  "name": "Intervention in Problems of Young People",
+  "offered": [
+   "march"
+  ],
+  "online": false
  },
  {
   "code": "ORAL30003",
@@ -778,114 +579,40 @@
    "june",
    "june",
    "august"
-  ]
- },
- {
-  "code": "PADM90013",
-  "name": "Leadership in Clinical Settings",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "PHIL90024",
-  "name": "Philosophy Methods",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "POPH90095",
-  "name": "Economic Evaluation 2",
-  "offered": [
-   "march"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "POPH90206",
   "name": "Health Policy",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POPH90218",
-  "name": "Public Health Leadership and Management",
+  "code": "BUSA90271",
+  "name": "Mergers and Acquisitions",
   "offered": [
    "march"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POPH90243",
-  "name": "Epidemiology 3",
+  "code": "LAWS70385",
+  "name": "White Collar Crime",
   "offered": [
    "march"
-  ]
- },
- {
-  "code": "PPMN90006",
-  "name": "Executive Leadership and Management",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "PPMN90007",
-  "name": "Public Policy Analysis",
-  "offered": [
-   "march",
-   "september"
-  ]
- },
- {
-  "code": "PPMN90037",
-  "name": "Governance",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "PPMN90042",
-  "name": "Political Problems and Policy Responses",
-  "offered": [
-   "march",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "PSYC90008",
   "name": "Ethics and Professional Issues",
   "offered": [
    "march"
-  ]
- },
- {
-  "code": "PSYT90096",
-  "name": "Foundations of Youth Mental Health",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "PSYT90100",
-  "name": "Mental Ill-health in Young People 2",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "PSYT90105",
-  "name": "Practice-based Research Methods",
-  "offered": [
-   "march"
-  ]
- },
- {
-  "code": "SOCI90011",
-  "name": "Foundations of Social Policy",
-  "offered": [
-   "march"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "VETS40023",
@@ -894,6 +621,1461 @@
    "march",
    "semester_2",
    "september"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90112",
+  "name": "Nursing Specialty 1",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90988",
+  "name": "Clinical Teaching Practice (EC&P) 5",
+  "offered": [
+   "march",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70110",
+  "name": "International Financial System",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70217",
+  "name": "Fundamentals of the Common Law",
+  "offered": [
+   "march",
+   "may",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90001",
+  "name": "Development Project Management & Design",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70323",
+  "name": "Foundations of Tax Law",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90127",
+  "name": "Leadership Theory & Practice",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90036",
+  "name": "Data in Criminology Policy and Practice",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90085",
+  "name": "Paediatric Intensive Care Nursing 1",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90042",
+  "name": "Political Problems and Policy Responses",
+  "offered": [
+   "march",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90029",
+  "name": "Geology of Gold",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90882",
+  "name": "Educational Foundations (Prim)",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70371",
+  "name": "Principles of Employment Law",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90011",
+  "name": "Foundations of Social Policy",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90836",
+  "name": "Leadership in Clinical Education",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM90053",
+  "name": "Interfacial Chemistry and Sonochemistry",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90952",
+  "name": "Informal Science Communication",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90803",
+  "name": "Pedagogy into Practice",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90078",
+  "name": "Assessment in Mental Health Nursing",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70009",
+  "name": "Comparative Corporate Tax",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90013",
+  "name": "Financial Management for Agribusiness",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90218",
+  "name": "Public Health Leadership and Management",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90028",
+  "name": "Introduction to Conservation Treatment",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90006",
+  "name": "Executive Leadership and Management",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC30076",
+  "name": "Wakanda: African Futures in Education",
+  "offered": [
+   "march",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90001",
+  "name": "Administrative Challenges in Practice",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90094",
+  "name": "Finance",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90507",
+  "name": "Oral Language, Literacy & Learning",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90988",
+  "name": "Clinical Teaching Practice (EC&P) 5",
+  "offered": [
+   "march",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90206",
+  "name": "Health Policy",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90008",
+  "name": "Ethics and Professional Issues",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90946",
+  "name": "Mathematics Across the Curriculum",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90488",
+  "name": "Business in Complex Environments",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90243",
+  "name": "Epidemiology 3",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70217",
+  "name": "Fundamentals of the Common Law",
+  "offered": [
+   "march",
+   "may",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90615",
+  "name": "Mathematics: Teaching with Technology",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90112",
+  "name": "Nursing Specialty 1",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70110",
+  "name": "International Financial System",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70385",
+  "name": "White Collar Crime",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90587",
+  "name": "Grammar for Language Teachers",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90222",
+  "name": "Intervention in Problems of Young People",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90199",
+  "name": "Pandemic Law and Practice",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90082",
+  "name": "Cancer and Palliative Care Nursing 1",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS40023",
+  "name": "Professional Veterinary Practice Part 2",
+  "offered": [
+   "march",
+   "semester_2",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90271",
+  "name": "Mergers and Acquisitions",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90006",
+  "name": "Executive Leadership and Management",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC30076",
+  "name": "Wakanda: African Futures in Education",
+  "offered": [
+   "march",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90001",
+  "name": "Administrative Challenges in Practice",
+  "offered": [
+   "march"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90043",
+  "name": "Special Topics in Finance A",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90996",
+  "name": "Supervised Teaching-Adult (Second Lang)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS90036",
+  "name": "MD Research Skills 2",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
+  "offered": [
+   "summer_term",
+   "april",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90084",
+  "name": "Paediatric Nursing 1",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90638",
+  "name": "Education, Knowledge and Power",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90526",
+  "name": "Strategic Consulting for Social Impact",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90323",
+  "name": "Construction Scheduling",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLRS90011",
+  "name": "Study Design in Clinical Research",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90231",
+  "name": "BioDesign Innovation",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70021",
+  "name": "Patent Law",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70468",
+  "name": "Negotiation Skills",
+  "offered": [
+   "february",
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL90024",
+  "name": "Philosophy Methods",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90005",
+  "name": "Business in Asia",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90095",
+  "name": "Economic Evaluation 2",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90018",
+  "name": "Consumer Perspective: Theory & Practice",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90506",
+  "name": "Language & Literacy Development",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90950",
+  "name": "Globalisation and Education Policy",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90144",
+  "name": "International Sustainable Finance",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90122",
+  "name": "Foundations of Critical Care Nursing",
+  "offered": [
+   "march",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90100",
+  "name": "Inference Methods in Biostatistics",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90049",
+  "name": "Reimagining Human Rights Law",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90047",
+  "name": "Organic Electronics",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70380",
+  "name": "Australian Consumer Law",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90012",
+  "name": "Introduction to Forensic Disability",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70113",
+  "name": "Public Private Partnerships Law",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC90004",
+  "name": "Monogastric Science",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30031",
+  "name": "Law Space: Geographies of Justice",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90078",
+  "name": "Development, Culture and Conflict",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20045",
+  "name": "Introduction to Screenprinting",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "winter_term",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90322",
+  "name": "Special Topics in Management",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90096",
+  "name": "Foundations of Youth Mental Health",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90257",
+  "name": "Supply Chain Challenges & Opportunities",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90282",
+  "name": "Principles of Heritage and Conservation",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90093",
+  "name": "Introduction to Positive Psychology",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS90036",
+  "name": "MD Research Skills 2",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
+  "offered": [
+   "summer_term",
+   "april",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90084",
+  "name": "Paediatric Nursing 1",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90638",
+  "name": "Education, Knowledge and Power",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90526",
+  "name": "Strategic Consulting for Social Impact",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90127",
+  "name": "Intensive Care Nursing 2",
+  "offered": [
+   "march",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90100",
+  "name": "Inference Methods in Biostatistics",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90049",
+  "name": "Reimagining Human Rights Law",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90096",
+  "name": "Supervised Observation (Second Language)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90047",
+  "name": "Organic Electronics",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20045",
+  "name": "Introduction to Screenprinting",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "winter_term",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90012",
+  "name": "Introduction to Forensic Disability",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC90004",
+  "name": "Monogastric Science",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70113",
+  "name": "Public Private Partnerships Law",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70380",
+  "name": "Australian Consumer Law",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30031",
+  "name": "Law Space: Geographies of Justice",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90078",
+  "name": "Development, Culture and Conflict",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90096",
+  "name": "Foundations of Youth Mental Health",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90322",
+  "name": "Special Topics in Management",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90257",
+  "name": "Supply Chain Challenges & Opportunities",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90282",
+  "name": "Principles of Heritage and Conservation",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90093",
+  "name": "Introduction to Positive Psychology",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90094",
+  "name": "Finance",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90507",
+  "name": "Oral Language, Literacy & Learning",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90615",
+  "name": "Mathematics: Teaching with Technology",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90082",
+  "name": "Cancer and Palliative Care Nursing 1",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90587",
+  "name": "Grammar for Language Teachers",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90199",
+  "name": "Pandemic Law and Practice",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90224",
+  "name": "Counselling Skills for Ed. Psychologists",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90946",
+  "name": "Mathematics Across the Curriculum",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90488",
+  "name": "Business in Complex Environments",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90243",
+  "name": "Epidemiology 3",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90222",
+  "name": "Intervention in Problems of Young People",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90206",
+  "name": "Health Policy",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90271",
+  "name": "Mergers and Acquisitions",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70385",
+  "name": "White Collar Crime",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90008",
+  "name": "Ethics and Professional Issues",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS40023",
+  "name": "Professional Veterinary Practice Part 2",
+  "offered": [
+   "march",
+   "semester_2",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90112",
+  "name": "Nursing Specialty 1",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90988",
+  "name": "Clinical Teaching Practice (EC&P) 5",
+  "offered": [
+   "march",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70110",
+  "name": "International Financial System",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70217",
+  "name": "Fundamentals of the Common Law",
+  "offered": [
+   "march",
+   "may",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90001",
+  "name": "Development Project Management & Design",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70323",
+  "name": "Foundations of Tax Law",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90517",
+  "name": "Social Entrepreneur Consulting Practicum",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90514",
+  "name": "Industry Studies in Europe",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90047",
+  "name": "Basin Evolution & Sequence Stratigraphy",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90225",
+  "name": "Psychological Tests",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70264",
+  "name": "International Human Rights Law",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90195",
+  "name": "Specific Learning Difficulties: Literacy",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90006",
+  "name": "Environmental Education",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90223",
+  "name": "Exceptionality:Assessment & Intervention",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90005",
+  "name": "Intensive Research Workshop",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90885",
+  "name": "Introduction to Clinical Practice (Prim)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90050",
+  "name": "Supervised Teaching (Second Language)",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90145",
+  "name": "Artificial Intelligence and the Law",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90804",
+  "name": "Clinical Assessment & Course Evaluation",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND90006",
+  "name": "Gender, Globalisation and Development",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90100",
+  "name": "Mental Ill-health in Young People 2",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90037",
+  "name": "Governance",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90014",
+  "name": "Choral Direction",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90007",
+  "name": "Public Policy Analysis",
+  "offered": [
+   "march",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90179",
+  "name": "Evidence-Based Performance Teaching",
+  "offered": [
+   "march",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90803",
+  "name": "Pedagogy into Practice",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90094",
+  "name": "Finance",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90507",
+  "name": "Oral Language, Literacy & Learning",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90988",
+  "name": "Clinical Teaching Practice (EC&P) 5",
+  "offered": [
+   "march",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90206",
+  "name": "Health Policy",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90008",
+  "name": "Ethics and Professional Issues",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90946",
+  "name": "Mathematics Across the Curriculum",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90488",
+  "name": "Business in Complex Environments",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90243",
+  "name": "Epidemiology 3",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70217",
+  "name": "Fundamentals of the Common Law",
+  "offered": [
+   "march",
+   "may",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90615",
+  "name": "Mathematics: Teaching with Technology",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90112",
+  "name": "Nursing Specialty 1",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70110",
+  "name": "International Financial System",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70385",
+  "name": "White Collar Crime",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90587",
+  "name": "Grammar for Language Teachers",
+  "offered": [
+   "march",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90222",
+  "name": "Intervention in Problems of Young People",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90199",
+  "name": "Pandemic Law and Practice",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90082",
+  "name": "Cancer and Palliative Care Nursing 1",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS40023",
+  "name": "Professional Veterinary Practice Part 2",
+  "offered": [
+   "march",
+   "semester_2",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90271",
+  "name": "Mergers and Acquisitions",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90006",
+  "name": "Executive Leadership and Management",
+  "offered": [
+   "march"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC30076",
+  "name": "Wakanda: African Futures in Education",
+  "offered": [
+   "march",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90001",
+  "name": "Administrative Challenges in Practice",
+  "offered": [
+   "march"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_may.json
+++ b/subject-utils/subject-lists/subjects_2021_may.json
@@ -1,34 +1,19 @@
 [
  {
-  "code": "ABPL90307",
-  "name": "MSD Vocational Placement",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "may",
-   "semester_2"
-  ]
- },
- {
-  "code": "ANSC90007",
-  "name": "Animal Welfare",
+  "code": "PSYT90068",
+  "name": "Perinatal Psychiatry",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90002",
-  "name": "Financial Accounting",
+  "code": "CHEM90045",
+  "name": "Advanced Physical Organic Chemistry",
   "offered": [
    "may"
-  ]
- },
- {
-  "code": "BUSA90054",
-  "name": "Corporate Strategy",
-  "offered": [
-   "may"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90124",
@@ -36,89 +21,113 @@
   "offered": [
    "summer_term",
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90201",
-  "name": "Managerial Project",
-  "offered": [
-   "summer_term",
-   "april",
-   "may",
-   "june"
-  ]
- },
- {
-  "code": "BUSA90218",
-  "name": "Innovation",
-  "offered": [
-   "may",
-   "november"
-  ]
- },
- {
-  "code": "BUSA90226",
-  "name": "Managing People",
+  "code": "LAWS90087",
+  "name": "Disability Human Rights Law",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90500",
-  "name": "Business Analytics Foundations",
+  "code": "EDUC90753",
+  "name": "Leading Learning and Teaching",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90501",
-  "name": "Advanced Business Analytics",
+  "code": "EDUC90987",
+  "name": "Clinical Teaching Practice (EC&P) 4",
   "offered": [
-   "may",
-   "august"
-  ]
+   "semester_1",
+   "may"
+  ],
+  "online": false
  },
  {
   "code": "BUSA90509",
   "name": "Executive Management 5",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90165",
+  "name": "Digital Consumer Protection Law",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90226",
+  "name": "Managing People",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70031",
+  "name": "Goods and Services Tax",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70049",
+  "name": "Taxation of Small and Medium Enterprises",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90943",
+  "name": "Marketing and Innovation in Education",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70207",
+  "name": "Copyright Law",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90088",
+  "name": "History & Philosophy of Psychiatry",
+  "offered": [
+   "may"
+  ],
+  "online": false
  },
  {
   "code": "BUSA90523",
   "name": "Managing Diversity in the Workplace",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "CHEM90045",
-  "name": "Advanced Physical Organic Chemistry",
+  "code": "PSYT90022",
+  "name": "Cognitive Behaviour Therapy",
   "offered": [
    "may"
-  ]
- },
- {
-  "code": "CUMC90020",
-  "name": "Video Lab",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "CUMC90022",
-  "name": "Digital Protocols",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "CUMC90029",
-  "name": "Preventive Conservation",
-  "offered": [
-   "may"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "DEVT90068",
@@ -126,151 +135,28 @@
   "offered": [
    "may",
    "november"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90753",
-  "name": "Leading Learning and Teaching",
+  "code": "BUSA90201",
+  "name": "Managerial Project",
   "offered": [
-   "may"
-  ]
- },
- {
-  "code": "EDUC90786",
-  "name": "Leading Educational Research",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "EDUC90807",
-  "name": "Building Positive Education Communities",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "EDUC90941",
-  "name": "Leading the Educational Organisation",
-  "offered": [
+   "summer_term",
+   "january",
+   "april",
    "may",
-   "october"
-  ]
+   "june"
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90943",
-  "name": "Marketing and Innovation in Education",
+  "code": "PSYT90059",
+  "name": "Substance Use Disorders",
   "offered": [
    "may"
-  ]
- },
- {
-  "code": "FNCE90044",
-  "name": "Special Topics in Finance B",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "GEOL90030",
-  "name": "Coastal Environmental Geomorphology",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "GEOL90038",
-  "name": "Igneous Geodynamics and Ore Deposits",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "GEOL90044",
-  "name": "Ore Deposit Models",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS70031",
-  "name": "Goods and Services Tax",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS70049",
-  "name": "Taxation of Small and Medium Enterprises",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS70206",
-  "name": "Banking and Secured Finance",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS70207",
-  "name": "Copyright Law",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS70210",
-  "name": "Resources Joint Ventures",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS70217",
-  "name": "Fundamentals of the Common Law",
-  "offered": [
-   "march",
-   "may",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "LAWS70225",
-  "name": "Medical Litigation",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS70234",
-  "name": "International Humanitarian Law",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS70293",
-  "name": "Climate Change Law",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS70319",
-  "name": "Tax Policy",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS70382",
-  "name": "Business and Human Rights",
-  "offered": [
-   "may"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS70392",
@@ -278,100 +164,97 @@
   "offered": [
    "may",
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS90022",
-  "name": "International Dispute Settlement",
+  "code": "EDUC90987",
+  "name": "Clinical Teaching Practice (EC&P) 4",
   "offered": [
+   "semester_1",
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS90080",
-  "name": "Negotiation and Dispute Resolution",
+  "code": "BUSA90226",
+  "name": "Managing People",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS90086",
-  "name": "Conducting Workplace Investigations",
+  "code": "BUSA90509",
+  "name": "Executive Management 5",
   "offered": [
    "may"
-  ]
- },
- {
-  "code": "LAWS90087",
-  "name": "Disability Human Rights Law",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS90127",
-  "name": "Comparative Indigenous Rights",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS90152",
-  "name": "Health Data Governance",
-  "offered": [
-   "may"
-  ]
- },
- {
-  "code": "LAWS90158",
-  "name": "Current Issues in International Tax",
-  "offered": [
-   "may"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS90165",
   "name": "Digital Consumer Protection Law",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS90172",
-  "name": "Core Principles of Contract",
+  "code": "CUMC90022",
+  "name": "Digital Protocols",
   "offered": [
    "may"
-  ]
- },
- {
-  "code": "MEDS90027",
-  "name": "Clinical Elective",
-  "offered": [
-   "may",
-   "november"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MGMT90132",
   "name": "Professional Communication",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90258",
-  "name": "Supply Chain Analytics",
-  "offered": [
-   "may",
-   "november"
-  ]
- },
- {
-  "code": "MUSI90027",
-  "name": "Piano Pedagogy",
+  "code": "FNCE90044",
+  "name": "Special Topics in Finance B",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90030",
+  "name": "Coastal Environmental Geomorphology",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90017",
+  "name": "Political Advising",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90018",
+  "name": "Project Management Practices",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90016",
+  "name": "Forensic Psychiatry",
+  "offered": [
+   "may"
+  ],
+  "online": false
  },
  {
   "code": "ORAL30003",
@@ -384,63 +267,91 @@
    "june",
    "june",
    "august"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70206",
+  "name": "Banking and Secured Finance",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70382",
+  "name": "Business and Human Rights",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70217",
+  "name": "Fundamentals of the Common Law",
+  "offered": [
+   "march",
+   "may",
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
   "code": "PADM90006",
   "name": "The Rule of Law",
   "offered": [
    "may"
-  ]
- },
- {
-  "code": "PADM90017",
-  "name": "Political Advising",
-  "offered": [
-   "may"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "PSYC90094",
   "name": "Positive Psychology in Practice",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PSYT90016",
-  "name": "Forensic Psychiatry",
+  "code": "BUSA90002",
+  "name": "Financial Accounting",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PSYT90022",
-  "name": "Cognitive Behaviour Therapy",
+  "code": "LAWS90086",
+  "name": "Conducting Workplace Investigations",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PSYT90059",
-  "name": "Substance Use Disorders",
+  "code": "LAWS70234",
+  "name": "International Humanitarian Law",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PSYT90068",
-  "name": "Perinatal Psychiatry",
+  "code": "LAWS90172",
+  "name": "Core Principles of Contract",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PSYT90088",
-  "name": "History & Philosophy of Psychiatry",
+  "code": "LAWS90152",
+  "name": "Health Data Governance",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "SCWK90048",
@@ -450,7 +361,16 @@
    "may",
    "september",
    "november"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90054",
+  "name": "Corporate Strategy",
+  "offered": [
+   "may"
+  ],
+  "online": false
  },
  {
   "code": "SCWK90050",
@@ -460,13 +380,711 @@
    "may",
    "august",
    "november"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70225",
+  "name": "Medical Litigation",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70293",
+  "name": "Climate Change Law",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90807",
+  "name": "Building Positive Education Communities",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDS90027",
+  "name": "Clinical Elective",
+  "offered": [
+   "may",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90501",
+  "name": "Advanced Business Analytics",
+  "offered": [
+   "may",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90027",
+  "name": "Piano Pedagogy",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90080",
+  "name": "Negotiation and Dispute Resolution",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90029",
+  "name": "Preventive Conservation",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90127",
+  "name": "Comparative Indigenous Rights",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90038",
+  "name": "Igneous Geodynamics and Ore Deposits",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90044",
+  "name": "Ore Deposit Models",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70210",
+  "name": "Resources Joint Ventures",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90500",
+  "name": "Business Analytics Foundations",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70319",
+  "name": "Tax Policy",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90941",
+  "name": "Leading the Educational Organisation",
+  "offered": [
+   "may",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC90007",
+  "name": "Animal Welfare",
+  "offered": [
+   "may"
+  ],
+  "online": false
  },
  {
   "code": "SOCI90025",
   "name": "Social Justice: Policy and Practice",
   "offered": [
    "may"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "PHTY90003",
+  "name": "Advanced Practice in Pelvic Floor Physio",
+  "offered": [
+   "may"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90307",
+  "name": "MSD Vocational Placement",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "may",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70031",
+  "name": "Goods and Services Tax",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90523",
+  "name": "Managing Diversity in the Workplace",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90022",
+  "name": "Cognitive Behaviour Therapy",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70049",
+  "name": "Taxation of Small and Medium Enterprises",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90943",
+  "name": "Marketing and Innovation in Education",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90068",
+  "name": "Contemporary Leadership",
+  "offered": [
+   "may",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70207",
+  "name": "Copyright Law",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90088",
+  "name": "History & Philosophy of Psychiatry",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90786",
+  "name": "Leading Educational Research",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90201",
+  "name": "Managerial Project",
+  "offered": [
+   "summer_term",
+   "january",
+   "april",
+   "may",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90059",
+  "name": "Substance Use Disorders",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90218",
+  "name": "Innovation",
+  "offered": [
+   "may",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70392",
+  "name": "International Business Transactions",
+  "offered": [
+   "may",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90022",
+  "name": "International Dispute Settlement",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHTY90002",
+  "name": "The Pelvic Floor:Function&Dysfunction",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90068",
+  "name": "Perinatal Psychiatry",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90045",
+  "name": "Advanced Physical Organic Chemistry",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90124",
+  "name": "Implementation of Strategy",
+  "offered": [
+   "summer_term",
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90087",
+  "name": "Disability Human Rights Law",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90753",
+  "name": "Leading Learning and Teaching",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90218",
+  "name": "Innovation",
+  "offered": [
+   "may",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHTY90002",
+  "name": "The Pelvic Floor:Function&Dysfunction",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90022",
+  "name": "International Dispute Settlement",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90786",
+  "name": "Leading Educational Research",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90022",
+  "name": "Digital Protocols",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90132",
+  "name": "Professional Communication",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90044",
+  "name": "Special Topics in Finance B",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90030",
+  "name": "Coastal Environmental Geomorphology",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90017",
+  "name": "Political Advising",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90018",
+  "name": "Project Management Practices",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90016",
+  "name": "Forensic Psychiatry",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70206",
+  "name": "Banking and Secured Finance",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70382",
+  "name": "Business and Human Rights",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70217",
+  "name": "Fundamentals of the Common Law",
+  "offered": [
+   "march",
+   "may",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90006",
+  "name": "The Rule of Law",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90094",
+  "name": "Positive Psychology in Practice",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90002",
+  "name": "Financial Accounting",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90086",
+  "name": "Conducting Workplace Investigations",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70234",
+  "name": "International Humanitarian Law",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90029",
+  "name": "Preventive Conservation",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70319",
+  "name": "Tax Policy",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90307",
+  "name": "MSD Vocational Placement",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "may",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90941",
+  "name": "Leading the Educational Organisation",
+  "offered": [
+   "may",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI90025",
+  "name": "Social Justice: Policy and Practice",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHTY90003",
+  "name": "Advanced Practice in Pelvic Floor Physio",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC90007",
+  "name": "Animal Welfare",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70210",
+  "name": "Resources Joint Ventures",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90038",
+  "name": "Igneous Geodynamics and Ore Deposits",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90127",
+  "name": "Comparative Indigenous Rights",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90044",
+  "name": "Ore Deposit Models",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90500",
+  "name": "Business Analytics Foundations",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90022",
+  "name": "Digital Protocols",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90132",
+  "name": "Professional Communication",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90017",
+  "name": "Political Advising",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70206",
+  "name": "Banking and Secured Finance",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70217",
+  "name": "Fundamentals of the Common Law",
+  "offered": [
+   "march",
+   "may",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90030",
+  "name": "Coastal Environmental Geomorphology",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90044",
+  "name": "Special Topics in Finance B",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC90007",
+  "name": "Animal Welfare",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI90025",
+  "name": "Social Justice: Policy and Practice",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHTY90003",
+  "name": "Advanced Practice in Pelvic Floor Physio",
+  "offered": [
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90307",
+  "name": "MSD Vocational Placement",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "may",
+   "semester_2"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_november.json
+++ b/subject-utils/subject-lists/subjects_2021_november.json
@@ -1,61 +1,27 @@
 [
  {
-  "code": "ABPL30069",
-  "name": "Installations and Happenings",
+  "code": "LAWS70125",
+  "name": "International Financial Transactions",
   "offered": [
    "november"
-  ]
- },
- {
-  "code": "ABPL90320",
-  "name": "Building Resilient Settlements",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "ABPL90380",
-  "name": "Designing for Heat in the Public Domain",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "ABPL90415",
-  "name": "Advanced Asset Strategy Applications",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "BOTA30001",
-  "name": "Marine Botany",
-  "offered": [
-   "november"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90072",
   "name": "Global Business Economics",
   "offered": [
    "november"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90218",
-  "name": "Innovation",
+  "code": "LAWS70261",
+  "name": "Designs Law and Practice",
   "offered": [
-   "may",
    "november"
-  ]
- },
- {
-  "code": "BUSA90485",
-  "name": "Global Business Practicum",
-  "offered": [
-   "january",
-   "november"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90508",
@@ -63,14 +29,8 @@
   "offered": [
    "summer_term",
    "november"
-  ]
- },
- {
-  "code": "CRIM90023",
-  "name": "Advanced Practice in Offender Management",
-  "offered": [
-   "november"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "DEVT90068",
@@ -78,43 +38,16 @@
   "offered": [
    "may",
    "november"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "DEVT90071",
-  "name": "Organisation Development and Change",
+  "code": "ABPL30069",
+  "name": "Installations and Happenings",
   "offered": [
    "november"
-  ]
- },
- {
-  "code": "DEVT90076",
-  "name": "Social Policy and Development",
-  "offered": [
-   "semester_1",
-   "november"
-  ]
- },
- {
-  "code": "FRST90030",
-  "name": "Forests in the Asia Pacific Region",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "GEOG30030",
-  "name": "Spatial Modelling for Nature and People",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "HORT90044",
-  "name": "Plant Health",
-  "offered": [
-   "november"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "IBUS90004",
@@ -123,15 +56,51 @@
    "summer_term",
    "june",
    "november"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS50031",
-  "name": "Legal Theory",
+  "code": "BUSA90218",
+  "name": "Innovation",
   "offered": [
-   "semester_2",
+   "may",
    "november"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90485",
+  "name": "Global Business Practicum",
+  "offered": [
+   "january",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70006",
+  "name": "International Tax: Principles, Structure",
+  "offered": [
+   "semester_1",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90297",
+  "name": "Preventing Violence Against Women",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90171",
+  "name": "Competition in Digital Markets",
+  "offered": [
+   "november"
+  ],
+  "online": false
  },
  {
   "code": "LAWS50036",
@@ -139,7 +108,601 @@
   "offered": [
    "semester_1",
    "november"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90215",
+  "name": "Law and Global Health Security",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90137",
+  "name": "Primary Health Care, Jamkhed, India",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90024",
+  "name": "Future of Work in Comparative Contexts",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90023",
+  "name": "Advanced Practice in Offender Management",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70120",
+  "name": "International Law and Children's Rights",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90071",
+  "name": "Organisation Development and Change",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "BOTA30001",
+  "name": "Marine Botany",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT30017",
+  "name": "Global Management Consulting",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90058",
+  "name": "Comparative Human Rights Law",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70270",
+  "name": "Construction Contract Analysis, Drafting",
+  "offered": [
+   "february",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90415",
+  "name": "Advanced Asset Strategy Applications",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90211",
+  "name": "Indonesian Law",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90037",
+  "name": "Conflict and Negotiation",
+  "offered": [
+   "summer_term",
+   "winter_term",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30023",
+  "name": "Global Climate Change in Context",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90172",
+  "name": "Opera Performance Practicum 4",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30030",
+  "name": "Spatial Modelling for Nature and People",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT90044",
+  "name": "Plant Health",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90048",
+  "name": "Supervised Field Placement 1A",
+  "offered": [
+   "february",
+   "may",
+   "september",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90050",
+  "name": "Supervised Field Placement 2A",
+  "offered": [
+   "february",
+   "may",
+   "august",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90261",
+  "name": "HR Analytics",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDS90027",
+  "name": "Clinical Elective",
+  "offered": [
+   "may",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70259",
+  "name": "Medical Ethics",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90169",
+  "name": "Opera Performance Practicum 2",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90380",
+  "name": "Designing for Heat in the Public Domain",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70037",
+  "name": "Royal Commissions and Public Inquiries",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90210",
+  "name": "Law and Psychology",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70141",
+  "name": "Energy Regulation and the Law",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70304",
+  "name": "Internat Investment Law and Arbitration",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90258",
+  "name": "Supply Chain Analytics",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90058",
+  "name": "Comparative Human Rights Law",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90172",
+  "name": "Opera Performance Practicum 4",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30023",
+  "name": "Global Climate Change in Context",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90037",
+  "name": "Conflict and Negotiation",
+  "offered": [
+   "summer_term",
+   "winter_term",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90415",
+  "name": "Advanced Asset Strategy Applications",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90211",
+  "name": "Indonesian Law",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70270",
+  "name": "Construction Contract Analysis, Drafting",
+  "offered": [
+   "february",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30030",
+  "name": "Spatial Modelling for Nature and People",
+  "offered": [
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90024",
+  "name": "Future of Work in Comparative Contexts",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90023",
+  "name": "Advanced Practice in Offender Management",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70120",
+  "name": "International Law and Children's Rights",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90215",
+  "name": "Law and Global Health Security",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90137",
+  "name": "Primary Health Care, Jamkhed, India",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90071",
+  "name": "Organisation Development and Change",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA30001",
+  "name": "Marine Botany",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30017",
+  "name": "Global Management Consulting",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90072",
+  "name": "Global Business Economics",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70125",
+  "name": "International Financial Transactions",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70261",
+  "name": "Designs Law and Practice",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90508",
+  "name": "Executive Management 4",
+  "offered": [
+   "summer_term",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90068",
+  "name": "Contemporary Leadership",
+  "offered": [
+   "may",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30069",
+  "name": "Installations and Happenings",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90004",
+  "name": "Cross Cultural Management and Teamwork",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90485",
+  "name": "Global Business Practicum",
+  "offered": [
+   "january",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90171",
+  "name": "Competition in Digital Markets",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90218",
+  "name": "Innovation",
+  "offered": [
+   "may",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90297",
+  "name": "Preventing Violence Against Women",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70006",
+  "name": "International Tax: Principles, Structure",
+  "offered": [
+   "semester_1",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30017",
+  "name": "Global Management Consulting",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90261",
+  "name": "HR Analytics",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90380",
+  "name": "Designing for Heat in the Public Domain",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90050",
+  "name": "Supervised Field Placement 2A",
+  "offered": [
+   "february",
+   "may",
+   "august",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70141",
+  "name": "Energy Regulation and the Law",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90048",
+  "name": "Supervised Field Placement 1A",
+  "offered": [
+   "february",
+   "may",
+   "september",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90044",
+  "name": "Plant Health",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70037",
+  "name": "Royal Commissions and Public Inquiries",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDS90027",
+  "name": "Clinical Elective",
+  "offered": [
+   "may",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90210",
+  "name": "Law and Psychology",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90169",
+  "name": "Opera Performance Practicum 2",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90320",
+  "name": "Building Resilient Settlements",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70259",
+  "name": "Medical Ethics",
+  "offered": [
+   "november"
+  ],
+  "online": true
  },
  {
   "code": "LAWS50059",
@@ -150,222 +713,143 @@
    "june",
    "semester_2",
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "LAWS50122",
-  "name": "Animals and the Law",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "LAWS70006",
-  "name": "International Tax: Principles, Structure",
+  "code": "DEVT90076",
+  "name": "Social Policy and Development",
   "offered": [
    "semester_1",
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "LAWS70037",
-  "name": "Royal Commissions and Public Inquiries",
+  "code": "FRST90030",
+  "name": "Forests in the Asia Pacific Region",
   "offered": [
    "november"
-  ]
- },
- {
-  "code": "LAWS70120",
-  "name": "International Law and Children's Rights",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "LAWS70125",
-  "name": "International Financial Transactions",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "LAWS70141",
-  "name": "Energy Regulation and the Law",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "LAWS70259",
-  "name": "Medical Ethics",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "LAWS70261",
-  "name": "Designs Law and Practice",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "LAWS70270",
-  "name": "Construction Contract Analysis, Drafting",
-  "offered": [
-   "february",
-   "november"
-  ]
- },
- {
-  "code": "LAWS70304",
-  "name": "Internat Investment Law and Arbitration",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "LAWS70389",
-  "name": "Global Commercial Contract Law",
-  "offered": [
-   "november"
-  ]
+  ],
+  "online": true
  },
  {
   "code": "LAWS90029",
   "name": "Planning and Building Sustainable Cities",
   "offered": [
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "LAWS90058",
-  "name": "Comparative Human Rights Law",
+  "code": "LAWS70389",
+  "name": "Global Commercial Contract Law",
   "offered": [
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "LAWS90171",
-  "name": "Competition in Digital Markets",
+  "code": "LAWS50031",
+  "name": "Legal Theory",
   "offered": [
+   "semester_2",
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "LAWS90210",
-  "name": "Law and Psychology",
+  "code": "LAWS50122",
+  "name": "Animals and the Law",
   "offered": [
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "LAWS90211",
-  "name": "Indonesian Law",
+  "code": "ABPL90320",
+  "name": "Building Resilient Settlements",
   "offered": [
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "LAWS90215",
-  "name": "Law and Global Health Security",
+  "code": "LAWS50059",
+  "name": "Legal Internship",
   "offered": [
+   "january",
+   "semester_1",
+   "june",
+   "semester_2",
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "MEDS90027",
-  "name": "Clinical Elective",
+  "code": "LAWS70389",
+  "name": "Global Commercial Contract Law",
   "offered": [
-   "may",
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "MGMT30017",
-  "name": "Global Management Consulting",
+  "code": "LAWS50031",
+  "name": "Legal Theory",
   "offered": [
-   "summer_term",
+   "semester_2",
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "MGMT90037",
-  "name": "Conflict and Negotiation",
+  "code": "DEVT90076",
+  "name": "Social Policy and Development",
   "offered": [
-   "summer_term",
-   "winter_term",
+   "semester_1",
    "november"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50122",
+  "name": "Animals and the Law",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90029",
+  "name": "Planning and Building Sustainable Cities",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70304",
+  "name": "Internat Investment Law and Arbitration",
+  "offered": [
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90030",
+  "name": "Forests in the Asia Pacific Region",
+  "offered": [
+   "november"
+  ],
+  "online": true
  },
  {
   "code": "MGMT90258",
   "name": "Supply Chain Analytics",
   "offered": [
-   "may",
    "november"
-  ]
- },
- {
-  "code": "MGMT90261",
-  "name": "HR Analytics",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "MUSI90169",
-  "name": "Opera Performance Practicum 2",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "MUSI90172",
-  "name": "Opera Performance Practicum 4",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "POPH90137",
-  "name": "Primary Health Care, Jamkhed, India",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "POPH90297",
-  "name": "Preventing Violence Against Women",
-  "offered": [
-   "november"
-  ]
- },
- {
-  "code": "SCWK90048",
-  "name": "Supervised Field Placement 1A",
-  "offered": [
-   "february",
-   "may",
-   "september",
-   "november"
-  ]
- },
- {
-  "code": "SCWK90050",
-  "name": "Supervised Field Placement 2A",
-  "offered": [
-   "february",
-   "may",
-   "august",
-   "november"
-  ]
- },
- {
-  "code": "SOCI90024",
-  "name": "Future of Work in Comparative Contexts",
-  "offered": [
-   "november"
-  ]
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_october.json
+++ b/subject-utils/subject-lists/subjects_2021_october.json
@@ -1,154 +1,27 @@
 [
  {
-  "code": "BISY90016",
-  "name": "Predictive Analytics",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "BUSA90279",
-  "name": "Organisational Change",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "BUSA90483",
-  "name": "General Management 2",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "BUSA90502",
-  "name": "Analytics Lab",
-  "offered": [
-   "august",
-   "october"
-  ]
- },
- {
   "code": "BUSA90503",
   "name": "Business Analytics Applications",
   "offered": [
    "october"
-  ]
- },
- {
-  "code": "BUSA90512",
-  "name": "Industry Studies in Asia",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "CLRS90013",
-  "name": "Responsibilities in Clinical Research",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "CRIM90013",
-  "name": "Advanced Practice in Forensic Disability",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "CRIM90020",
-  "name": "Crime, Culture & the Media",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "CUMC90030",
-  "name": "Conservation Assessment and Treatment 1",
-  "offered": [
-   "october"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "CUMC90031",
   "name": "Analytical Science in Conservation",
   "offered": [
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90910",
-  "name": "Clinical Teaching Practice (Sec) 3",
-  "offered": [
-   "semester_1",
-   "october"
-  ]
- },
- {
-  "code": "EDUC90941",
-  "name": "Leading the Educational Organisation",
-  "offered": [
-   "may",
-   "october"
-  ]
- },
- {
-  "code": "INDG90006",
-  "name": "Powerful Encounters",
+  "code": "CRIM90020",
+  "name": "Crime, Culture & the Media",
   "offered": [
    "october"
-  ]
- },
- {
-  "code": "LAWS70002",
-  "name": "Tax of Business and Investment Income",
-  "offered": [
-   "semester_1",
-   "october"
-  ]
- },
- {
-  "code": "LAWS70181",
-  "name": "Defamation Law",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "LAWS70197",
-  "name": "Labour Standards and their Enforcement",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "LAWS70205",
-  "name": "Project Finance",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "LAWS70239",
-  "name": "Payment Matters in Construction Projects",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "LAWS70350",
-  "name": "Management for Professionals",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "LAWS70362",
-  "name": "Information Technology Contracting Law",
-  "offered": [
-   "october"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS70392",
@@ -156,104 +29,195 @@
   "offered": [
    "may",
    "october"
-  ]
- },
- {
-  "code": "LAWS70398",
-  "name": "Law of the Sea",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "LAWS90006",
-  "name": "Law and Legal Practice in Asia",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "LAWS90013",
-  "name": "Constitutional Rights and Freedoms",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "LAWS90130",
-  "name": "Tax Administration",
-  "offered": [
-   "october"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS90153",
   "name": "Institutional Abuse and Legal Redress",
   "offered": [
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS90214",
-  "name": "Indigenous Law in Aotearoa and Australia",
+  "code": "EDUC90910",
+  "name": "Clinical Teaching Practice (Sec) 3",
   "offered": [
+   "semester_1",
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS90216",
-  "name": "Cryptoassets in Global Context",
+  "code": "BUSA90512",
+  "name": "Industry Studies in Asia",
   "offered": [
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90255",
-  "name": "Designing Supply Chains",
+  "code": "LAWS90013",
+  "name": "Constitutional Rights and Freedoms",
   "offered": [
-   "april",
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90272",
-  "name": "Procurement and Supply Management",
+  "code": "CRIM90013",
+  "name": "Advanced Practice in Forensic Disability",
   "offered": [
-   "february",
-   "april",
-   "june",
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90273",
-  "name": "Service Supply Chain Management",
+  "code": "VETS90089",
+  "name": "Eradicable Diseases",
   "offered": [
-   "february",
-   "april",
-   "june",
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90274",
-  "name": "Supply Chain Finance and Contracts",
+  "code": "POPH90299",
+  "name": "Workspace Design Evaluation",
   "offered": [
-   "february",
-   "april",
-   "june",
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90275",
-  "name": "Sustainable Supply Chain Management",
+  "code": "PHTY90004",
+  "name": "Exercise for Women",
   "offered": [
-   "february",
-   "april",
-   "june",
    "october"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90130",
+  "name": "Tax Administration",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90483",
+  "name": "General Management 2",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70205",
+  "name": "Project Finance",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70197",
+  "name": "Labour Standards and their Enforcement",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90279",
+  "name": "Organisational Change",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70239",
+  "name": "Payment Matters in Construction Projects",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLRS90013",
+  "name": "Responsibilities in Clinical Research",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG90006",
+  "name": "Powerful Encounters",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90502",
+  "name": "Analytics Lab",
+  "offered": [
+   "august",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90278",
+  "name": "Supply Chain Strategy",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90941",
+  "name": "Leading the Educational Organisation",
+  "offered": [
+   "may",
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90244",
+  "name": "Global Health and Human Rights",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70350",
+  "name": "Management for Professionals",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70362",
+  "name": "Information Technology Contracting Law",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70181",
+  "name": "Defamation Law",
+  "offered": [
+   "october"
+  ],
+  "online": false
  },
  {
   "code": "MGMT90276",
@@ -263,27 +227,16 @@
    "april",
    "june",
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90277",
-  "name": "Supply Chain Intelligence",
+  "code": "PADM90008",
+  "name": "Using Evidence",
   "offered": [
-   "february",
-   "april",
-   "june",
    "october"
-  ]
- },
- {
-  "code": "MGMT90278",
-  "name": "Supply Chain Strategy",
-  "offered": [
-   "february",
-   "april",
-   "june",
-   "october"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MGMT90279",
@@ -293,54 +246,417 @@
    "april",
    "june",
    "october"
-  ]
- },
- {
-  "code": "PADM90008",
-  "name": "Using Evidence",
-  "offered": [
-   "october"
-  ]
- },
- {
-  "code": "POPH90244",
-  "name": "Global Health and Human Rights",
-  "offered": [
-   "october"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "POPH90299",
   "name": "Workspace Design Evaluation",
   "offered": [
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCWK90049",
-  "name": "Supervised Field Placement 1B",
+  "code": "PHTY90004",
+  "name": "Exercise for Women",
   "offered": [
-   "summer_term",
-   "april",
-   "june",
    "october"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCWK90051",
-  "name": "Supervised Field Placement 2B",
+  "code": "LAWS70197",
+  "name": "Labour Standards and their Enforcement",
   "offered": [
-   "summer_term",
-   "april",
-   "june",
    "october"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90130",
+  "name": "Tax Administration",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70205",
+  "name": "Project Finance",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90279",
+  "name": "Organisational Change",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90483",
+  "name": "General Management 2",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLRS90013",
+  "name": "Responsibilities in Clinical Research",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70239",
+  "name": "Payment Matters in Construction Projects",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG90006",
+  "name": "Powerful Encounters",
+  "offered": [
+   "october"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90910",
+  "name": "Clinical Teaching Practice (Sec) 3",
+  "offered": [
+   "semester_1",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90512",
+  "name": "Industry Studies in Asia",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90013",
+  "name": "Constitutional Rights and Freedoms",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90013",
+  "name": "Advanced Practice in Forensic Disability",
+  "offered": [
+   "october"
+  ],
+  "online": true
  },
  {
   "code": "VETS90089",
   "name": "Eradicable Diseases",
   "offered": [
    "october"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90031",
+  "name": "Analytical Science in Conservation",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90503",
+  "name": "Business Analytics Applications",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90020",
+  "name": "Crime, Culture & the Media",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70392",
+  "name": "International Business Transactions",
+  "offered": [
+   "may",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90153",
+  "name": "Institutional Abuse and Legal Redress",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90299",
+  "name": "Workspace Design Evaluation",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHTY90004",
+  "name": "Exercise for Women",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90130",
+  "name": "Tax Administration",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90483",
+  "name": "General Management 2",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70205",
+  "name": "Project Finance",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70197",
+  "name": "Labour Standards and their Enforcement",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90279",
+  "name": "Organisational Change",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70239",
+  "name": "Payment Matters in Construction Projects",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLRS90013",
+  "name": "Responsibilities in Clinical Research",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG90006",
+  "name": "Powerful Encounters",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90502",
+  "name": "Analytics Lab",
+  "offered": [
+   "august",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90278",
+  "name": "Supply Chain Strategy",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90941",
+  "name": "Leading the Educational Organisation",
+  "offered": [
+   "may",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90244",
+  "name": "Global Health and Human Rights",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70350",
+  "name": "Management for Professionals",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70362",
+  "name": "Information Technology Contracting Law",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70181",
+  "name": "Defamation Law",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90276",
+  "name": "Logistics and Transportation Management",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90008",
+  "name": "Using Evidence",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90279",
+  "name": "Supply Chain Technologies",
+  "offered": [
+   "february",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90299",
+  "name": "Workspace Design Evaluation",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHTY90004",
+  "name": "Exercise for Women",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70197",
+  "name": "Labour Standards and their Enforcement",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90130",
+  "name": "Tax Administration",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70205",
+  "name": "Project Finance",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90279",
+  "name": "Organisational Change",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90483",
+  "name": "General Management 2",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLRS90013",
+  "name": "Responsibilities in Clinical Research",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70239",
+  "name": "Payment Matters in Construction Projects",
+  "offered": [
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG90006",
+  "name": "Powerful Encounters",
+  "offered": [
+   "october"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_semester_1.json
+++ b/subject-utils/subject-lists/subjects_2021_semester_1.json
@@ -1,78 +1,437 @@
 [
  {
-  "code": "ABPL10004",
-  "name": "Global Foundations of Design",
+  "code": "FLTV20019",
+  "name": "Writing Animation 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV30021",
+  "name": "Collaborative Production",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10014",
+  "name": "Pictures, Sounds, Words",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV30023",
+  "name": "Animation Studio 3A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10012",
+  "name": "Screenwriting Practices 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV20014",
+  "name": "Animation Research 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90245",
+  "name": "Orchestra Audition Preparation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90026",
+  "name": "Minor Thesis 4",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL10005",
-  "name": "Understanding the Built Environment",
+  "code": "MGMT90141",
+  "name": "Business Analysis & Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40083",
+  "name": "Research Methods",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL20033",
-  "name": "Construction Analysis",
+  "code": "HIST90024",
+  "name": "International History",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20080",
+  "name": "Early Voices 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90001",
+  "name": "Researching/Writing Stories",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL20035",
-  "name": "Cities: From Local to Global",
+  "code": "ABPL90295",
+  "name": "Construction Regulations and Control",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL20036",
-  "name": "Environmental Building Systems",
+  "code": "GEOG90018",
+  "name": "Contemporary Geographical Thought",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90014",
+  "name": "Epidemiology 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90193",
+  "name": "Studio Teaching 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL20042",
-  "name": "Construction of Residential Buildings",
+  "code": "LING90003",
+  "name": "Research in Applied Linguistics",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL30037",
-  "name": "Architecture Design Studio: Fire",
+  "code": "MEDI40006",
+  "name": "Biomedical Advanced Coursework",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90234",
+  "name": "Core Skills in Opera 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90106",
+  "name": "Information Systems Maj Res Project Pt 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL30041",
-  "name": "Construction Design",
+  "code": "COMP90069",
+  "name": "Computer Science Research Project Pt3",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL30042",
-  "name": "Landscape Studio: Urban Open Space",
+  "code": "MUSI30193",
+  "name": "Piano Duo and Duet 1",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL30046",
-  "name": "Steel and Concrete Structural Systems",
+  "code": "POPH90289",
+  "name": "Biostatistics Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "IBUS90001",
+  "name": "Global Strategy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90131",
+  "name": "Veterinary Parasitology A",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90018",
+  "name": "Journalism Project (Extended) Part 2",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50039",
+  "name": "Legal Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90314",
+  "name": "Property Agency and Marketing (PG)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90002",
+  "name": "Research for Hearing and Speech Sciences",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI40005",
+  "name": "Research Project - SVHM Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90058",
+  "name": "Signal Processing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHRM90002",
+  "name": "Pharmacology for Health Professionals",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90009",
+  "name": "Physical Cosmology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90002",
+  "name": "Editorial English",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90103",
+  "name": "Prehabilitation and Risk Assessment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30250",
+  "name": "Practical Music 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90031",
+  "name": "Advanced Linguistics Analysis A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90030",
+  "name": "Criminology & Sociology Internship Pt 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90038",
+  "name": "IS Strategy and Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90038",
+  "name": "Engineering Hydrology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90050",
+  "name": "Doppler Echocardiography",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90869",
+  "name": "Doctor of Education Thesis Proposal",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90026",
+  "name": "Engineering Entrepreneurship",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90032",
+  "name": "Music Therapy Methods 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90020",
+  "name": "Management Accounting Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90004",
+  "name": "Business and Professional Communications",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90146",
+  "name": "Strategic Management",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90007",
+  "name": "Environmental Research Project (25)",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90111",
+  "name": "Well-being in Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90026",
+  "name": "Marketing Metrics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "ABPL30048",
@@ -80,495 +439,49 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL30050",
-  "name": "Modern Architecture: MoMo to PoMo",
+  "code": "POLS90042",
+  "name": "Latin America in the World",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL30051",
-  "name": "Urban Morphological Mapping",
+  "code": "BUSA90518",
+  "name": "Innovation and Enterprise Internship",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL30053",
-  "name": "Formative Ideas in Architecture",
+  "code": "PHIL90007",
+  "name": "Literature Review",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL30055",
-  "name": "Construction Management",
+  "code": "ECON90016",
+  "name": "Environmental Economics and Strategy",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL30059",
-  "name": "Property Case Studies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL30067",
-  "name": "Design Workshop",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL30068",
-  "name": "Design Internship",
+  "code": "MUSI40064",
+  "name": "The Research Process for Musicians",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "ABPL90010",
-  "name": "Advanced Construction Technology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90016",
-  "name": "Asset Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90017",
-  "name": "Urban Design Theory",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90020",
-  "name": "Measured Drawings & Digital Heritage",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90026",
-  "name": "Property Development",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90028",
-  "name": "Project Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90034",
-  "name": "Property Securitisation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90035",
-  "name": "Risk in Construction",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90041",
-  "name": "Property Law (PG)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90056",
-  "name": "Urban Transport Politics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90061",
-  "name": "Urban Design Studio A",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90065",
-  "name": "Managing Global City Regions",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90066",
-  "name": "MSD Research Project Short (12.5 Points)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90067",
-  "name": "MSD Thesis -Semester Long (25 Points)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90072",
-  "name": "Landscape Studio 5:Sustainable Urbanism",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90077",
-  "name": "Introduction to Transport and Land Use",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90078",
-  "name": "Contemporary Landscape Theory",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90086",
-  "name": "Environmental Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90089",
-  "name": "Australian Architecture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90107",
-  "name": "Landscape Studio 1: Design Techniques",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90118",
-  "name": "Applied Architectural Technology",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90123",
-  "name": "Advanced Computational Design",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90129",
-  "name": "Advanced Cost Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90130",
-  "name": "Planning Law & Statutory Planning",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90134",
-  "name": "Planning Theory and History",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90135",
-  "name": "Analytical Methods",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90140",
-  "name": "Architectural Practice",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90147",
-  "name": "Design Futures",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90149",
-  "name": "Contemporary Digital Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90167",
-  "name": "Design Communications Workshop (P/G)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90172",
-  "name": "Landscape Studio 3 Speculations",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90222",
-  "name": "Ex_Lab: Timber Furniture",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90236",
-  "name": "Design Approaches and Methods (PG)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90246",
-  "name": "The Economies of Cities and Regions",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90263",
-  "name": "Constructed Ecologies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90271",
-  "name": "Shaping the Landscape",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90273",
-  "name": "Urban Design Studio B",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90274",
-  "name": "Property Markets and Valuations",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90284",
-  "name": "Master of Architecture Studio A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90286",
-  "name": "Construction Methods A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90288",
-  "name": "Architectural Cultures 1: Modernism",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90292",
-  "name": "Construction of Buildings",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90295",
-  "name": "Construction Regulations and Control",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90306",
-  "name": "MUP Independent Study",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90307",
-  "name": "MSD Vocational Placement",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "may",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90309",
-  "name": "Supply Chains in Construction",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90313",
-  "name": "Management of Construction",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90314",
-  "name": "Property Agency and Marketing (PG)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90324",
-  "name": "Materials and Structures",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90334",
-  "name": "Means and Methods in Construction",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90339",
-  "name": "International Real Estate Economics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90341",
-  "name": "Urban Environmental Policy and Planning",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90359",
-  "name": "Research Practicum in Construction",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90360",
-  "name": "MUCH Heritage Industry Internship",
-  "offered": [
-   "january",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90361",
-  "name": "ExLaB: Experimental Furniture Futures",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90362",
-  "name": "Research Thesis - Property",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90363",
-  "name": "Property Research and Analysis",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90368",
-  "name": "Architecture and Media",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90369",
-  "name": "Architecture as Spectacle",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90370",
-  "name": "Design Management",
-  "offered": [
-   "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "ABPL90375",
@@ -576,701 +489,16 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL90376",
-  "name": "Urban Design Thesis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90382",
-  "name": "Urban and Cultural Heritage Minor Thesis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90384",
-  "name": "MUP Studio",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90389",
-  "name": "Urban Design Studio C",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90390",
-  "name": "Architectural Engineering Thesis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90396",
-  "name": "MSD Minor Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90397",
-  "name": "MSD Minor Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90403",
-  "name": "Visions and Agendas in Architecture",
+  "code": "FLTV90011",
+  "name": "Graphics for Stage and Screen",
   "offered": [
    "semester_1"
-  ]
- },
- {
-  "code": "ABPL90405",
-  "name": "Energy & Carbon in the Built Environment",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90409",
-  "name": "Realising The Knowledge Economy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90413",
-  "name": "Construction Cost Planning",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90414",
-  "name": "Lean Construction",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90417",
-  "name": "Environment Behavior Methods for Design",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90420",
-  "name": "Interactive Architecture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90421",
-  "name": "Design - Philosophy - Architecture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ABPL90422",
-  "name": "SI-Lab: Scanning and Virtual Reality",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90424",
-  "name": "Introduction to High-Performance Design",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90425",
-  "name": "Informal Settlement",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACCT10001",
-  "name": "Accounting Reports and Analysis",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT10002",
-  "name": "Introductory Financial Accounting",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT20001",
-  "name": "Cost Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT20002",
-  "name": "Intermediate Financial Accounting",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT20007",
-  "name": "Accounting Information: Risks & Controls",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT30001",
-  "name": "Financial Accounting Theory",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT30002",
-  "name": "Enterprise Performance Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT30004",
-  "name": "Auditing and Assurance Services",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT40001",
-  "name": "Research in Financial Accounting",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACCT40002",
-  "name": "Research in Management Accounting",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACCT40008",
-  "name": "Honours Research Essay Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACCT90002",
-  "name": "Financial Statement Analysis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90004",
-  "name": "Accounting for Decision Making",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90009",
-  "name": "Strategic Cost Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90010",
-  "name": "Strategic Performance Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90012",
-  "name": "Corporate Reporting",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90013",
-  "name": "Theory of Financial Accounting",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90014",
-  "name": "Auditing and Assurance Services",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90015",
-  "name": "Legal Issues for Business",
-  "offered": [
-   "semester_1",
-   "june",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90016",
-  "name": "Taxation for Business Decision Making",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90019",
-  "name": "Financial Accounting Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACCT90020",
-  "name": "Management Accounting Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACCT90030",
-  "name": "Information Processes & Control",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90033",
-  "name": "Integrated Accounting Studies",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90041",
-  "name": "Fundamentals in Accounting",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90042",
-  "name": "Accounting and Finance for Actuaries",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL20001",
-  "name": "Introductory Financial Mathematics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL30001",
-  "name": "Actuarial Modelling I",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL30002",
-  "name": "Actuarial Modelling II",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL30007",
-  "name": "Actuarial Modelling III",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL30008",
-  "name": "Actuarial Analytics and Data I",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL40001",
-  "name": "Actuarial Studies Research Essay",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACTL40002",
-  "name": "Risk Theory I",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL40004",
-  "name": "Advanced Financial Mathematics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL40006",
-  "name": "Actuarial Practice and Control I",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL40010",
-  "name": "Actuarial Studies Projects Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL90001",
-  "name": "Mathematics of Finance I",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL90003",
-  "name": "Mathematics of Finance III",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL90004",
-  "name": "Insurance Risk Models",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL90006",
-  "name": "Life Insurance Models I",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL90008",
-  "name": "Statistical Techniques in Insurance",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACTL90010",
-  "name": "Actuarial Practice And Control I",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL90013",
-  "name": "Actuarial Studies Projects",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACTL90016",
-  "name": "Actuarial Science Research Report Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACTL90017",
-  "name": "Actuarial Science Research Report Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACTL90018",
-  "name": "General Insurance Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL90020",
-  "name": "General Insurance Modelling",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL90022",
-  "name": "Economics for Actuaries",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACTL90023",
-  "name": "Data Analytics in Insurance 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACUR90002",
-  "name": "Art Museums and Curatorship",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACUR90007",
-  "name": "Collection Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ACUR90009",
-  "name": "Art Curatorship Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACUR90010",
-  "name": "Art Curatorship Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI10045",
-  "name": "Foundations of Agricultural Sciences 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI10047",
-  "name": "Agriculture in Australia",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI10050",
-  "name": "Agricultural Systems Biology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI20026",
-  "name": "Plant Growth Processes",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI20042",
-  "name": "Agricultural Economics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI20043",
-  "name": "Biochemistry in Agricultural Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI20044",
-  "name": "Microbiology in Agriculture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI30022",
-  "name": "Special Studies",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI30030",
-  "name": "Livestock Production Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI30033",
-  "name": "Farm Management Economics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI30037",
-  "name": "Soil Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI30042",
-  "name": "Plant Pathology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI40017",
-  "name": "Agric.Science Research Project Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI90066",
-  "name": "Soil Science and Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI90070",
-  "name": "Minor Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI90072",
-  "name": "Major Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI90075",
-  "name": "Research Methods For Life Sciences",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AGRI90078",
-  "name": "Internship for Agricultural Sciences",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI90079",
-  "name": "Minor Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI90080",
-  "name": "Major Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI90081",
-  "name": "Minor Research Project Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "AGRI90082",
@@ -1278,737 +506,474 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AGRI90083",
-  "name": "Internship for Agricultural Sciences Pt1",
+  "code": "FREN90003",
+  "name": "Graduate French A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG40003",
+  "name": "Advancing Geography & Environmental Stud",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90081",
+  "name": "Minor Research Project Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AGRI90084",
-  "name": "Internship for Agricultural Sciences Pt2",
+  "code": "ECON90075",
+  "name": "Economic Analysis and Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90041",
+  "name": "Casework/Research Report 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90082",
+  "name": "Applied Risk Management",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AGRI90086",
-  "name": "Communicating Agricultural Sciences",
+  "code": "MUSI20177",
+  "name": "Contextual Studies 3",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AGRI90091",
-  "name": "Advanced Plant Breeding and Improvement",
+  "code": "MUSI20160",
+  "name": "Applied Aural Musicianship 3",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AGRI90092",
-  "name": "Agricultural Advisory Practice & Theory",
+  "code": "HLTH90019",
+  "name": "Indigenous Health and Nursing",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AHIS10001",
-  "name": "Art History: Theory and Controversy",
+  "code": "FINA10025",
+  "name": "Studio Studies 1",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AHIS20011",
-  "name": "European Renaissance Art",
+  "code": "COMP30013",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90018",
+  "name": "The Eye and Vision: A Window to Disease",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AHIS20016",
-  "name": "Art and Revolution",
+  "code": "AGRI20044",
+  "name": "Microbiology in Agriculture",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AHIS20021",
-  "name": "Arts of East Asia",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AHIS30003",
-  "name": "European Art & Absolute Power 1660-1815",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AHIS30005",
-  "name": "Contemporary Aboriginal Art",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AHIS30020",
-  "name": "Contemporary Art",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AHIS40008",
-  "name": "Twentieth-Century Italian Art: 1909-1969",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AHIS40023",
-  "name": "Art History Thesis Part 1",
+  "code": "MUSI90229",
+  "name": "Orchestral Performance Practicum 3",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AHIS40024",
-  "name": "Art History Thesis Part 2",
+  "code": "ABPL90271",
+  "name": "Shaping the Landscape",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90047",
+  "name": "IE Research Project 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AHIS90005",
-  "name": "History and Philosophy of Museums",
+  "code": "LAWS50119",
+  "name": "Sports Law",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AHIS90007",
-  "name": "Biennales, Triennales and Documentas",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AIND10004",
-  "name": "Art and Indigenous Voice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AMGT90001",
-  "name": "Principles of Arts Management",
+  "code": "EDUC90930",
+  "name": "Local Literacies in Global Contexts",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AMGT90004",
-  "name": "States, Governments and the Arts",
+  "code": "GERM90003",
+  "name": "Graduate German A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90013",
+  "name": "Case Studies in Finance",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AMGT90007",
-  "name": "Advanced Arts Management",
+  "code": "CRIM40003",
+  "name": "Drugs and Justice",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AMGT90013",
-  "name": "Finance and Budgeting",
+  "code": "FLTV10006",
+  "name": "Screen Practice 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90074",
+  "name": "Introduction to Power Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL40016",
+  "name": "Italian Thesis Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AMGT90017",
-  "name": "Communicating the Arts",
+  "code": "ELEN90069",
+  "name": "Electrical Power Systems",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AMGT90027",
-  "name": "Arts Management Thesis Part 1",
+  "code": "MULT10018",
+  "name": "Power",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90236",
+  "name": "EMA Special Project (Year Long) Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "AMGT90028",
-  "name": "Arts Management Thesis Part 2",
+  "code": "PSYC90027",
+  "name": "Clinical Psychology in Medical Settings",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS90002",
+  "name": "Design Projects 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90045",
+  "name": "Aerospace Dynamics and Control",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90030",
+  "name": "Nuclear Weapons and Disarmament",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND40007",
+  "name": "Gender Studies Thesis Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ANAT20006",
-  "name": "Principles of Human Structure",
+  "code": "GEOM90038",
+  "name": "Advanced Imaging",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90019",
+  "name": "Financial Accounting Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20175",
+  "name": "Individual Performance Studies 3",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ANAT30007",
-  "name": "Human Locomotor Systems",
+  "code": "MAST90109",
+  "name": "Data Science Research Project Pt2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90018",
+  "name": "Making Sense of Crime and Justice",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ANAT40001",
-  "name": "Anatomy & Neurosci Research Proj Part 1",
+  "code": "FINA30025",
+  "name": "Studio Options",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90006",
+  "name": "Solid Wastes to Sustainable Resources",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30213",
+  "name": "Composition 3",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ANAT40002",
-  "name": "Seminars in Anatomy and Neuroscience",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANAT40005",
-  "name": "Anatomy & Neurosci Research Proj Part 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANAT90004",
-  "name": "Anatomy and Physiology for Audiology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANAT90011",
-  "name": "Anatomy and Physiology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANAT90012",
-  "name": "Project in Anatomy",
+  "code": "FNCE90064",
+  "name": "Emerging Markets Finance",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ANAT90013",
-  "name": "Project in Anatomy",
+  "code": "EDUC90868",
+  "name": "Advanced Methodology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90287",
+  "name": "Professional Practice - Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "ANAT90014",
-  "name": "Project in Anatomy",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ANAT90015",
-  "name": "Project in Anatomy",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ANAT90016",
-  "name": "Anatomy and Physiology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANCW10001",
-  "name": "Ancient Egypt and Mesopotamia",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANCW10006",
-  "name": "Ancient Egyptian 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANCW20015",
-  "name": "Classical Mythology",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "ANCW20019",
-  "name": "The Rise and Fall of the Roman Republic",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANCW20023",
-  "name": "Ancient Egyptian 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANCW20025",
-  "name": "Archaeology of the Roman World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANCW30016",
-  "name": "The Age of Alexander the Great",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANCW30017",
-  "name": "Interpreting the Ancient World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANCW40012",
-  "name": "The Roman Way of Life",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANCW40014",
-  "name": "Research in Ancient World Studies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANCW40016",
-  "name": "Ancient World Studies Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ANCW40017",
-  "name": "Ancient World Studies Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ANCW40019",
-  "name": "Frontiers of the Greek World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANSC20001",
-  "name": "Animal Physiology and Growth",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANSC20005",
-  "name": "Companion Animal Biology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANSC30001",
-  "name": "Animal Disease Biotechnology 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANSC30003",
-  "name": "Applied Animal Behaviour",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANSC30004",
-  "name": "Applied Animal Reproduction & Genetics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANSC30006",
-  "name": "Production Animal Health",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANSC40001",
-  "name": "Animal Sci & Mgt Research Project Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANSC90001",
-  "name": "Wildlife Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANTH20001",
-  "name": "Keeping the Body in Mind",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANTH20007",
-  "name": "Working with Value",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANTH20011",
-  "name": "Ethnic Nationalism and the Modern World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANTH30003",
-  "name": "Lived Religion in an Uncertain World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANTH30005",
-  "name": "Power, Ideology and Inequality",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANTH30009",
-  "name": "Anthropology of More-Than-Human Worlds",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANTH40001",
-  "name": "Philosophy and Scope of Anthropology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ANTH40009",
-  "name": "Anthropology Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ANTH40010",
-  "name": "Anthropology Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARBC10001",
-  "name": "Arabic 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC10003",
-  "name": "Arabic 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC10005",
-  "name": "Arabic 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC20001",
-  "name": "Arabic in Context 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC20002",
-  "name": "Arabic 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC20004",
-  "name": "Arabic 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC20006",
-  "name": "Arabic 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC30002",
-  "name": "Arabic 9",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC30004",
-  "name": "Arabic 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC30006",
-  "name": "Arabic 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC40001",
-  "name": "Honours Arabic A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARBC40007",
-  "name": "Arabic Studies Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARBC40008",
-  "name": "Arabic Studies Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARBC90003",
-  "name": "Graduate Arabic A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARCH10001",
-  "name": "Foundations of Design: Representation",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARCH10002",
-  "name": "Construction as Alchemy",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARCH10003",
-  "name": "Design Studio Alpha",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARCH20001",
-  "name": "Design Studio Beta",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARCH20002",
-  "name": "Design Studio Gamma",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARCH20003",
-  "name": "Modern Architecture: MoMo to PoMo",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARCH20004",
-  "name": "Digital Design",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARCH30001",
-  "name": "Design Studio Delta",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARCH30002",
-  "name": "Design Studio Epsilon",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARTS30002",
-  "name": "Introduction to Language Translation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARTS90008",
-  "name": "Researching the Past",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARTS90009",
-  "name": "Researching Texts",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARTS90010",
-  "name": "Researching Society and Culture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARTS90011",
-  "name": "Researching Images",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARTS90012",
-  "name": "Researching Ideas",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARTS90013",
-  "name": "Researching Media and Culture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ARTS90014",
-  "name": "Researching Politics and Policy",
-  "offered": [
-   "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "ARTS90015",
   "name": "Researching Language",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ARTS90024",
-  "name": "Industry Core and Placement",
+  "code": "MECM40018",
+  "name": "Media & Communications Thesis Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90005",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM40016",
+  "name": "German Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND40008",
+  "name": "Queer Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN40017",
+  "name": "Screen & Cultural Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40027",
+  "name": "English & Theatre Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90011",
+  "name": "Researching Images",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90239",
+  "name": "Professional Practice - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90046",
+  "name": "Treasury Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90012",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90021",
+  "name": "Conservation and Cultural Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
  },
  {
   "code": "ARTS90026",
@@ -2017,307 +982,343 @@
    "semester_1",
    "winter_term",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ARTS90027",
-  "name": "Interdisciplinary Industry Project 2",
-  "offered": [
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "ASIA10001",
-  "name": "Language and Power in Asian Societies",
+  "code": "CRIM40005",
+  "name": "Punishment and Detention: New Challenges",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ASIA20001",
-  "name": "Media and Urban Culture in Asia",
+  "code": "MEDI40002",
+  "name": "Advanced Studies in Biomedicine",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ASIA20003",
-  "name": "Genders and Desires in Asia",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ASIA30004",
-  "name": "Corruption in Asia",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ASIA40004",
-  "name": "Asian Studies Thesis Part 1",
+  "code": "MECM90030",
+  "name": "Media and Communications Thesis Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ASIA40005",
-  "name": "Asian Studies Thesis Part 2",
+  "code": "POPH90284",
+  "name": "Research Project in Public Health Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ASIA90004",
-  "name": "Critical Asian Perspectives",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ASIA90012",
-  "name": "International Relations Thesis Part 1",
+  "code": "MUSI30225",
+  "name": "Ensemble Studies 5",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ASIA90013",
-  "name": "International Relations Thesis Part 2",
+  "code": "AGRI90070",
+  "name": "Minor Research Project",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ASIA90017",
-  "name": "Contemporary China",
+  "code": "ELEN90059",
+  "name": "Lightwave Systems",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ASIA90018",
-  "name": "Indonesia Rising?",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ATOC20001",
-  "name": "Weather and Climate Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ATOC30004",
-  "name": "Dynamical Meteorology and Oceanography",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ATOC30008",
-  "name": "Atmospheric Processes and Composition",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ATOC90002",
-  "name": "Climate Science for Decision-Making",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ATOC90010",
-  "name": "Statistics in Climate Dynamics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ATOC90013",
-  "name": "Atmospheric Modelling",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ATOC90017",
-  "name": "Advanced Past Climates",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90001",
-  "name": "Electrophysiological Assessment B",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90002",
-  "name": "Research for Hearing and Speech Sciences",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90016",
-  "name": "Pathologies of the Auditory System",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90025",
-  "name": "Communication Across the Lifespan",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90027",
-  "name": "Clinical Processes A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90034",
-  "name": "Planning and Integrating Intervention",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90035",
-  "name": "Speech and Language Disorders - Advanced",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90036",
-  "name": "Disorders of Fluency",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90048",
-  "name": "Principles of Clinical Audiology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90049",
-  "name": "Principles of Hearing Rehabilitation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90050",
-  "name": "Acoustics and Perception of Speech",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "AUDI90051",
-  "name": "Principles of Paediatric Audiology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BCMB20002",
-  "name": "Biochemistry and Molecular Biology",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "BCMB20005",
-  "name": "Techniques in Molecular Science",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "BCMB30002",
-  "name": "Functional Genomics and Bioinformatics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BCMB30003",
-  "name": "Molecular Aspects of Cell Biology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BCMB30010",
-  "name": "Advanced Techniques in Molecular Science",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "BCMB30011",
-  "name": "Cellular Metabolism and Disease",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BCMB30012",
-  "name": "Current Advances in Molecular Science",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "BCMB40009",
-  "name": "Biochemistry Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "BCMB40012",
-  "name": "Biochemistry Research Project Part 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BIEN90001",
-  "name": "Biochemical Engineering Research Project",
+  "code": "GEOM90031",
+  "name": "Spatial Information Research Project D",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40012",
+  "name": "GradDip Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90071",
+  "name": "DRFS Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90029",
+  "name": "Adv Clinical Practice in Specialty 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90070",
+  "name": "Clinical Sexual & Reproductive Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50025",
+  "name": "Torts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40013",
+  "name": "GradDip Composition 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90414",
+  "name": "Lean Construction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90044",
+  "name": "Thinking and Reasoning with Data",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90013",
+  "name": "Econometrics 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90118",
+  "name": "Applied Architectural Technology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90224",
+  "name": "Orchestral Experience 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10027",
+  "name": "Everyday Morality",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20026",
+  "name": "Minor Music Performance 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91030",
+  "name": "Research in Educational Relationships",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL40001",
+  "name": "Italian Honours Language Seminar 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90015",
+  "name": "Principles of Specialty 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90037",
+  "name": "MFPI Internship Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90039",
+  "name": "Executive Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90020",
+  "name": "Distributed Algorithms",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90043",
+  "name": "Gastrointestinal Tract Pancreas Adrenals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40017",
+  "name": "Practical Study 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10052",
+  "name": "Brass Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT40007",
+  "name": "Special Research Topics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90368",
+  "name": "Architecture and Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90015",
+  "name": "Journalism Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40011",
+  "name": "Writing for the Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90048",
+  "name": "Project Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40004",
+  "name": "Value Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90079",
+  "name": "Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90016",
+  "name": "Engineering Management Capstone",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90043",
+  "name": "Enterprise Applications & Architectures",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "BIEN90003",
@@ -2326,165 +1327,736 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BINF90001",
-  "name": "Statistics for Bioinformatics",
+  "code": "MUSI30253",
+  "name": "Performance 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90225",
+  "name": "Music Outreach & Social Entrepreneurship",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BINF90002",
-  "name": "Elements of Bioinformatics",
+  "code": "GENP90017",
+  "name": "Immunisation and Travel Health",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90025",
+  "name": "Minor Thesis 3",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOL10002",
-  "name": "Biomolecules and Cells",
+  "code": "EDUC90948",
+  "name": "Mathematics: Improving Learning",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOL10006",
-  "name": "Systems Biology",
+  "code": "COMP90066",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90224",
+  "name": "Orchestral Experience 3",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOL10008",
-  "name": "Introductory Biology: Life's Machinery",
+  "code": "UNIB10027",
+  "name": "Everyday Morality",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20026",
+  "name": "Minor Music Performance 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90042",
+  "name": "Liver, Spleen and Sampling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EVSC90020",
+  "name": "Environmental Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE10003",
+  "name": "Science: Supporting Health and Wellbeing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90389",
+  "name": "Urban Design Studio C",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91030",
+  "name": "Research in Educational Relationships",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL40001",
+  "name": "Italian Honours Language Seminar 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90064",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90063",
+  "name": "Introduction to Quantum Computing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ATOC90010",
+  "name": "Statistics in Climate Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90015",
+  "name": "Principles of Specialty 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ZOOL90007",
+  "name": "Graduate Seminar in Ecology & Evolution",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90339",
+  "name": "International Real Estate Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL90039",
+  "name": "Applied Ethics Thesis Part 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC40001",
+  "name": "Honours Arabic A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10024",
+  "name": "Making Micro Movies - Filming the Real",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90039",
+  "name": "Executive Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90020",
+  "name": "Distributed Algorithms",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "RADI90019",
+  "name": "Diagnostic Radiology 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90025",
+  "name": "Consecutive Interpreting",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MREN90001",
+  "name": "Polymers and Composites",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90004",
+  "name": "Accounting for Decision Making",
   "offered": [
    "summer_term",
-   "semester_1"
-  ]
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
-  "code": "BIOL10009",
-  "name": "Biology: Life's Machinery",
+  "code": "MUSI20013",
+  "name": "Chamber Music 1",
   "offered": [
-   "semester_1"
-  ]
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
-  "code": "BIOL20001",
-  "name": "Evolution: Making Sense Of Life",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BIOL40010",
-  "name": "Research Project - RMH Part 1",
+  "code": "ABPL90324",
+  "name": "Materials and Structures",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOL40011",
-  "name": "Research Project - RMH Part 2",
+  "code": "ENGR90031",
+  "name": "Energy Systems Project",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOL40013",
-  "name": "Research Project - RMH Part 2",
+  "code": "FOOD90037",
+  "name": "MFPI Internship Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90105",
+  "name": "Methods of Mathematical Statistics",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOL90001",
-  "name": "Microscopy for Biological Sciences",
+  "code": "DENT90016",
+  "name": "Principles of Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90029",
+  "name": "Differential Topology and Geometry",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOM10001",
-  "name": "Discovering Biomedicine",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "BIOM20001",
-  "name": "Molecular and Cellular Biomedicine",
+  "code": "JOUR90021",
+  "name": "International Traditions in Journalism",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOM30002",
-  "name": "Biomedicine: Molecule to Malady",
+  "code": "PHYC90022",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30167",
+  "name": "Brass Ensemble 1",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOM30003",
-  "name": "Biomedical Science Research Project",
+  "code": "UNIB20024",
+  "name": "Designer Humans - Prospects & Perils",
   "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
+   "semester_1"
+  ],
+  "online": false
  },
  {
-  "code": "BIOM90012",
-  "name": "Research Project (SBS)",
+  "code": "SCIE40001",
+  "name": "Critical Thinking in Research",
   "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+   "semester_1"
+  ],
+  "online": false
  },
  {
-  "code": "BIOM90013",
-  "name": "Research Project (SBS)",
+  "code": "LAWS50078",
+  "name": "Environmental Law",
   "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+   "semester_1"
+  ],
+  "online": false
  },
  {
-  "code": "BIOM90014",
-  "name": "Research Project (SBS)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "BIOM90015",
-  "name": "Research Project (SBS)",
+  "code": "JOUR90003",
+  "name": "Journalism Internship",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOM90016",
-  "name": "Research Project (MMS)",
+  "code": "LING40015",
+  "name": "LAL Thesis Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOM90017",
-  "name": "Research Project (MMS)",
+  "code": "LAWS50030",
+  "name": "Property",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50063",
+  "name": "Competition Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90068",
+  "name": "Applications in Animal Health 2 Part A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM90055",
+  "name": "Chemical Regulations and Safety",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS20010",
+  "name": "Production Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS40020",
+  "name": "Vet Bioscience Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90045",
+  "name": "Spatial Tools for Ecosystem Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC40014",
+  "name": "Advanced Research Methods In Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM40002",
+  "name": "Qualitative Research Methods",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90118",
+  "name": "Clinical Biostatistics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90005",
+  "name": "Hydrogeology/Environmental Geochemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "THTR70009",
+  "name": "Writing for Performance 2 (Collab)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90004",
+  "name": "Public Administration Thesis",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90016",
+  "name": "Journalism Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90030",
+  "name": "Geography Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90059",
+  "name": "Integrated Design - Infrastructure",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90007",
+  "name": "Cognitive-Behaviour Therapy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30042",
+  "name": "Landscape Studio: Urban Open Space",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90075",
+  "name": "Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90035",
+  "name": "Risk in Construction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO40012",
+  "name": "Vision Science Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90031",
+  "name": "Quantitative Environmental Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "THTR40006",
+  "name": "Research Methods (Music Theatre)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90014",
+  "name": "Screen Design Projects A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90135",
+  "name": "Analytical Methods",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90083",
+  "name": "Internship for Agricultural Sciences Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90201",
+  "name": "Entrepreneurial Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90016",
+  "name": "International Financial Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENP60002",
+  "name": "Preventive Health Care",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT40008",
+  "name": "Honours Research Essay Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30019",
+  "name": "Chamber Music 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90049",
+  "name": "Principles of Ultrasound Heart Scan",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90029",
+  "name": "Analysing Energy Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90031",
+  "name": "Energy Systems Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20013",
+  "name": "Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90324",
+  "name": "Materials and Structures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG40004",
+  "name": "Indigenous Studies Thesis Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE90013",
+  "name": "Communication for Research Scientists",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10207",
+  "name": "Medieval and Renaissance Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90016",
+  "name": "Performance & Reward Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO90002",
+  "name": "Graduate Indonesian A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACUR90007",
+  "name": "Collection Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
  },
  {
   "code": "BIOM90018",
@@ -2492,189 +2064,1221 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOM90019",
-  "name": "Research Project (MMS)",
+  "code": "LAWS70015",
+  "name": "Minor Thesis F/T LLM",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOM90020",
-  "name": "Research Project (MDS)",
+  "code": "VETS90082",
+  "name": "Animal Management and Veterinary Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90044",
+  "name": "Vet Public Health Research Project Pt 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOM90021",
-  "name": "Research Project (MDS)",
+  "code": "DENT90023",
+  "name": "Adv Clinical Practice in Specialty 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOM90022",
-  "name": "Research Project (MDS)",
+  "code": "ECON90079",
+  "name": "Advanced Experimental Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90058",
+  "name": "Veterinary Bioscience 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90277",
+  "name": "M.Epidemiology Research Project Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BIOM90023",
-  "name": "Research Project (MDS)",
+  "code": "MUSI10182",
+  "name": "Individual Performance Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90019",
+  "name": "Advanced Heat & Mass Transport Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50094",
+  "name": "International Commercial Law & Disputes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90152",
+  "name": "Second Instrument / Vocal Study 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BLAW10001",
-  "name": "Principles of Business Law",
+  "code": "DNCE40005",
+  "name": "Research Methods (Dance)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90200",
+  "name": "Suzuki Practicum Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BLAW20001",
-  "name": "Corporate Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BLAW30003",
-  "name": "Taxation Law II",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BMEN20003",
-  "name": "Applied Computation in Bioengineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BMEN30005",
-  "name": "Introduction to Biomechanics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BMEN30006",
-  "name": "Circuits and Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BMEN30010",
-  "name": "Mechanics for Bioengineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "BMEN90018",
-  "name": "Biomedical Engineering Capstone Project",
+  "code": "ISYS90045",
+  "name": "Professional IS Consulting",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BMEN90021",
-  "name": "Medical Imaging",
+  "code": "SOCI20017",
+  "name": "Sexualising Society: Sociology of Sex",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BMEN90027",
-  "name": "Systems and Synthetic Biology",
+  "code": "MUSI20223",
+  "name": "Music Performance Science",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BMEN90032",
-  "name": "Biomed Eng Capstone Proj Part 2",
+  "code": "FNCE90062",
+  "name": "Capstone Studies in Finance",
   "offered": [
-   "semester_1"
-  ]
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
-  "code": "BMEN90033",
-  "name": "Bioinstrumentation",
+  "code": "COMP90038",
+  "name": "Algorithms and Complexity",
   "offered": [
-   "semester_1"
-  ]
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
-  "code": "BMEN90037",
-  "name": "Bioengineering Data Analytics",
+  "code": "CHEM10006",
+  "name": "Chemistry for Biomedicine",
   "offered": [
-   "semester_1"
-  ]
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
-  "code": "BMEN90038",
-  "name": "Biomechanics",
+  "code": "LAWS50037",
+  "name": "Evidence and Proof",
   "offered": [
-   "semester_1"
-  ]
+   "semester_1",
+   "june"
+  ],
+  "online": false
  },
  {
-  "code": "BMEN90039",
-  "name": "Biomedical Eng Management & Regulations",
+  "code": "SOCI40008",
+  "name": "Reading Sociology",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90056",
+  "name": "Business and Government",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90015",
+  "name": "Band Direction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10024",
+  "name": "Making Micro Movies - Filming the Real",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL90039",
+  "name": "Applied Ethics Thesis Part 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC40001",
+  "name": "Honours Arabic A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST10016",
+  "name": "Europe: From Black Death to New Worlds",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC30018",
+  "name": "Quantum Physics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ZOOL90007",
+  "name": "Graduate Seminar in Ecology & Evolution",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90339",
+  "name": "International Real Estate Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90014",
+  "name": "Legal Issues in Arts and Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NUTR30002",
+  "name": "Monitoring Food and Nutrition Intake",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA30004",
+  "name": "Corruption in Asia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO20004",
+  "name": "Perception, Illusions and Art",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC30013",
+  "name": "Research Methods for Human Inquiry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM40010",
+  "name": "German Honours Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI30005",
+  "name": "Sociology Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90056",
+  "name": "World Economic History",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP20008",
+  "name": "Elements of Data Processing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90005",
+  "name": "Environmental Management ISO 14000",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90055",
+  "name": "Manufacturing Processes and Technology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30042",
+  "name": "Plant Pathology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30025",
+  "name": "Chinese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90071",
+  "name": "Economics Research Report Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90171",
+  "name": "Leadership in Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE90011",
+  "name": "From Lab to Life",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE90026",
+  "name": "Clinical Genome Variant Analysis 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90020",
+  "name": "General Insurance Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOL30006",
+  "name": "Ecology in Changing Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90424",
+  "name": "Introduction to High-Performance Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90006",
+  "name": "Writing and Editing for Digital Media",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO30002",
+  "name": "Memory & Memoirs of 20th Century Europe",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM10026",
+  "name": "Up Close and Personal with MTC",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10037",
+  "name": "Music in Everyday Life",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN30021",
+  "name": "Exploring Latin America",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE30006",
+  "name": "Entrepreneurial Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90086",
+  "name": "Quality and Safety in Healthcare",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90069",
+  "name": "Clinical Leadership in Context",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90067",
+  "name": "Health Assessment for Advanced Practice1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENP40000",
+  "name": "Primary Care Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30007",
+  "name": "Japanese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "KORE20003",
+  "name": "Korean 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOL30007",
+  "name": "Marine Ecosystems: Ecology & Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG20002",
+  "name": "Landscapes and Environmental Change",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC20006",
+  "name": "Biological Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO20003",
+  "name": "Database Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30032",
+  "name": "Campaigns and Elections",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD30007",
+  "name": "Food Processing & Preservation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30139",
+  "name": "Shakuhachi Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "BOTA20001",
   "name": "Green Planet: Plants and the Environment",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BTCH30002",
-  "name": "Trends & Issues in Agrifood Biotech",
+  "code": "POLS30015",
+  "name": "International Gender Politics",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BTCH30003",
-  "name": "Biotechnology in Practice",
+  "code": "ABPL30053",
+  "name": "Formative Ideas in Architecture",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BTCH90009",
-  "name": "Genomics and Bioinformatics",
+  "code": "MUSI20124",
+  "name": "University Symphonic Ensembles 1",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BTCH90010",
-  "name": "Genetically Modified Organisms",
+  "code": "CCDP20001",
+  "name": "Street Art",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20029",
+  "name": "Critical and Theoretical Studies 3",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS30001",
+  "name": "Russian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30004",
+  "name": "Japanese through the Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW20025",
+  "name": "Archaeology of the Roman World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90226",
+  "name": "Societal Implications of Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20018",
+  "name": "Going Places - Travelling Smarter",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20163",
+  "name": "Samba Band",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS30020",
+  "name": "Contemporary Art",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20073",
+  "name": "Links Between Health and Learning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10002",
+  "name": "Logic: Language and Information",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10173",
+  "name": "Guitar Group 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10008",
+  "name": "German 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH20011",
+  "name": "Ethnic Nationalism and the Modern World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10003",
+  "name": "Chinese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30043",
+  "name": "The Power and Limits of Logic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS10001",
+  "name": "Art History: Theory and Controversy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO10012",
+  "name": "Literature: Reading Indonesian Lives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING20011",
+  "name": "Grammar of English",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN20009",
+  "name": "Transport Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30024",
+  "name": "The Foundations of Interpretation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10003",
+  "name": "Physics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BLAW20001",
+  "name": "Corporate Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10004",
+  "name": "German 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN30001",
+  "name": "French 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYS20009",
+  "name": "Research-Based Physiology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30013",
+  "name": "Economic Analysis and Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN30014",
+  "name": "Spanish 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST30075",
+  "name": "Gender in History, 1800 to the Present",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST30068",
+  "name": "A History of Violence",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30004",
+  "name": "Japanese through the Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90226",
+  "name": "Societal Implications of Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20018",
+  "name": "Going Places - Travelling Smarter",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20163",
+  "name": "Samba Band",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20073",
+  "name": "Links Between Health and Learning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20012",
+  "name": "Arts Internship: Not for Profit",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10002",
+  "name": "Logic: Language and Information",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10173",
+  "name": "Guitar Group 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC20005",
+  "name": "Companion Animal Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS30003",
+  "name": "European Art & Absolute Power 1660-1815",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10003",
+  "name": "Introductory Macroeconomics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30005",
+  "name": "Algebra",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV20005",
+  "name": "Making Movies 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT10002",
+  "name": "Engagements with Place",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20033",
+  "name": "Real Analysis: Advanced",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL30007",
+  "name": "Actuarial Modelling III",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING30014",
+  "name": "Australian Indigenous Languages",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL20042",
+  "name": "Construction of Residential Buildings",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH30002",
+  "name": "Techniques for Investigation of Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20004",
+  "name": "Probability",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN30003",
+  "name": "French 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW20023",
+  "name": "Ancient Egyptian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR90017",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH40005",
+  "name": "Pathology Research Project Part 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MIIM30016",
+  "name": "Techniques in Microbiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30020",
+  "name": "Probability for Inference",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL30001",
+  "name": "Actuarial Modelling I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30011",
+  "name": "Great Chinese Classics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN10007",
+  "name": "Japanese 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20007",
+  "name": "Japanese 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20015",
+  "name": "French 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO10001",
+  "name": "Indonesian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL20011",
+  "name": "Italian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM30002",
+  "name": "German Cultural Studies C",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI20026",
+  "name": "Plant Growth Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC20012",
+  "name": "Quantum and Thermal Physics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI20005",
+  "name": "Creative Non Fiction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30011",
+  "name": "Chinese Politics and Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW20025",
+  "name": "Archaeology of the Roman World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AIND10004",
+  "name": "Art and Indigenous Voice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS30020",
+  "name": "Contemporary Art",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS20011",
+  "name": "European Renaissance Art",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH20007",
+  "name": "Working with Value",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20077",
+  "name": "Printing, Collage and Social Engagement",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
  },
  {
   "code": "BUSA30000",
@@ -2682,14 +3286,1334 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90518",
-  "name": "Innovation and Enterprise Internship",
+  "code": "ITAL10006",
+  "name": "Italian 5",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH30001",
+  "name": "Design Studio Delta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ATOC30008",
+  "name": "Atmospheric Processes and Composition",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC20006",
+  "name": "Arabic 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN30016",
+  "name": "Spanish 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20008",
+  "name": "Australian Indigenous Politics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC30017",
+  "name": "Perception, Memory and Cognition",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20003",
+  "name": "Quantitative Methods 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL10008",
+  "name": "Introductory Biology: Life's Machinery",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN30009",
+  "name": "Electrical Network Analysis and Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL20043",
+  "name": "History of Early Modern Philosophy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT30013",
+  "name": "Managing for Competitive Advantage",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD10001",
+  "name": "Beer Styles and Sensory Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM20002",
+  "name": "Criminal Law and Political Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM20010",
+  "name": "Comparing Media Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20001",
+  "name": "Climate Change ll",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MIIM20001",
+  "name": "Principles of Microbiology & Immunology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30048",
+  "name": "Performance and the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30001",
+  "name": "Geomorphology: Catchment to Coast",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10021",
+  "name": "Interactive Art Media 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GDES30002",
+  "name": "Branding",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENVS10001",
+  "name": "Natural Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20008",
+  "name": "Indonesian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP30024",
+  "name": "Artificial Intelligence",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC20001",
+  "name": "Animal Physiology and Growth",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20122",
+  "name": "Composition Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC30003",
+  "name": "Applied Animal Behaviour",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM30021",
+  "name": "German 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90013",
+  "name": "Finance and Budgeting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90114",
+  "name": "Information Systems Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90028",
+  "name": "Introduction to Energy Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90235",
+  "name": "EMA Special Project (Year Long) Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90129",
+  "name": "Vet Bioscience: Locomotion",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM10033",
+  "name": "Performance Preparation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90137",
+  "name": "Mathematical Game Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV70045",
+  "name": "Business of Screenwriting",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN40007",
+  "name": "Spanish & Latin American Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40018",
+  "name": "Don Juan: Our Contemporary",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90107",
+  "name": "Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM40003",
+  "name": "Macroeconometrics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90072",
+  "name": "Major Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90105",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90064",
+  "name": "Advanced Methods: Differential Equations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV40011",
+  "name": "Research Methods (Screenwriting)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20181",
+  "name": "Interactive Composition 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN40008",
+  "name": "Spanish & Latin American Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90029",
+  "name": "Advanced Solid Mechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "RADI90021",
+  "name": "Diagnostic Radiology 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90131",
+  "name": "Veterinary Parasitology A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90018",
+  "name": "Journalism Project (Extended) Part 2",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50039",
+  "name": "Legal Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90314",
+  "name": "Property Agency and Marketing (PG)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90002",
+  "name": "Research for Hearing and Speech Sciences",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI40005",
+  "name": "Research Project - SVHM Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90058",
+  "name": "Signal Processing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHRM90002",
+  "name": "Pharmacology for Health Professionals",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90009",
+  "name": "Physical Cosmology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90002",
+  "name": "Editorial English",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90103",
+  "name": "Prehabilitation and Risk Assessment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30250",
+  "name": "Practical Music 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90031",
+  "name": "Advanced Linguistics Analysis A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90030",
+  "name": "Criminology & Sociology Internship Pt 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90038",
+  "name": "IS Strategy and Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90197",
+  "name": "Professional Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90046",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90066",
+  "name": "Soil Science and Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW40014",
+  "name": "Research in Ancient World Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90022",
+  "name": "Research Methods",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90024",
+  "name": "Production Collaboration",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90047",
+  "name": "OMS Clinical Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90026",
+  "name": "Extreme Loading of Structures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20201",
+  "name": "Performance 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90397",
+  "name": "MSD Minor Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90018",
+  "name": "Particle Mechanics and Processing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90026",
+  "name": "Introduction to Optimisation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90104",
+  "name": "Chronic Disease Management: Foundations",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90082",
+  "name": "Software Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90078",
+  "name": "Computer Science Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90038",
+  "name": "Engineering Hydrology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90050",
+  "name": "Doppler Echocardiography",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90048",
+  "name": "Second Language Teaching Methodology",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90100",
+  "name": "Recital 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90004",
+  "name": "Business and Professional Communications",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90020",
+  "name": "Management Accounting Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90146",
+  "name": "Strategic Management",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90007",
+  "name": "Environmental Research Project (25)",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90026",
+  "name": "Marketing Metrics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30048",
+  "name": "Architecture Design Studio: Air",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90001",
+  "name": "Principles of Arts Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40067",
+  "name": "Honours Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90009",
+  "name": "Researching Texts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90100",
+  "name": "Abdominal and Peri-Arrest Ultrasound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40095",
+  "name": "The Music of Spain",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30068",
+  "name": "Design Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90010",
+  "name": "Performing Arts Research Methodologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV30011",
+  "name": "Screen Culture and Aesthetics 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90028",
+  "name": "Geography Practical",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90237",
+  "name": "Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30033",
+  "name": "Farm Management Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90020",
+  "name": "Environmental Industry Research (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90022",
+  "name": "Practical Earth Science A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40062",
+  "name": "Honours Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30028",
+  "name": "Studio Studies 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM40003",
+  "name": "Drugs and Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10006",
+  "name": "Screen Practice 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90074",
+  "name": "Introduction to Power Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL40016",
+  "name": "Italian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90069",
+  "name": "Electrical Power Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40017",
+  "name": "Practical Study 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40036",
+  "name": "Conducting",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90064",
+  "name": "Emerging Markets Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90868",
+  "name": "Advanced Methodology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90287",
+  "name": "Professional Practice - Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40018",
+  "name": "Media & Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90005",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40004",
+  "name": "Value Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90079",
+  "name": "Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90016",
+  "name": "Engineering Management Capstone",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90026",
+  "name": "Engineering Entrepreneurship",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90032",
+  "name": "Music Therapy Methods 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90869",
+  "name": "Doctor of Education Thesis Proposal",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90111",
+  "name": "Well-being in Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL90007",
+  "name": "Literature Review",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90016",
+  "name": "Environmental Economics and Strategy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN90003",
+  "name": "Graduate French A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG40003",
+  "name": "Advancing Geography & Environmental Stud",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90081",
+  "name": "Minor Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20177",
+  "name": "Contextual Studies 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90106",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90289",
+  "name": "Biostatistics Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90035",
+  "name": "Advanced Clinical Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90131",
+  "name": "Veterinary Parasitology A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90018",
+  "name": "Journalism Project (Extended) Part 2",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50039",
+  "name": "Legal Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "IBUS90001",
+  "name": "Global Strategy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90314",
+  "name": "Property Agency and Marketing (PG)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90002",
+  "name": "Research for Hearing and Speech Sciences",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI40005",
+  "name": "Research Project - SVHM Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHRM90002",
+  "name": "Pharmacology for Health Professionals",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90058",
+  "name": "Signal Processing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90009",
+  "name": "Physical Cosmology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90031",
+  "name": "Advanced Linguistics Analysis A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90038",
+  "name": "IS Strategy and Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90002",
+  "name": "Editorial English",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90103",
+  "name": "Prehabilitation and Risk Assessment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30250",
+  "name": "Practical Music 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90030",
+  "name": "Criminology & Sociology Internship Pt 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90197",
+  "name": "Professional Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN40008",
+  "name": "Spanish & Latin American Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20181",
+  "name": "Interactive Composition 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV40011",
+  "name": "Research Methods (Screenwriting)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90029",
+  "name": "Advanced Solid Mechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "RADI90021",
+  "name": "Diagnostic Radiology 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90021",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING40002",
+  "name": "Issues in Linguistic Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90021",
+  "name": "Translation, Interpreting, Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "BUSA90520",
@@ -2697,7 +4621,4226 @@
   "offered": [
    "summer_term",
    "semester_1"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90019",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20089",
+  "name": "Guitar Ensemble 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL40001",
+  "name": "Actuarial Studies Research Essay",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90044",
+  "name": "Research Methods",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10076",
+  "name": "Piano Duo and Duet 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90085",
+  "name": "Communicating Current Issues in Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90015",
+  "name": "Special Topics in Adv. Econometrics 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90033",
+  "name": "Quantitative Analysis of Finance I",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90016",
+  "name": "Research Project (MMS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OTOL40002",
+  "name": "Otolaryngology Advanced Coursework",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90039",
+  "name": "Civil Society, NGOs and the State",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90101",
+  "name": "Obstetrics Gynaecology and Practicum",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90105",
+  "name": "Chronic Disease Management: In Practice",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG40002",
+  "name": "Textual Revelations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90001",
+  "name": "Principles of Arts Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30068",
+  "name": "Design Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90009",
+  "name": "Researching Texts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI90018",
+  "name": "Advanced Writing Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90100",
+  "name": "Abdominal and Peri-Arrest Ultrasound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90010",
+  "name": "Performing Arts Research Methodologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40067",
+  "name": "Honours Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40095",
+  "name": "The Music of Spain",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV30011",
+  "name": "Screen Culture and Aesthetics 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90237",
+  "name": "Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90028",
+  "name": "Geography Practical",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30028",
+  "name": "Studio Studies 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30033",
+  "name": "Farm Management Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90020",
+  "name": "Environmental Industry Research (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM40003",
+  "name": "Drugs and Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90022",
+  "name": "Practical Earth Science A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40062",
+  "name": "Honours Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10006",
+  "name": "Screen Practice 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90074",
+  "name": "Introduction to Power Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL40016",
+  "name": "Italian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90069",
+  "name": "Electrical Power Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT10018",
+  "name": "Power",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90027",
+  "name": "Clinical Psychology in Medical Settings",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS90002",
+  "name": "Design Projects 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90236",
+  "name": "EMA Special Project (Year Long) Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND40007",
+  "name": "Gender Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90030",
+  "name": "Nuclear Weapons and Disarmament",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90045",
+  "name": "Aerospace Dynamics and Control",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90038",
+  "name": "Advanced Imaging",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90019",
+  "name": "Financial Accounting Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90109",
+  "name": "Data Science Research Project Pt2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90018",
+  "name": "Making Sense of Crime and Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90006",
+  "name": "Solid Wastes to Sustainable Resources",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20175",
+  "name": "Individual Performance Studies 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30025",
+  "name": "Studio Options",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90056",
+  "name": "Advanced Anatomy and Doppler Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30213",
+  "name": "Composition 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90011",
+  "name": "Economic Analysis for Engineers",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90022",
+  "name": "Collaboration in Action",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "WELF90006",
+  "name": "Fitness to Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90055",
+  "name": "Control Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH40010",
+  "name": "Anthropology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90131",
+  "name": "Internship II",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE90027",
+  "name": "Ecosystem Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90420",
+  "name": "Interactive Architecture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST10013",
+  "name": "Music Theatre Contextual Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90018",
+  "name": "Managing Behaviour in Organisations",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90047",
+  "name": "Macroeconomics 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50063",
+  "name": "Competition Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90068",
+  "name": "Applications in Animal Health 2 Part A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30223",
+  "name": "Contextual Studies 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM90055",
+  "name": "Chemical Regulations and Safety",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS20010",
+  "name": "Production Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90026",
+  "name": "International Political Economy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90118",
+  "name": "Clinical Biostatistics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM40002",
+  "name": "Qualitative Research Methods",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "THTR70006",
+  "name": "Research and New Performance Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS20010",
+  "name": "Production Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS40020",
+  "name": "Vet Bioscience Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90045",
+  "name": "Spatial Tools for Ecosystem Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC40014",
+  "name": "Advanced Research Methods In Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM40002",
+  "name": "Qualitative Research Methods",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90118",
+  "name": "Clinical Biostatistics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90005",
+  "name": "Hydrogeology/Environmental Geochemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "THTR70009",
+  "name": "Writing for Performance 2 (Collab)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM90004",
+  "name": "Public Administration Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90016",
+  "name": "Journalism Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90030",
+  "name": "Geography Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90059",
+  "name": "Integrated Design - Infrastructure",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90007",
+  "name": "Cognitive-Behaviour Therapy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30042",
+  "name": "Landscape Studio: Urban Open Space",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90075",
+  "name": "Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90050",
+  "name": "Geotechnical Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90017",
+  "name": "Marketing the Arts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90043",
+  "name": "Sustainable Infrastructure Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90123",
+  "name": "Animal Production Systems: Extensive",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST10013",
+  "name": "Music Theatre Contextual Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90200",
+  "name": "Suzuki Practicum Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90043",
+  "name": "Sustainable Infrastructure Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90123",
+  "name": "Animal Production Systems: Extensive",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90027",
+  "name": "Future Fuels and Petroleum",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40016",
+  "name": "Creative Writing Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40021",
+  "name": "Philosophy Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90011",
+  "name": "Directed Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN40018",
+  "name": "Screen & Cultural Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50030",
+  "name": "Property",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90194",
+  "name": "Instrumental Pedagogy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING40015",
+  "name": "LAL Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90054",
+  "name": "AI Planning for Autonomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90049",
+  "name": "Structural Theory and Design 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90066",
+  "name": "Infections Population & Pub. Health PtA",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90059",
+  "name": "Integrated Design - Infrastructure",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90030",
+  "name": "Geography Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90075",
+  "name": "Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10182",
+  "name": "Individual Performance Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90152",
+  "name": "Second Instrument / Vocal Study 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI40007",
+  "name": "Sociology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90082",
+  "name": "Animal Management and Veterinary Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90044",
+  "name": "Vet Public Health Research Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90023",
+  "name": "Adv Clinical Practice in Specialty 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90079",
+  "name": "Advanced Experimental Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90058",
+  "name": "Veterinary Bioscience 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90277",
+  "name": "M.Epidemiology Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10182",
+  "name": "Individual Performance Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90019",
+  "name": "Advanced Heat & Mass Transport Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50094",
+  "name": "International Commercial Law & Disputes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90152",
+  "name": "Second Instrument / Vocal Study 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE40005",
+  "name": "Research Methods (Dance)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90200",
+  "name": "Suzuki Practicum Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90045",
+  "name": "Professional IS Consulting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI20017",
+  "name": "Sexualising Society: Sociology of Sex",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20223",
+  "name": "Music Performance Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90041",
+  "name": "Applications of Music in Therapy A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90153",
+  "name": "Professional Practice 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90044",
+  "name": "Objectivist Research in Music Therapy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20088",
+  "name": "MCM Indonesian Gamelan Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST30002",
+  "name": "Land And Environment Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC20013",
+  "name": "Laboratory and Computational Physics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NUTR30005",
+  "name": "Molecular Nutrition and Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI40007",
+  "name": "Sociology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90013",
+  "name": "Strategy Execution for Engineers",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90038",
+  "name": "Engineering Capstone Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90035",
+  "name": "Victims and Criminal Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40020",
+  "name": "Reading and Writing Philosophy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90892",
+  "name": "Clinical Teaching Practice (EC) 1",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "CCDP10003",
+  "name": "Video Games: Remaking Reality",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH40001",
+  "name": "Pathology Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90025",
+  "name": "Journalism Project Part 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN20006",
+  "name": "Digital Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENP40002",
+  "name": "Introduction to Primary Care Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS30030",
+  "name": "Introduction to Professional Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS20019",
+  "name": "Frontiers in Veterinary Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM30018",
+  "name": "Diplomacy: Engaging the Muslim World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30019",
+  "name": "Sustainable Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST30074",
+  "name": "Global Histories of Indigenous Activism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH40006",
+  "name": "Clinical Path Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90030",
+  "name": "Information Processes & Control",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90037",
+  "name": "Bioengineering Data Analytics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90055",
+  "name": "Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE30027",
+  "name": "Inter-disciplinary Project",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC30006",
+  "name": "Production Animal Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50055",
+  "name": "Advocacy",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN30010",
+  "name": "Mechanics for Bioengineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC30001",
+  "name": "Animal Disease Biotechnology 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30037",
+  "name": "Soil Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20031",
+  "name": "Analysis of Biological Data",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYS30009",
+  "name": "Experimental Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90007",
+  "name": "Project Management Practices",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30027",
+  "name": "Chinese 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90086",
+  "name": "Quality and Safety in Healthcare",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90069",
+  "name": "Clinical Leadership in Context",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90067",
+  "name": "Health Assessment for Advanced Practice1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENP40000",
+  "name": "Primary Care Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90018",
+  "name": "Corporate Financial Policy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE90005",
+  "name": "Ethics and Responsibility in Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SKIL90004",
+  "name": "Project Management in Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "KORE20003",
+  "name": "Korean 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30007",
+  "name": "Japanese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOL30007",
+  "name": "Marine Ecosystems: Ecology & Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD10001",
+  "name": "Beer Styles and Sensory Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM20010",
+  "name": "Comparing Media Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GDES20001",
+  "name": "Graphic Design Studio 2: Image & Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT20001",
+  "name": "Cost Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30041",
+  "name": "Construction Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM20002",
+  "name": "Criminal Law and Political Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20001",
+  "name": "Climate Change ll",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN30013",
+  "name": "French Cinema: The New Wave and Beyond",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN30008",
+  "name": "Engineering Risk Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR30002",
+  "name": "Fluid Mechanics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10006",
+  "name": "Calculus 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS10004",
+  "name": "Ancient Greek 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MIIM20001",
+  "name": "Principles of Microbiology & Immunology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYS20008",
+  "name": "Human Physiology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20080",
+  "name": "School Experience as Breadth",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN30005",
+  "name": "The Environmental Screenscape",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO10003",
+  "name": "Indonesian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA20001",
+  "name": "Media and Urban Culture in Asia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30051",
+  "name": "Comedy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10008",
+  "name": "German 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH20011",
+  "name": "Ethnic Nationalism and the Modern World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10003",
+  "name": "Chinese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30043",
+  "name": "The Power and Limits of Logic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS10001",
+  "name": "Art History: Theory and Controversy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO10012",
+  "name": "Literature: Reading Indonesian Lives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI20007",
+  "name": "Poetry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC30023",
+  "name": "Science and Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE30006",
+  "name": "Entrepreneurial Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOTH20002",
+  "name": "Classical Sociological Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10005",
+  "name": "Quantitative Methods 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10017",
+  "name": "Riffs: Guitar Cultures & Practice 1",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM30003",
+  "name": "German 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10023",
+  "name": "The Making of Melbourne",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL30004",
+  "name": "Geochemistry & Petrogenesis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30053",
+  "name": "The Ethnography of Music",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM30006",
+  "name": "Crime and Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC20009",
+  "name": "Technology & Contemporary Life",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10037",
+  "name": "Music in Everyday Life",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20012",
+  "name": "Chinese 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20012",
+  "name": "French Travel Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC30004",
+  "name": "Applied Animal Reproduction & Genetics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG30003",
+  "name": "Service and Relationship Marketing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC10002",
+  "name": "Science and Pseudoscience",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN20022",
+  "name": "Spanish 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20070",
+  "name": "Learning via Sport and Outdoor Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10058",
+  "name": "Music, Learning and Popular Musicians",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL30015",
+  "name": "Italian 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR90015",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN20005",
+  "name": "Foundations of Electrical Networks",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE30002",
+  "name": "Genes: Organisation and Function",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30020",
+  "name": "Mathematical Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10026",
+  "name": "Disability, Diversity and Inclusion",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL10004",
+  "name": "Global Foundations of Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW10006",
+  "name": "Ancient Egyptian 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD30008",
+  "name": "Advanced Food Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS20004",
+  "name": "Russian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20006",
+  "name": "Indonesian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN10003",
+  "name": "Japanese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20006",
+  "name": "Indonesian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT30013",
+  "name": "Managing for Competitive Advantage",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH20002",
+  "name": "Design Studio Gamma",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20086",
+  "name": "Modern China in Global History 1949-1999",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30048",
+  "name": "Performance and the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM20007",
+  "name": "German 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30001",
+  "name": "Geomorphology: Catchment to Coast",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL20007",
+  "name": "Italian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GDES30002",
+  "name": "Branding",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CREA10001",
+  "name": "Contemporary Art and Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10021",
+  "name": "Interactive Art Media 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC30004",
+  "name": "Applied Animal Reproduction & Genetics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG30003",
+  "name": "Service and Relationship Marketing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN20003",
+  "name": "Object Oriented Software Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20012",
+  "name": "French Travel Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20174",
+  "name": "The Laptop Recording Studio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20012",
+  "name": "Chinese 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENVS10001",
+  "name": "Natural Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10006",
+  "name": "German 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20027",
+  "name": "Chinese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20008",
+  "name": "Indonesian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL30007",
+  "name": "Geobiology: Fossils & Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP30024",
+  "name": "Artificial Intelligence",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC20001",
+  "name": "Animal Physiology and Growth",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10054",
+  "name": "Drawing, Painting and Sensory Knowing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC10002",
+  "name": "Science and Pseudoscience",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN20022",
+  "name": "Spanish 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL30015",
+  "name": "Italian 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20122",
+  "name": "Composition Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC30003",
+  "name": "Applied Animal Behaviour",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20070",
+  "name": "Learning via Sport and Outdoor Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10058",
+  "name": "Music, Learning and Popular Musicians",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA10001",
+  "name": "Language and Power in Asian Societies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10003",
+  "name": "An Ecological History of Humanity",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20089",
+  "name": "Britain's Empire: Power and Resistance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN10003",
+  "name": "Spanish 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM30021",
+  "name": "German 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN30006",
+  "name": "Software Modelling and Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC20004",
+  "name": "Arabic 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90004",
+  "name": "Sustainability Governance and Leadership",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL10002",
+  "name": "Biomolecules and Cells",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90042",
+  "name": "Natural Language Processing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN30014",
+  "name": "Analog and Digital Electronics Concepts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN40002",
+  "name": "Spanish Honours Language Seminar 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP10002",
+  "name": "Foundations of Algorithms",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR90015",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM20018",
+  "name": "Chemistry: Reactions and Synthesis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20017",
+  "name": "Indonesia in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20009",
+  "name": "Vector Calculus",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30025",
+  "name": "Linear Statistical Models",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB20005",
+  "name": "Techniques in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB40009",
+  "name": "Biochemistry Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT90015",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN20005",
+  "name": "Foundations of Electrical Networks",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE30002",
+  "name": "Genes: Organisation and Function",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30020",
+  "name": "Mathematical Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB30010",
+  "name": "Advanced Techniques in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH30001",
+  "name": "Mechanisms of Human Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30046",
+  "name": "Steel and Concrete Structural Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB30003",
+  "name": "Molecular Aspects of Cell Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20009",
+  "name": "Chinese Economic Documents",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30024",
+  "name": "Economics of Financial Markets",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20006",
+  "name": "Probability for Statistics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM30017",
+  "name": "Specialised Topics in Chemistry A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM30015",
+  "name": "Advanced Practical Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20001",
+  "name": "Chinese 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL20012",
+  "name": "Italian 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV30029",
+  "name": "Screenwriting Practices 3A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90286",
+  "name": "Construction Methods A",
+  "offered": [
+   "february",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10017",
+  "name": "Animation History and Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10018",
+  "name": "Writing Animation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA90018",
+  "name": "Indonesia Rising?",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90113",
+  "name": "Information Systems Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90032",
+  "name": "Sensor Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90057",
+  "name": "Elements of Probability",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90086",
+  "name": "Environmental Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90018",
+  "name": "Clinical Practice in Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90010",
+  "name": "Applied Linguistics Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90033",
+  "name": "Climate Change Mitigation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS40036",
+  "name": "Classics Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90083",
+  "name": "Data Analysis for Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90010",
+  "name": "Advanced Construction Technology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20073",
+  "name": "Brass Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM10008",
+  "name": "Foundation Studies in Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90027",
+  "name": "Systems and Synthetic Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90027",
+  "name": "Advanced Seminars in Specialty 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90132",
+  "name": "Lie Algebras",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90093",
+  "name": "Ensemble A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RADI90017",
+  "name": "Diagnostic Radiology 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90276",
+  "name": "M.Epidemiology Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10092",
+  "name": "Vocal Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90020",
+  "name": "Business and Legal Translation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT90004",
+  "name": "Anatomy and Physiology for Audiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90076",
+  "name": "IT Infrastructure for Digital Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90422",
+  "name": "SI-Lab: Scanning and Virtual Reality",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40004",
+  "name": "Thinking Writing: Theory and Creativity",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS30008",
+  "name": "Production Practice 3 - Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90021",
+  "name": "Social Policy Special Topics B",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90055",
+  "name": "Development Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90151",
+  "name": "Music Performance Curriculum& Assessment",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90225",
+  "name": "Creating a Successful Business Model",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90334",
+  "name": "Means and Methods in Construction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90013",
+  "name": "Actuarial Studies Projects",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90022",
+  "name": "Food Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90074",
+  "name": "Web Security",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90201",
+  "name": "Community-Based Participatory Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90015",
+  "name": "Human Resource Fundamentals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90164",
+  "name": "EMA Special Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30206",
+  "name": "Vocal Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90008",
+  "name": "Quantum Field Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90097",
+  "name": "Production, Herd and Public Health A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90024",
+  "name": "High Rise Structures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90149",
+  "name": "Contemporary Digital Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS10009",
+  "name": "Production Studio 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90292",
+  "name": "Construction of Buildings",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30231",
+  "name": "Music Making Laboratory 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV40008",
+  "name": "Research Methods (Film and Television)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE10001",
+  "name": "Science: A Study of Life and Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PAED40001",
+  "name": "Paediatrics Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90064",
+  "name": "Industry Core and Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS40001",
+  "name": "Cultural Policy and Power",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90023",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOTH40001",
+  "name": "Relationships in Modernity",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90028",
+  "name": "Project Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20027",
+  "name": "Studio Studies 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90035",
+  "name": "Integrated Marketing Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70146",
+  "name": "Tax Treaties",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT40002",
+  "name": "Research in Management Accounting",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90064",
+  "name": "Advanced Studies in Economics 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90212",
+  "name": "Law and Civil Society in Asia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90010",
+  "name": "Spatial Information Research Project A",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90172",
+  "name": "Landscape Studio 3 Speculations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90033",
+  "name": "Marketing Communications Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90421",
+  "name": "Design - Philosophy - Architecture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90023",
+  "name": "Spatial Information Research Project B",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHTY90040",
+  "name": "Physiotherapy Professional Portfolio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90292",
+  "name": "M.Epidemiology Research Project - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND40006",
+  "name": "Gender Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA90012",
+  "name": "International Relations Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90148",
+  "name": "Probability and Distribution Theory",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90036",
+  "name": "Capstone Project A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30165",
+  "name": "Big Band 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90020",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90041",
+  "name": "Urinary Reproductive Tracts Lymph Nodes",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90107",
+  "name": "Information Systems Maj Res Project Pt 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90074",
+  "name": "Economics Thesis Workshop Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10023",
+  "name": "Introduction to Screenwriting Practices",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN90004",
+  "name": "Modelling Complex Software Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90032",
+  "name": "Emerging Technologies and Issues",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90015",
+  "name": "Managerial Economics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90048",
+  "name": "Artificial Intelligence for Engineers",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE90018",
+  "name": "Science Research Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90009",
+  "name": "Development Theories",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN40001",
+  "name": "Honours Japanese A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90010",
+  "name": "Print Production and Design",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL40006",
+  "name": "Actuarial Practice and Control I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90013",
+  "name": "Independent Dramaturgy Project",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90117",
+  "name": "Health Indicators and Health Surveys",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50068",
+  "name": "Equality and Discrimination Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90390",
+  "name": "Architectural Engineering Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN40008",
+  "name": "Japanese Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90003",
+  "name": "Macroeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90010",
+  "name": "Meat and Meat Products",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90558",
+  "name": "Education Research Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90061",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90169",
+  "name": "Adolescent Sexuality and Sexual Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90062",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90077",
+  "name": "Designing Digital Health Solutions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND90012",
+  "name": "Gender and Development Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90192",
+  "name": "Studio Teaching 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90027",
+  "name": "Clinical Processes A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20056",
+  "name": "Composition 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90042",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PAED40005",
+  "name": "Paediatrics Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90030",
+  "name": "Principles of Psychological Assessment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL90001",
+  "name": "Microscopy for Biological Sciences",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90078",
+  "name": "Internship for Agricultural Sciences",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90016",
+  "name": "Asset Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM40017",
+  "name": "German Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90002",
+  "name": "Financial Statement Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90088",
+  "name": "System Optimisation & Machine Learning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90023",
+  "name": "Treatment Effects and Program Evaluation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70067",
+  "name": "International Legal Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90049",
+  "name": "Digital Business Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV20010",
+  "name": "Screen Culture 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90020",
+  "name": "Measured Drawings & Digital Heritage",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90334",
+  "name": "Minor Project in Education 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90036",
+  "name": "Cardiovascular & Respiratory Emergencies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90048",
+  "name": "Advanced Case Studies Practicum",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90170",
+  "name": "Adolescent Health Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING40008",
+  "name": "Experimental Phonetics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90403",
+  "name": "Visions and Agendas in Architecture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90007",
+  "name": "Quantum Mechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90010",
+  "name": "Actuarial Practice And Control I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90010",
+  "name": "Translation Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30244",
+  "name": "Chamber Choir 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EVSC90017",
+  "name": "Global Environmental Change",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40015",
+  "name": "Creative Writing Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LANG40004",
+  "name": "Seminar in Languages 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90208",
+  "name": "Sustainable Business Practices",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90029",
+  "name": "Criminology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20156",
+  "name": "Practical Anatomy for Classical Voice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90032",
+  "name": "Biomed Eng Capstone Proj Part 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90065",
+  "name": "Managing Global City Regions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST90023",
+  "name": "The Writing of Australian History",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CREA90014",
+  "name": "Creative Arts Therapies Research 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90031",
+  "name": "Criminology & Sociology Internship Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90012",
+  "name": "Corporate Restructuring and Valuation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90041",
+  "name": "Property Law (PG)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90001",
+  "name": "Basic Econometrics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT40011",
+  "name": "Oral Health Sci Research Proj Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90039",
+  "name": "Mediation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90028",
+  "name": "Robotics Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90004",
+  "name": "States, Governments and the Arts",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90101",
+  "name": "Advanced Social Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90036",
+  "name": "Music Psychology Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90084",
+  "name": "Statistical Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90014",
+  "name": "Researching Politics and Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN90002",
+  "name": "Graduate Japanese A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90067",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91021",
+  "name": "Clinical Teaching Practice (GD EC) 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90039",
+  "name": "Advanced Surveying and Mapping",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90280",
+  "name": "Managerial Decision Analytics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90001",
+  "name": "Structural Editing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90067",
+  "name": "MSD Thesis -Semester Long (25 Points)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOLS40002",
+  "name": "Socio-Legal Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90066",
+  "name": "MSD Research Project Short (12.5 Points)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90050",
+  "name": "IT Project and Change Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90198",
+  "name": "Professional Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90024",
+  "name": "Computational Fluid Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90042",
+  "name": "Spatial Information Programming",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90080",
+  "name": "Computer Science Research Project Part 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40019",
+  "name": "Media & Communications Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST40030",
+  "name": "History for Historians",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "RURA90008",
+  "name": "Utilising Knowledge in Aboriginal Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90951",
+  "name": "Understanding Education Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90122",
+  "name": "Inference for Spatio-Temporal Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND90011",
+  "name": "Gender and Development Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90121",
+  "name": "Vet Bioscience: Cells to Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90017",
+  "name": "Actuarial Science Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90032",
+  "name": "Advanced Linguistics Analysis B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90004",
+  "name": "Marketing Management",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS40024",
+  "name": "Art History Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS90001",
+  "name": "Design Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA40005",
+  "name": "Asian Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90046",
+  "name": "3-D Echocardiography & New Technologies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90029",
+  "name": "Media and Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI10045",
+  "name": "Foundations of Agricultural Sciences 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90006",
+  "name": "Environmental Research Review (12.5)",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH40005",
+  "name": "Population Health Research Project 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH40001",
+  "name": "Philosophy and Scope of Anthropology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN40005",
+  "name": "French IV: Honours Language I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90024",
+  "name": "Project In Geoscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90157",
+  "name": "Pedagogue Recital",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90072",
+  "name": "DRFS Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BINF90001",
+  "name": "Statistics for Bioinformatics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90115",
+  "name": "Veterinary Bioscience 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH40002",
+  "name": "Critical Analysis of Pathology Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90013",
+  "name": "Research Proposal 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90012",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40063",
+  "name": "Honours Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA90008",
+  "name": "Perspectives in Art & Cultural Theory 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90024",
+  "name": "Teaching Translation and Interpreting",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS40006",
+  "name": "Russian Language & Culture 4A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90009",
+  "name": "Quantitative Methods for Business",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10014",
+  "name": "Foundation Mathematics 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90031",
+  "name": "Audiovisual Communication",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70003",
+  "name": "Minor Thesis (LLM) # P/T",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BTCH90009",
+  "name": "Genomics and Bioinformatics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30032",
+  "name": "Music Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90038",
+  "name": "MFPI Internship Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "BUSA90525",
@@ -2707,211 +8850,745 @@
    "semester_1",
    "winter_term",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "CCDP10002",
-  "name": "The Electronic Arts: Vision and Sound",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CCDP10003",
-  "name": "Video Games: Remaking Reality",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CCDP20001",
-  "name": "Street Art",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CCDP40001",
-  "name": "Research Methods (Social Practice)",
+  "code": "JOUR90010",
+  "name": "Newsroom-Applied Professional Practice",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "CEDB20003",
-  "name": "Fundamentals of Cell Biology",
+  "code": "ENST90043",
+  "name": "Sustainable Landscapes",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "CEDB30002",
-  "name": "Concepts in Cell & Developmental Biology",
+  "code": "AMGT90024",
+  "name": "Cultural Festivals and Special Events",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "CHEM10003",
-  "name": "Chemistry 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHEM10006",
-  "name": "Chemistry for Biomedicine",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEM10007",
-  "name": "Fundamentals of Chemistry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEM10008",
-  "name": "Foundation Studies in Chemistry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEM20011",
-  "name": "Environmental Chemistry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEM20018",
-  "name": "Chemistry: Reactions and Synthesis",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEM20026",
-  "name": "Principles of Chemical Biology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEM30015",
-  "name": "Advanced Practical Chemistry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEM30016",
-  "name": "Reactivity and Mechanism",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEM30017",
-  "name": "Specialised Topics in Chemistry A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEM90007",
-  "name": "Environmental Chemistry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEM90055",
-  "name": "Chemical Regulations and Safety",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEN20009",
-  "name": "Transport Processes",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEN30001",
-  "name": "Reactor Engineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEN90007",
-  "name": "Chemical Engineering Thermodynamics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEN90013",
-  "name": "Process Engineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEN90018",
-  "name": "Particle Mechanics and Processing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEN90019",
-  "name": "Advanced Heat & Mass Transport Processes",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEN90020",
-  "name": "Chemical Engineering Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEN90023",
-  "name": "Chemical Engineering Research Project",
+  "code": "LAWS50060",
+  "name": "Melbourne Journal of International Law",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "CHEN90026",
-  "name": "Chemical Engineering Minor Research Proj",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHEN90027",
-  "name": "Future Fuels and Petroleum",
+  "code": "MGMT90224",
+  "name": "Garage Project",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90104",
+  "name": "Enhanced Recovery After Surgery",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90002",
+  "name": "Presenting Academic Discourse",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90005",
+  "name": "Thesis (Masters/coursework)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90008",
+  "name": "Researching the Past",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NRMT90003",
+  "name": "Social Research Methods",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20055",
+  "name": "Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40003",
+  "name": "Researching Audiences and Reception",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO40003",
+  "name": "Topics in Indonesian Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV70030",
+  "name": "Narrative Projects 2A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90020",
+  "name": "Risk Management and Citizen Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90015",
+  "name": "Legal Issues for Business",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90363",
+  "name": "Property Research and Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10016",
+  "name": "Mathematics for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90027",
+  "name": "Energy for Sustainable Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90012",
+  "name": "Corporate Reporting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90002",
+  "name": "Supervised Reading (Asia Institute)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90008",
+  "name": "Foundations of Spatial Information",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20104",
+  "name": "Shakuhachi 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90065",
+  "name": "Fundamentals of Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90037",
+  "name": "Abdominal & Urogenital Emergencies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90014",
+  "name": "Auditing and Assurance Services",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90288",
+  "name": "Architectural Cultures 1: Modernism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN40010",
+  "name": "French Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM30016",
+  "name": "Digital Media Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90094",
+  "name": "Health Economics 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90019",
+  "name": "Internship II (Semester Long)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS70001",
+  "name": "MVSc (Clinical) Practicum # FT",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC90010",
+  "name": "Environment and Knowledge",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90038",
+  "name": "Clinical Training in Music Therapy 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90008",
+  "name": "Statistical Techniques in Insurance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90085",
+  "name": "Volunteer Experience in I.T.",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20215",
+  "name": "Medieval and Renaissance Ensemble 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90069",
+  "name": "Digital Transformation of Health",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90032",
+  "name": "Macroeconomics for Managers",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90056",
+  "name": "Electronic Circuit Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90040",
+  "name": "General Principles and FAST Techniques",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CREA90017",
+  "name": "Creative Arts Therapists in Community",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40055",
+  "name": "Music Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL40010",
+  "name": "Research Project - RMH Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30020",
+  "name": "Chamber Music 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90024",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90052",
+  "name": "Advanced Signal Processing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40104",
+  "name": "Dissertation Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS40023",
+  "name": "Art History Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90288",
+  "name": "Biostatistics Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90048",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90122",
+  "name": "Intro to the Veterinary Profession",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90117",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90120",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90010",
+  "name": "Technology Innovation Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90221",
+  "name": "Orchestral Performance Practicum 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS40009",
+  "name": "Russian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN40006",
+  "name": "Chinese Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ESLA90001",
+  "name": "Professional Speaking Communication",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90274",
+  "name": "Property Markets and Valuations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CONS30001",
+  "name": "Building Information Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90009",
+  "name": "Judging Crime",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30047",
+  "name": "Music Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90038",
+  "name": "Advanced Clinical Practice 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90149",
+  "name": "Applied Instrumental and Vocal Teaching",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90109",
+  "name": "Information Systems Min Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90051",
+  "name": "Principles of Paediatric Audiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50059",
+  "name": "Legal Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "june",
+   "semester_2",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90060",
+  "name": "Financial Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40002",
+  "name": "Advanced Macroeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYS30010",
+  "name": "Advanced Human Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10010",
+  "name": "Indigenous Astronomy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PADM20001",
+  "name": "Foundations of Digital Government",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90057",
+  "name": "Communication Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90012",
+  "name": "Second Language Acquisition",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90154",
+  "name": "Professional Practice 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30174",
+  "name": "Conservatorium Choir 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90040",
+  "name": "Film and Engineering at the Crossroads",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30265",
+  "name": "Italian Lyric Diction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90034",
+  "name": "Creating Innovative Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT90034",
+  "name": "Landscape Design",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT90008",
+  "name": "Horticultural Plant Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30030",
+  "name": "Applied Mathematical Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC30021",
+  "name": "Laboratory and Computational Physics 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30032",
+  "name": "Biological Modelling and Simulation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90008",
+  "name": "International Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "CHEN90028",
@@ -2920,3237 +9597,8 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "CHEN90030",
-  "name": "Chemical Engineering Minor Thesis",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHEN90031",
-  "name": "Bioprocess Engineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHEN90038",
-  "name": "Product Design and Analysis",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN10001",
-  "name": "Chinese 9",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN10003",
-  "name": "Chinese 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN10005",
-  "name": "Chinese 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN10015",
-  "name": "Chinese 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN10017",
-  "name": "Chinese 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN10019",
-  "name": "Contemporary Chinese Literature",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20001",
-  "name": "Chinese 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20003",
-  "name": "Chinese 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20005",
-  "name": "Modern Chinese Literature",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20006",
-  "name": "Great Chinese Classics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20007",
-  "name": "Chinese Studies: Culture and Empire",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20009",
-  "name": "Chinese Economic Documents",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20010",
-  "name": "Chinese in Context 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20012",
-  "name": "Chinese 9",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20022",
-  "name": "Advanced Seminar in Chinese",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20025",
-  "name": "Human Rights in East and Southeast Asia",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20027",
-  "name": "Chinese 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN20029",
-  "name": "Understanding the New Media in China",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN30002",
-  "name": "Taiwan & Beyond: Chinese Settler Culture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN30007",
-  "name": "Advanced Seminar in Chinese",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN30008",
-  "name": "Chinese 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN30010",
-  "name": "Modern Chinese Literature",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN30011",
-  "name": "Great Chinese Classics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN30012",
-  "name": "Chinese Economic Documents",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN30025",
-  "name": "Chinese 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN30027",
-  "name": "Chinese 9",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN40006",
-  "name": "Chinese Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHIN40007",
-  "name": "Chinese Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHIN90001",
-  "name": "Honours Chinese A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN90003",
-  "name": "Topics in Chinese Studies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CHIN90005",
-  "name": "Graduate Chinese A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS10004",
-  "name": "Ancient Greek 1",
-  "offered": [
-   "semester_1",
-   "winter_term"
-  ]
- },
- {
-  "code": "CLAS10006",
-  "name": "Latin 1",
-  "offered": [
-   "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS10012",
-  "name": "Latin 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS10020",
-  "name": "Ancient Greek 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS20013",
-  "name": "Ancient Greek 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS20015",
-  "name": "Ancient Greek 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS20029",
-  "name": "Latin 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS20030",
-  "name": "Latin 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS30013",
-  "name": "Latin 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS30024",
-  "name": "Ancient Greek 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS40036",
-  "name": "Classics Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CLAS40037",
-  "name": "Classics Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CLAS40038",
-  "name": "Ancient Greek Honours Seminar 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS40040",
-  "name": "Latin Honours Seminar 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP10001",
-  "name": "Foundations of Computing",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP10002",
-  "name": "Foundations of Algorithms",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP10003",
-  "name": "Media Computation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP20005",
-  "name": "Engineering Computation",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP20007",
-  "name": "Design of Algorithms",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP20008",
-  "name": "Elements of Data Processing",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP30013",
-  "name": "Advanced Studies in Computing",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP30023",
-  "name": "Computer Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP30024",
-  "name": "Artificial Intelligence",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP30027",
-  "name": "Machine Learning",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP90005",
-  "name": "Advanced Studies in Computing",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90007",
-  "name": "Internet Technologies",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90015",
-  "name": "Distributed Systems",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90016",
-  "name": "Computational Genomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP90020",
-  "name": "Distributed Algorithms",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP90024",
-  "name": "Cluster and Cloud Computing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP90038",
-  "name": "Algorithms and Complexity",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90041",
-  "name": "Programming and Software Development",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90042",
-  "name": "Natural Language Processing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP90044",
-  "name": "Research Methods",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90048",
-  "name": "Declarative Programming",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP90049",
-  "name": "Introduction to Machine Learning",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90050",
-  "name": "Advanced Database Systems",
-  "offered": [
-   "semester_1",
-   "winter_term"
-  ]
- },
- {
-  "code": "COMP90051",
-  "name": "Statistical Machine Learning",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90054",
-  "name": "AI Planning for Autonomy",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90055",
-  "name": "Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90059",
-  "name": "Introduction to Programming",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90060",
-  "name": "Computer Science Research Project Pt1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90061",
-  "name": "Computer Science Research Project Pt1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90062",
-  "name": "Computer Science Research Project Pt1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90063",
-  "name": "Computer Science Research Project Pt1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90064",
-  "name": "Computer Science Research Project Pt2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90065",
-  "name": "Computer Science Research Project Pt2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90066",
-  "name": "Computer Science Research Project Pt2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90067",
-  "name": "Computer Science Research Project Pt2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90068",
-  "name": "Computer Science Research Project Pt3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90069",
-  "name": "Computer Science Research Project Pt3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90070",
-  "name": "Computer Science Research Project Pt3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90071",
-  "name": "Computer Science Research Project Pt3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90072",
-  "name": "The Art of Scientific Computation",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90074",
-  "name": "Web Security",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP90077",
-  "name": "Advanced Algorithms and Data Structures",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "COMP90078",
-  "name": "Computer Science Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90079",
-  "name": "Computer Science Research Project Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90080",
-  "name": "Computer Science Research Project Part 3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90081",
-  "name": "Computer Science Research Project Part 4",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90082",
-  "name": "Software Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90085",
-  "name": "Volunteer Experience in I.T.",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90087",
-  "name": "The Ethics of Artificial Intelligence",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CONS30001",
-  "name": "Building Information Modelling",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CREA10001",
-  "name": "Contemporary Art and Biomedicine",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CREA90002",
-  "name": "Arts for Health and Wellbeing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CREA90003",
-  "name": "Evaluation of Wellbeing in Creative Arts",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CREA90014",
-  "name": "Creative Arts Therapies Research 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CREA90017",
-  "name": "Creative Arts Therapists in Community",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM10001",
-  "name": "Crime, Criminology, and Critique",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM20002",
-  "name": "Criminal Law and Political Justice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM20003",
-  "name": "Policing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM20010",
-  "name": "Law, Justice and Social Change",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM30002",
-  "name": "Global Criminology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM30005",
-  "name": "Corporate Power and White Collar Crime",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM30006",
-  "name": "Crime and Culture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM30010",
-  "name": "Managing Justice: Agencies and the State",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM30011",
-  "name": "Young People, Crime and Justice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM40002",
-  "name": "Qualitative Research Methods",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM40003",
-  "name": "Drugs and Justice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM40005",
-  "name": "Punishment and Detention: New Challenges",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM40008",
-  "name": "Criminology Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CRIM40009",
-  "name": "Criminology Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CRIM90009",
-  "name": "Judging Crime",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM90011",
-  "name": "Research and Criminal Justice Governance",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM90018",
-  "name": "Making Sense of Crime and Justice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CRIM90028",
-  "name": "Criminology Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CRIM90029",
-  "name": "Criminology Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CRIM90030",
-  "name": "Criminology & Sociology Internship Pt 1",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CRIM90031",
-  "name": "Criminology & Sociology Internship Pt 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CRIM90035",
-  "name": "Victims and Criminal Justice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CULS20014",
-  "name": "Television, Lifestyle & Consumer Culture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CULS20018",
-  "name": "Popular Culture: From K-pop to Selfies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CULS30004",
-  "name": "Thinking Sex",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CULS30006",
-  "name": "Global Cultures",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CULS40001",
-  "name": "Cultural Policy and Power",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CULS90011",
-  "name": "The Cosmopolitan Imaginary",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CUMC90006",
-  "name": "Conservation Internship and Projects",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CUMC90035",
-  "name": "Conservation Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CUMC90036",
-  "name": "Conservation Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CVEN30008",
-  "name": "Engineering Risk Analysis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CVEN30010",
-  "name": "Systems Modelling and Design",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CVEN90017",
-  "name": "Earthquake Resistant Design of Buildings",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CVEN90024",
-  "name": "High Rise Structures",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CVEN90026",
-  "name": "Extreme Loading of Structures",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CVEN90043",
-  "name": "Sustainable Infrastructure Engineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CVEN90044",
-  "name": "Engineering Site Characterisation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CVEN90047",
-  "name": "IE Research Project 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CVEN90049",
-  "name": "Structural Theory and Design 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CVEN90050",
-  "name": "Geotechnical Engineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CVEN90059",
-  "name": "Integrated Design - Infrastructure",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CVEN90063",
-  "name": "Transport System Modelling",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CWRI10001",
-  "name": "Creative Writing: Ideas and Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CWRI10002",
-  "name": "Knowledge Practices 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CWRI20005",
-  "name": "Creative Non Fiction",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CWRI20007",
-  "name": "Poetry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CWRI20009",
-  "name": "Writing for Screen",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CWRI20012",
-  "name": "Writing Identity and Difference",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CWRI30006",
-  "name": "Poetry and Poetics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CWRI40004",
-  "name": "Thinking Writing: Theory and Creativity",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CWRI40011",
-  "name": "Graphic Narratives",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "CWRI40015",
-  "name": "Creative Writing Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CWRI40016",
-  "name": "Creative Writing Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CWRI90015",
-  "name": "Creative Writing Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CWRI90016",
-  "name": "Creative Writing Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CWRI90018",
-  "name": "Advanced Writing Project Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT40003",
-  "name": "Advances in Oral Health Research",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT40010",
-  "name": "Oral Health Sci Research Proj Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT40011",
-  "name": "Oral Health Sci Research Proj Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90011",
-  "name": "Research Design 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90013",
-  "name": "Research Proposal 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90014",
-  "name": "Research Proposal 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90015",
-  "name": "Principles of Specialty 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90016",
-  "name": "Principles of Specialty 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90017",
-  "name": "Clinical Practice in Specialty 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90018",
-  "name": "Clinical Practice in Specialty 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90019",
-  "name": "Minor Thesis 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90021",
-  "name": "Advanced Seminars in Specialty 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90023",
-  "name": "Adv Clinical Practice in Specialty 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90024",
-  "name": "Adv Clinical Practice in Specialty 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90025",
-  "name": "Minor Thesis 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90026",
-  "name": "Minor Thesis 4",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90027",
-  "name": "Advanced Seminars in Specialty 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90029",
-  "name": "Adv Clinical Practice in Specialty 3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90030",
-  "name": "Adv Clinical Practice in Specialty 4",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90031",
-  "name": "Research Design 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90032",
-  "name": "Research Design 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90033",
-  "name": "Research Project 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90035",
-  "name": "Advanced Clinical Practice 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90037",
-  "name": "Advanced Clinical Practice 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90038",
-  "name": "Advanced Clinical Practice 4",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DENT90039",
-  "name": "Forensic Odontology 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90041",
-  "name": "Casework/Research Report 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90045",
-  "name": "Research Project 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DENT90047",
-  "name": "OMS Clinical Practice 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DEVT10001",
-  "name": "The Developing World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DEVT10002",
-  "name": "Engagements with Place",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DEVT90002",
-  "name": "Internship in Development",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DEVT90003",
-  "name": "The Political Ecology of Development",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DEVT90008",
-  "name": "International Internship in Development",
-  "offered": [
-   "january",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DEVT90009",
-  "name": "Development Theories",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DEVT90039",
-  "name": "Civil Society, NGOs and the State",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DEVT90053",
-  "name": "Intervening in Development",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DEVT90054",
-  "name": "Development Studies Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DEVT90055",
-  "name": "Development Studies Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DEVT90060",
-  "name": "Internship in Development",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DEVT90061",
-  "name": "Global Urban Development",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DEVT90076",
-  "name": "Social Policy and Development",
-  "offered": [
-   "semester_1",
-   "november"
-  ]
- },
- {
-  "code": "DNCE10027",
-  "name": "Dancing the Dance 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DNCE10029",
-  "name": "Body Knowledges: Dance Science",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DNCE10030",
-  "name": "Dance Lab 1: Studio Practices",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DNCE40005",
-  "name": "Research Methods (Dance)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DPSS10008",
-  "name": "Artefact and Performance 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DPSS10009",
-  "name": "Production Studio 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DPSS20010",
-  "name": "Production Practice 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DPSS20011",
-  "name": "Production Studio 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DPSS30008",
-  "name": "Production Practice 3 - Part A",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DPSS30009",
-  "name": "Production Practice 3 - Part B",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "DPSS90001",
-  "name": "Design Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DPSS90002",
-  "name": "Design Projects 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM10026",
-  "name": "Up Close and Personal with MTC",
-  "offered": [
-   "semester_1",
-   "june",
-   "semester_2"
-  ]
- },
- {
-  "code": "DRAM10032",
-  "name": "Contextual Studies 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM10033",
-  "name": "Performance Preparation 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM20023",
-  "name": "Contextual Studies 2 Theory in Action",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM40001",
-  "name": "Research Methods (Theatre Practice)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM90010",
-  "name": "Performing Arts Research Methodologies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM90011",
-  "name": "Applied Dramaturgy 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM90013",
-  "name": "Independent Dramaturgy Project",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM90019",
-  "name": "Dramaturgy, Text and Performance",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM90020",
-  "name": "Directing Methodologies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM90022",
-  "name": "Collaboration in Action",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "DRAM90023",
-  "name": "Applied Dramaturgy 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOL30006",
-  "name": "Ecology in Changing Environments",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOL30007",
-  "name": "Marine Ecosystems: Ecology & Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM20001",
-  "name": "Econometrics 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECOM30001",
-  "name": "Basic Econometrics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM30002",
-  "name": "Econometrics 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECOM40003",
-  "name": "Macroeconometrics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM40006",
-  "name": "Econometrics 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM90001",
-  "name": "Basic Econometrics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM90002",
-  "name": "Econometrics 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECOM90005",
-  "name": "Advanced Econometric Techniques",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM90007",
-  "name": "Macroeconometrics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM90009",
-  "name": "Quantitative Methods for Business",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECOM90013",
-  "name": "Econometrics 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM90015",
-  "name": "Special Topics in Adv. Econometrics 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM90020",
-  "name": "Computational Economics and Business",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM90022",
-  "name": "Research Methods",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM90023",
-  "name": "Treatment Effects and Program Evaluation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECOM90024",
-  "name": "Forecasting in Economics and Business",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON10003",
-  "name": "Introductory Macroeconomics",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON10004",
-  "name": "Introductory Microeconomics",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON10005",
-  "name": "Quantitative Methods 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON20002",
-  "name": "Intermediate Microeconomics",
-  "offered": [
-   "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON20003",
-  "name": "Quantitative Methods 2",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON20007",
-  "name": "Globalisation and the World Economy",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON30001",
-  "name": "International Trade Policy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON30005",
-  "name": "Money and Banking",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON30010",
-  "name": "Microeconomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON30013",
-  "name": "Economic Analysis and Policy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON30018",
-  "name": "Economics of the Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON30020",
-  "name": "Mathematical Economics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON30024",
-  "name": "Economics of Financial Markets",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON30025",
-  "name": "Computational Economics and Business",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON40001",
-  "name": "Advanced Microeconomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON40002",
-  "name": "Advanced Macroeconomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON40018",
-  "name": "Economics Research Essay Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90002",
-  "name": "Microeconomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90003",
-  "name": "Macroeconomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90010",
-  "name": "Quantitative Analysis of Finance II",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON90015",
-  "name": "Managerial Economics",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON90016",
-  "name": "Environmental Economics and Strategy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90029",
-  "name": "Economics For Public Policy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90032",
-  "name": "Macroeconomics for Managers",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90033",
-  "name": "Quantitative Analysis of Finance I",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON90034",
-  "name": "Economics of Finance",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON90047",
-  "name": "Macroeconomics 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90053",
-  "name": "Mathematics for Economists",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON90055",
-  "name": "Computational Economics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90063",
-  "name": "Advanced Microeconomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90064",
-  "name": "Advanced Studies in Economics 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90065",
-  "name": "Advanced Studies in Economics 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90071",
-  "name": "Economics Research Report Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90073",
-  "name": "Economics Thesis Workshop Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90074",
-  "name": "Economics Thesis Workshop Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON90075",
-  "name": "Economic Analysis and Policy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON90079",
-  "name": "Advanced Experimental Economics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC10048",
-  "name": "Creativity, Play and the Arts",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC10051",
-  "name": "Sports Coaching: Theory and Practice",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC10054",
-  "name": "Drawing, Painting and Sensory Knowing",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC10056",
-  "name": "Learning and the Digital Generations",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC10057",
-  "name": "Wellbeing, Motivation and Performance",
-  "offered": [
-   "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC10058",
-  "name": "Music, Learning and Popular Musicians",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC10060",
-  "name": "Introduction to Indigenous Education",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC20064",
-  "name": "Concepts of Childhood",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC20065",
-  "name": "Knowledge, Learning and Culture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC20068",
-  "name": "Sport, Education and the Media",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC20070",
-  "name": "Learning via Sport and Outdoor Education",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC20073",
-  "name": "Links Between Health and Learning",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC20077",
-  "name": "Printing, Collage and Social Engagement",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC20080",
-  "name": "School Experience as Breadth",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC20084",
-  "name": "Staging Theatre for Youth Audiences",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC20085",
-  "name": "Singing, Song Writing and Youth Music",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC90002",
-  "name": "Effective University Teaching",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC90048",
-  "name": "Second Language Teaching Methodology",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90057",
-  "name": "Education Capstone Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC90101",
-  "name": "Multilingual Practices in Global Times",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC90334",
-  "name": "Minor Project in Education 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC90335",
-  "name": "Minor Project in Education",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC90558",
-  "name": "Education Research Design",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC90606",
-  "name": "Engagement and the Arts",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC90728",
-  "name": "Innovative Spaces and Pedagogy",
-  "offered": [
-   "semester_1",
-   "august"
-  ]
- },
- {
-  "code": "EDUC90838",
-  "name": "Project in Clinical Education",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC90868",
-  "name": "Advanced Methodology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC90869",
-  "name": "Doctor of Education Thesis Proposal",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC90892",
-  "name": "Clinical Teaching Practice (EC) 1",
-  "offered": [
-   "semester_1",
-   "august"
-  ]
- },
- {
-  "code": "EDUC90929",
-  "name": "Understanding Education in Context",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC90930",
-  "name": "Local Literacies in Global Contexts",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC90932",
-  "name": "Education Research Design Part 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC90948",
-  "name": "Mathematics: Improving Learning",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC90951",
-  "name": "Understanding Education Policy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC90989",
-  "name": "Capstone Professional Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC91021",
-  "name": "Clinical Teaching Practice (GD EC) 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC91029",
-  "name": "Understanding the Student as Learner",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC91030",
-  "name": "Research in Educational Relationships",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC91033",
-  "name": "Teaching Number (7-10)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC91034",
-  "name": "Teaching Algebra (7-10)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC91037",
-  "name": "Teaching and Learning in Science",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC91038",
-  "name": "Inquiry and Literacy in Science",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN20005",
-  "name": "Foundations of Electrical Networks",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN20006",
-  "name": "Digital Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN30009",
-  "name": "Electrical Network Analysis and Design",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN30010",
-  "name": "Digital System Design",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN30012",
-  "name": "Signals and Systems",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN30014",
-  "name": "Analog and Digital Electronics Concepts",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN90011",
-  "name": "Directed Studies",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN90026",
-  "name": "Introduction to Optimisation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN90051",
-  "name": "Advanced Communication Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN90052",
-  "name": "Advanced Signal Processing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN90054",
-  "name": "Probability and Random Models",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN90055",
-  "name": "Control Systems",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN90056",
-  "name": "Electronic Circuit Design",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN90057",
-  "name": "Communication Systems",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN90058",
-  "name": "Signal Processing",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN90059",
-  "name": "Lightwave Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN90066",
-  "name": "Embedded System Design",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN90069",
-  "name": "Electrical Power Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN90074",
-  "name": "Introduction to Power Engineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN90077",
-  "name": "Grid Integration of Renewables",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN90083",
-  "name": "Electrical Engineering Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ELEN90088",
-  "name": "System Optimisation & Machine Learning",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN90089",
-  "name": "Communication Design Clinic",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ELEN90090",
-  "name": "Autonomous Systems Clinic",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENEN20002",
-  "name": "Earth Processes for Engineering",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENEN30002",
-  "name": "Intro to Sustainable Water Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENEN90005",
-  "name": "Environmental Management ISO 14000",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENEN90006",
-  "name": "Solid Wastes to Sustainable Resources",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENEN90027",
-  "name": "Energy for Sustainable Development",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENEN90031",
-  "name": "Quantitative Environmental Modelling",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENEN90033",
-  "name": "Solar Energy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENEN90038",
-  "name": "Engineering Hydrology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL10002",
-  "name": "Literature and Performance",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL10004",
-  "name": "Indigenous Literature",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL20009",
-  "name": "The Australian Imaginary",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL20030",
-  "name": "Modern and Contemporary Theatre",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL20031",
-  "name": "Literature, Adaptation, Media",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL20033",
-  "name": "Shakespeare in Performance",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL30006",
-  "name": "Global Literature and Postcolonialism",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL30013",
-  "name": "Gothic Fictions",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL30016",
-  "name": "Decadent Literature",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL30046",
-  "name": "Romancing the Medieval",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL30048",
-  "name": "Performance and the World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL30051",
-  "name": "Comedy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL40015",
-  "name": "American Fiction: The 20th Century",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL40018",
-  "name": "Don Juan: Our Contemporary",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL40024",
-  "name": "Renaissance Drama",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGL40026",
-  "name": "English & Theatre Studies Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGL40027",
-  "name": "English & Theatre Studies Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGL90002",
-  "name": "Writing as Women: Critical Readings",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGM90007",
-  "name": "Project Management Practices",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGM90011",
-  "name": "Economic Analysis for Engineers",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGM90013",
-  "name": "Strategy Execution for Engineers",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGM90014",
-  "name": "The World of Engineering Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGM90015",
-  "name": "Management and Leadership for Engineers",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGM90016",
-  "name": "Engineering Management Capstone",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR10004",
-  "name": "Engineering Technology and Society",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGR20004",
-  "name": "Engineering Mechanics",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR20005",
-  "name": "Numerical Methods in Engineering",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR30002",
-  "name": "Fluid Mechanics",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90021",
-  "name": "Critical Communication for Engineers",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90024",
-  "name": "Computational Fluid Dynamics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGR90026",
-  "name": "Engineering Entrepreneurship",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGR90028",
-  "name": "Introduction to Energy Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGR90029",
-  "name": "Analysing Energy Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGR90031",
-  "name": "Energy Systems Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90032",
-  "name": "Energy Supply and Value Chains",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENGR90033",
-  "name": "Internship",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90034",
-  "name": "Creating Innovative Engineering",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90035",
-  "name": "Graduate Research Internship",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90036",
-  "name": "Leadership for Innovation",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90037",
-  "name": "Engineering Capstone Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90038",
-  "name": "Engineering Capstone Project Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90039",
-  "name": "Creating Innovative Professionals",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90041",
-  "name": "Engineering Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENST20001",
-  "name": "Human Behaviour and Environment",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENST30002",
-  "name": "Land And Environment Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENST90006",
-  "name": "Environmental Research Review (12.5)",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENST90007",
-  "name": "Environmental Research Project (25)",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENST90016",
-  "name": "Environmental Research Project (50)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENST90020",
-  "name": "Environmental Industry Research (50)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENST90025",
-  "name": "Environmental Industry Research (25)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENST90032",
-  "name": "Sustainability and Behaviour Change",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENST90033",
-  "name": "Climate Change Mitigation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENST90043",
-  "name": "Sustainable Landscapes",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENST90045",
-  "name": "Spatial Tools for Ecosystem Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENVS10001",
-  "name": "Natural Environments",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ENVS10006",
-  "name": "Mapping Environments",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ERTH30001",
-  "name": "Hydrogeology/Environmental Geochemistry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ESLA10003",
-  "name": "Academic English 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ESLA90001",
-  "name": "Professional Speaking Communication",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ESLA90003",
-  "name": "Professional Literacies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EURO20003",
-  "name": "Memory & Memoirs of 20th Century Europe",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EURO30002",
-  "name": "Memory & Memoirs of 20th Century Europe",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EURO40002",
-  "name": "Seminars in Languages and Linguistics A",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EURO40003",
-  "name": "Seminars in Languages and Linguistics B",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EVSC10001",
-  "name": "The Global Environment",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EVSC20004",
-  "name": "Blue Planet-Intro to Marine Environments",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EVSC20006",
-  "name": "Energy and the Environment",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EVSC30003",
-  "name": "Environmental Risk Assessment",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EVSC30006",
-  "name": "Ecology of Urban Landscapes",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EVSC90015",
-  "name": "Environmental Impact Assessment",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EVSC90017",
-  "name": "Global Environmental Change",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "EVSC90020",
-  "name": "Environmental Modelling",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA10025",
-  "name": "Studio Studies 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA10026",
-  "name": "Critical and Theoretical Studies 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA10035",
-  "name": "Still Life: Nature Morte",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FINA10036",
-  "name": "Life Drawing: The Body",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA20026",
-  "name": "Painting Techniques",
-  "offered": [
-   "summer_term",
-   "february",
-   "semester_1",
-   "winter_term",
-   "june",
-   "semester_2"
-  ]
- },
- {
-  "code": "FINA20027",
-  "name": "Studio Studies 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA20029",
-  "name": "Critical and Theoretical Studies 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA20043",
-  "name": "Light in Performance",
-  "offered": [
-   "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "FINA20044",
@@ -6162,676 +9610,204 @@
    "winter_term",
    "june",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA30001",
-  "name": "Studio Studies 5",
+  "code": "MUSI30030",
+  "name": "The Music Of Spain",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA30017",
-  "name": "Critical and Theoretical Studies 5",
+  "code": "RUSS10001",
+  "name": "Russian 1",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA30022",
-  "name": "Space Studio",
+  "code": "SPAN20018",
+  "name": "Spanish 5",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA30023",
-  "name": "Space in Performance",
+  "code": "JAPN10010",
+  "name": "Variation in Japanese Language",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA30025",
-  "name": "Studio Options",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA30028",
-  "name": "Studio Studies 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA40004",
-  "name": "Research Methods (Visual Art)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA60008",
-  "name": "Studio Materials and Methods A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA60011",
-  "name": "Contemporary Art Practice A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA60013",
-  "name": "Critical Issues in Contemporary Art A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA70006",
-  "name": "Studio Practice 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA70008",
-  "name": "Professional Perspectives",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA90002",
-  "name": "Research Methods",
-  "offered": [
-   "march",
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA90006",
-  "name": "Perspectives in Art & Cultural Theory 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FINA90008",
-  "name": "Perspectives in Art & Cultural Theory 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV10006",
-  "name": "Screen Practice 1A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV10007",
-  "name": "Screenwriting 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV10010",
-  "name": "Making Movies 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FLTV10012",
-  "name": "Screenwriting Practices 1A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV10014",
-  "name": "Pictures, Sounds, Words",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV10016",
-  "name": "Animation Studio 1A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV10017",
-  "name": "Animation History and Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV10018",
-  "name": "Writing Animation 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV10021",
-  "name": "Interactive Art Media 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FLTV10023",
-  "name": "Introduction to Screenwriting Practices",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FLTV10024",
-  "name": "Making Micro Movies - Filming the Real",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV20005",
-  "name": "Making Movies 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV20006",
-  "name": "Screen Practice 2A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV20010",
-  "name": "Screen Culture 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV20012",
-  "name": "Screenwriting Practices 2A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV20014",
-  "name": "Animation Research 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV20015",
-  "name": "Animation Studio 2A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV20018",
-  "name": "Writing for the Youth Screen Market",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV20019",
-  "name": "Writing Animation 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV30009",
-  "name": "Languages of the Screen",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV30011",
-  "name": "Screen Culture and Aesthetics 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV30018",
-  "name": "Animation Lab 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV30021",
-  "name": "Collaborative Production",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV30023",
-  "name": "Animation Studio 3A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV30025",
-  "name": "Screen Practice 3A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV30029",
-  "name": "Screenwriting Practices 3A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV40005",
-  "name": "Research Methods (Animation)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV40008",
-  "name": "Research Methods (Film and Television)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV40011",
-  "name": "Research Methods (Screenwriting)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV70020",
-  "name": "Narrative Projects 1A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV70026",
-  "name": "Scriptwriting 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV70028",
-  "name": "Documentary Projects 2A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV70030",
-  "name": "Narrative Projects 2A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV70041",
-  "name": "Storytelling Workshop",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV70042",
-  "name": "Cinematic Writing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV70043",
-  "name": "Writing for Television",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV70044",
-  "name": "Writing and Rewriting",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV70045",
-  "name": "Business of Screenwriting",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV90003",
-  "name": "Design Processes and Principles A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV90004",
-  "name": "Design Realisation and Collaboration A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV90005",
-  "name": "Design Documentation and Communication A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV90006",
-  "name": "Studies in Screen",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV90011",
-  "name": "Graphics for Stage and Screen",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV90014",
-  "name": "Screen Design Projects A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV90015",
-  "name": "Industry Investigation Project A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV90022",
-  "name": "Business of Producing 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV90025",
-  "name": "Documentary Projects 1A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FLTV90026",
-  "name": "Screen Language 1A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FNCE10002",
-  "name": "Principles of Finance",
+  "code": "MULT20010",
+  "name": "Arts Internship",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE20005",
-  "name": "Corporate Financial Decision Making",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE30001",
-  "name": "Investments",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE30006",
-  "name": "Entrepreneurial Finance",
+  "code": "NEUR30002",
+  "name": "Neurophysiology: Neurons and Circuits",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE30007",
-  "name": "Derivative Securities",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE30008",
-  "name": "Street Finance",
+  "code": "INDG20001",
+  "name": "Indigenous Treaties and Titles",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE30011",
-  "name": "Essentials of Corporate Valuation",
+  "code": "LING30007",
+  "name": "Semantics",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE40001",
-  "name": "Advanced Corporate Finance",
+  "code": "ANTH20001",
+  "name": "Keeping the Body in Mind",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE40002",
-  "name": "Advanced Investments",
+  "code": "CULS20014",
+  "name": "Television, Lifestyle & Consumer Culture",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE40003",
-  "name": "Numerical Techniques in Finance",
+  "code": "EVSC20006",
+  "name": "Energy and the Environment",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE40004",
-  "name": "Research Methods in Finance",
+  "code": "ABPL30050",
+  "name": "Modern Architecture: MoMo to PoMo",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE90011",
-  "name": "Derivative Securities",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90012",
-  "name": "Corporate Restructuring and Valuation",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90013",
-  "name": "Case Studies in Finance",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90016",
-  "name": "International Financial Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90018",
-  "name": "Corporate Financial Policy",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90046",
-  "name": "Treasury Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90047",
-  "name": "Financial Markets and Instruments",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90048",
-  "name": "Project Finance",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90049",
-  "name": "Property Development and Investment",
+  "code": "SCRN20011",
+  "name": "Hollywood and Entertainment",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE90056",
-  "name": "Investment Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90060",
-  "name": "Financial Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90062",
-  "name": "Capstone Studies in Finance",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90064",
-  "name": "Emerging Markets Finance",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90065",
-  "name": "Fundamentals of Finance",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90071",
-  "name": "DRFS Research Report Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90072",
-  "name": "DRFS Research Report Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90074",
-  "name": "Laboratory Rotation 2",
+  "code": "CHEM10007",
+  "name": "Fundamentals of Chemistry",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE90077",
-  "name": "Empirical Investments",
+  "code": "EDUC20064",
+  "name": "Concepts of Childhood",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30012",
+  "name": "Variation in Japanese Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HEBR20007",
+  "name": "Hebrew 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30010",
+  "name": "Microeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT30006",
+  "name": "Managing Entrepreneurship and Innovation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30013",
+  "name": "Gothic Fictions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90049",
+  "name": "Public /Social Policy Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN20003",
+  "name": "Applied Computation in Bioengineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90105",
+  "name": "Influence and Persuasion",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20105",
+  "name": "Shakuhachi 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "FNCE90080",
@@ -6839,699 +9815,1088 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE90082",
-  "name": "Applied Risk Management",
+  "code": "MUSI90150",
+  "name": "Music Learning, Teaching and Research",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE90083",
-  "name": "Data Analysis for Finance",
+  "code": "NURS90068",
+  "name": "Health Assessment for Adv. Practice 2",
   "offered": [
    "semester_1"
-  ]
- },
- {
-  "code": "FNCE90085",
-  "name": "Communicating Current Issues in Finance",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FNCE90086",
-  "name": "Behavioural Finance",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD10001",
-  "name": "Beer Styles and Sensory Analysis",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD20003",
-  "name": "Intro to Food Science & Human Nutrition",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD30007",
-  "name": "Food Processing & Preservation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD30008",
-  "name": "Advanced Food Analysis",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD40001",
-  "name": "Food Science Research Project Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD90010",
-  "name": "Meat and Meat Products",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD90022",
-  "name": "Food Chemistry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD90023",
-  "name": "Food Microbiology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD90029",
-  "name": "Food Engineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD90036",
-  "name": "MFPI Internship",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FOOD90037",
-  "name": "MFPI Internship Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FOOD90038",
-  "name": "MFPI Internship Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FOOD90041",
-  "name": "The Politics of Food",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FOOD90042",
-  "name": "Special Studies in Food",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FREN10001",
-  "name": "French 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN10004",
-  "name": "French 1",
-  "offered": [
-   "semester_1",
-   "winter_term"
-  ]
- },
- {
-  "code": "FREN10006",
-  "name": "French 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN20001",
-  "name": "French 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN20011",
-  "name": "French Cinema: The New Wave and Beyond",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN20012",
-  "name": "French Travel Writing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN20015",
-  "name": "French 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN20019",
-  "name": "French 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN30001",
-  "name": "French 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN30003",
-  "name": "French 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN30013",
-  "name": "French Cinema: The New Wave and Beyond",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN30014",
-  "name": "French Travel Writing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN40005",
-  "name": "French IV: Honours Language I",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FREN40010",
-  "name": "French Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FREN40011",
-  "name": "French Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FREN90003",
-  "name": "Graduate French A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FRST30003",
-  "name": "Urban Forest Ecosystems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "FRST90076",
-  "name": "Short Research Project B",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FRST90077",
-  "name": "Long Research Project B",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GDES10001",
-  "name": "Graphic Design Studio 1: Image & Text",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GDES20001",
-  "name": "Graphic Design Studio 2: Image & Media",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GDES30001",
-  "name": "Infographics Studio",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GDES30002",
-  "name": "Branding",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEND20008",
-  "name": "Sex and Gender Present and Future",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEND40006",
-  "name": "Gender Studies Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEND40007",
-  "name": "Gender Studies Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEND40008",
-  "name": "Queer Theory",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEND90011",
-  "name": "Gender and Development Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEND90012",
-  "name": "Gender and Development Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GENE10001",
-  "name": "Genetics in the Media",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GENE20001",
-  "name": "Foundations of Genetics and Genomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GENE30001",
-  "name": "Evolutionary Genetics and Genomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GENE30002",
-  "name": "Genes: Organisation and Function",
-  "offered": [
-   "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "GENE90001",
   "name": "Human Genetics & Genomics in Healthcare",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GENE90018",
-  "name": "Advanced Topics in Genetics",
+  "code": "CRIM90011",
+  "name": "Research and Criminal Justice Governance",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GENE90019",
-  "name": "Genes Molecules and Cells",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GENE90021",
-  "name": "Advanced Clinical Genomics 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GENE90026",
-  "name": "Clinical Genome Variant Analysis 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GENP40000",
-  "name": "Primary Care Research Project Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GENP40002",
-  "name": "Introduction to Primary Care Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GENP60002",
-  "name": "Preventive Health Care",
+  "code": "FNCE90047",
+  "name": "Financial Markets and Instruments",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GENP90017",
-  "name": "Immunisation and Travel Health",
+  "code": "NURS90129",
+  "name": "Nursing Science 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90045",
+  "name": "Systems Modelling and Simulation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90026",
+  "name": "Property Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10068",
+  "name": "String Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10009",
+  "name": "Foundations of Physics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90140",
+  "name": "Architectural Practice",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOG10001",
-  "name": "Famine: The Geography of Scarcity",
+  "code": "GERM20001",
+  "name": "German 7",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOG20001",
-  "name": "Society and Environments",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG20002",
-  "name": "Landscapes and Environmental Change",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG20003",
-  "name": "Environmental Politics and Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG20010",
-  "name": "China in Transition",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG20012",
-  "name": "Post-Conflict Development and Difference",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG20016",
-  "name": "Fertility, Mortality and Social Change",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG30001",
-  "name": "Geomorphology: Catchment to Coast",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG30019",
-  "name": "Sustainable Development",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG30022",
-  "name": "Riverine Landscapes: Hydrology & Ecology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG30029",
-  "name": "Geographies of Migration",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG40003",
-  "name": "Advancing Geography & Environmental Stud",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG90003",
-  "name": "Integrated River & Catchment Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOG90010",
-  "name": "Geography Research Project",
+  "code": "ARCH30002",
+  "name": "Design Studio Epsilon",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOG90011",
-  "name": "Geography Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOG90012",
-  "name": "Geography Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOG90013",
-  "name": "Geography Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOG90015",
-  "name": "Geography Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOG90018",
-  "name": "Contemporary Geographical Thought",
+  "code": "UNIB10009",
+  "name": "Food for a Healthy Planet",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOG90020",
-  "name": "Risk Management and Citizen Science",
+  "code": "BMEN30006",
+  "name": "Circuits and Systems",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOG90021",
-  "name": "Conservation and Cultural Environments",
+  "code": "EVSC30003",
+  "name": "Environmental Risk Assessment",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOG90022",
-  "name": "International Internship in Environment",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOG90028",
-  "name": "Geography Practical",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOG90030",
-  "name": "Geography Minor Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOG90031",
-  "name": "Geography Minor Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOG90032",
-  "name": "Geography Minor Research Project Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOG90033",
-  "name": "Geography Minor Research Project Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOL20002",
-  "name": "Structural and Metamorphic Geology",
+  "code": "EURO20003",
+  "name": "Memory & Memoirs of 20th Century Europe",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN30014",
+  "name": "French Travel Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS20008",
+  "name": "Legal Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE30001",
+  "name": "Investments",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM10003",
+  "name": "Islam and Muslim Societies: Introduction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PROP20002",
+  "name": "Design and Property Principles",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30020",
+  "name": "Arts Internship: Not for Profit",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20003",
+  "name": "Critical Analytical Skills",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20149",
+  "name": "Music Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM10003",
+  "name": "Chemistry 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM20006",
+  "name": "Understanding Australian Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20173",
+  "name": "The Art of Game Music",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH20001",
+  "name": "Design Studio Beta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10011",
+  "name": "The Secret Life of the Body 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "GEOL20003",
   "name": "Earth Composition, Minerals and Magmas",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOL30004",
-  "name": "Geochemistry & Petrogenesis",
+  "code": "FINA30022",
+  "name": "Space Studio",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOL30007",
-  "name": "Geobiology: Fossils & Environments",
+  "code": "PHIL20001",
+  "name": "Science, Reason and Reality",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOL90005",
+  "code": "ENGL20009",
+  "name": "The Australian Imaginary",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD20003",
+  "name": "Intro to Food Science & Human Nutrition",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC30012",
+  "name": "The Unconscious Mind",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS30004",
+  "name": "Thinking Sex",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN10005",
+  "name": "Japanese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20135",
+  "name": "Chinese Music Ensemble 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO10014",
+  "name": "Indonesia in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP10003",
+  "name": "Media Computation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JEWI20007",
+  "name": "Modern Israel: Good Bad and Disputed",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30023",
+  "name": "Space in Performance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW10001",
+  "name": "Ancient Egypt and Mesopotamia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN20002",
+  "name": "Earth Processes for Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ERTH30001",
   "name": "Hydrogeology/Environmental Geochemistry",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOL90022",
-  "name": "Practical Earth Science A",
+  "code": "BMEN30005",
+  "name": "Introduction to Biomechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS20014",
+  "name": "Intellectual Property Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS30006",
+  "name": "Global Cultures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BLAW30003",
+  "name": "Taxation Law II",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN10001",
+  "name": "Introduction to Screen Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS30005",
+  "name": "Contemporary Aboriginal Art",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST20001",
+  "name": "Human Behaviour and Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL10009",
+  "name": "Biology: Life's Machinery",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG30004",
+  "name": "Aboriginal Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20003",
+  "name": "Japanese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20068",
+  "name": "The French Revolution",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20134",
+  "name": "Melbourne Big Band 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30007",
+  "name": "Popular Fiction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING20009",
+  "name": "Language in Aboriginal Australia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW30011",
+  "name": "Underworld and Afterlife",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN30002",
+  "name": "Intro to Sustainable Water Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30007",
+  "name": "Advanced Seminar in Chinese",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL20036",
+  "name": "Environmental Building Systems",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOL90023",
-  "name": "Practical Earth Science B",
+  "code": "BCMB30011",
+  "name": "Cellular Metabolism and Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN30001",
+  "name": "Reactor Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG20006",
+  "name": "Brand Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT30004",
+  "name": "Auditing and Assurance Services",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "WELF90009",
+  "name": "Genetic Counselling Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT90012",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN30012",
+  "name": "Signals and Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ZOOL20005",
+  "name": "Animal Structure and Function",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10019",
+  "name": "Contemporary Chinese Literature",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10022",
+  "name": "Linear Algebra: Advanced",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30012",
+  "name": "Chinese Economic Documents",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30002",
+  "name": "Taiwan & Beyond: Chinese Settler Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BTCH30003",
+  "name": "Biotechnology in Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN10007",
+  "name": "Spanish 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM20003",
+  "name": "Policing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL10002",
+  "name": "Philosophy: The Big Questions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BLAW10001",
+  "name": "Principles of Business Law",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING30003",
+  "name": "First Language Acquisition",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM30002",
+  "name": "Econometrics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING10002",
+  "name": "Intercultural Communication",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PLAN30003",
+  "name": "Research Methods for Planners",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10047",
+  "name": "Music History 1: Monteverdi to Mozart",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10004",
+  "name": "Introductory Microeconomics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30001",
+  "name": "International Trade Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90005",
+  "name": "Audio Journalism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM20003",
+  "name": "German Cultural Studies B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR20005",
+  "name": "Numerical Methods in Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR90016",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO30005",
+  "name": "Web Information Technologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO30020",
+  "name": "Indonesia in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT30007",
+  "name": "Human Locomotor Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB30012",
+  "name": "Current Advances in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT40001",
+  "name": "Anatomy & Neurosci Research Proj Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HLTH90014",
+  "name": "Healthcare Research-Principles & Designs",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE20001",
+  "name": "Foundations of Genetics and Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL30002",
+  "name": "Actuarial Modelling II",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20012",
+  "name": "Variation in Japanese Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN30010",
+  "name": "Systems Modelling and Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYS40005",
+  "name": "Physiology Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT90013",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS30013",
+  "name": "Latin 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR30003",
+  "name": "Principles of Neuroscience",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20015",
+  "name": "Literature: Reading Indonesian Lives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT90014",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL30001",
+  "name": "Italian 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90013",
+  "name": "Theory of Financial Accounting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90284",
+  "name": "Master of Architecture Studio A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90025",
+  "name": "Documentary Projects 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV70043",
+  "name": "Writing for Television",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT90038",
+  "name": "Food Production for Urban Landscapes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90018",
+  "name": "Sociolinguistics and Language Learning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90007",
+  "name": "Chemical Engineering Thermodynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90045",
+  "name": "Residential Land Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI90016",
+  "name": "Creative Writing Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90016",
+  "name": "Actuarial Science Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40070",
+  "name": "Professional Project (Ethnomusicology)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90023",
+  "name": "Translation Technologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90121",
+  "name": "Vet Bioscience: Cells to Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90032",
+  "name": "Advanced Linguistics Analysis B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN90005",
+  "name": "Graduate Chinese A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40002",
+  "name": "Recent European Philosophy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90382",
+  "name": "Urban and Cultural Heritage Minor Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40015",
+  "name": "American Fiction: The 20th Century",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NRMT10007",
+  "name": "Land Resources and Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90078",
+  "name": "Contemporary Landscape Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40111",
+  "name": "Honours Music Studies 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS20021",
+  "name": "Arts of East Asia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
  },
  {
   "code": "GEOL90024",
@@ -7539,37 +10904,889 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOL90025",
-  "name": "Research Project In Geoscience",
+  "code": "FLTV90026",
+  "name": "Screen Language 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90020",
+  "name": "Directing Methodologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS40001",
+  "name": "Cultural Policy and Power",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90023",
+  "name": "Research Project",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOM20013",
-  "name": "Applications of GIS",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOM30009",
-  "name": "Imaging the Environment",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOM90008",
-  "name": "Foundations of Spatial Information",
+  "code": "BIOM90012",
+  "name": "Research Project (SBS)",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90013",
+  "name": "Research Proposal 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90065",
+  "name": "Managing Global City Regions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST90023",
+  "name": "The Writing of Australian History",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90012",
+  "name": "Corporate Restructuring and Valuation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90041",
+  "name": "Property Law (PG)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90039",
+  "name": "Mediation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90028",
+  "name": "Robotics Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOTH40001",
+  "name": "Relationships in Modernity",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90028",
+  "name": "Project Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90989",
+  "name": "Capstone Professional Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90218",
+  "name": "Constitutions in Global Perspective",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90019",
+  "name": "Journalism Project (Extended) Part 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NUTR40001",
+  "name": "Human Nutrition Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90022",
+  "name": "Economics for Actuaries",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYS90008",
+  "name": "Advanced Seminars in Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90066",
+  "name": "Foundations of Nursing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST90077",
+  "name": "Long Research Project B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN40007",
+  "name": "Chinese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90019",
+  "name": "Minor Thesis 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90013",
+  "name": "Translation and Interpreting Thesis 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90023",
+  "name": "Food Microbiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90041",
+  "name": "Fundamentals in Accounting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM10032",
+  "name": "Contextual Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30260",
+  "name": "Medieval and Renaissance Ensemble 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM10001",
+  "name": "Discovering Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90038",
+  "name": "Biomechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40018",
+  "name": "Economics Research Essay Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90307",
+  "name": "MSD Vocational Placement",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "may",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90118",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90004",
+  "name": "Evaluating the User Experience",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90119",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN90016",
+  "name": "Software Processes and Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90032",
+  "name": "Geography Minor Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90133",
+  "name": "Animal Production Systems: Epidemiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW40017",
+  "name": "Ancient World Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI40014",
+  "name": "Biomedicine Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90120",
+  "name": "Vet Bioscience: Digestive System",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40011",
+  "name": "Graphic Narratives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE40002",
+  "name": "Advanced Investments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90238",
+  "name": "Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90013",
+  "name": "Social Policy Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90081",
+  "name": "Computer Science Research Project Part 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40081",
+  "name": "Honours Chamber Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90031",
+  "name": "Enumerative Combinatorics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90054",
+  "name": "International Relations Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90030",
+  "name": "Managing Innovation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS30009",
+  "name": "Production Practice 3 - Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90027",
+  "name": "Interdisciplinary Industry Project 2",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90054",
+  "name": "Development Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90032",
+  "name": "Sustainability and Behaviour Change",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL40001",
+  "name": "Oral Health Research Project 4A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90060",
+  "name": "Applications in Animal Health A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90024",
+  "name": "Forecasting in Economics and Business",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MREN90003",
+  "name": "Electronic and Magnetic Materials",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90123",
+  "name": "Longitudinal and Correlated Data",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT10016",
+  "name": "Reason",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL90021",
+  "name": "Critical and Creative Thinking",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90003",
+  "name": "The Political Ecology of Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS40024",
+  "name": "Art History Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS90001",
+  "name": "Design Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA40005",
+  "name": "Asian Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90009",
+  "name": "HCI Project (Advanced)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90002",
+  "name": "Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90029",
+  "name": "Media and Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90286",
+  "name": "Professional Practice - Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90039",
+  "name": "CPR, Eye Emergencies & Practical ECC",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI10045",
+  "name": "Foundations of Agricultural Sciences 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG40003",
+  "name": "Indigenous Studies Thesis Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90006",
+  "name": "Environmental Research Review (12.5)",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90022",
+  "name": "Translation Industry Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20025",
+  "name": "Minor Music Performance 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ESLA90003",
+  "name": "Professional Literacies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90029",
+  "name": "Criminology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90032",
+  "name": "Biomed Eng Capstone Proj Part 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90031",
+  "name": "Criminology & Sociology Internship Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90001",
+  "name": "Basic Econometrics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CREA90014",
+  "name": "Creative Arts Therapies Research 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT40011",
+  "name": "Oral Health Sci Research Proj Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90405",
+  "name": "Energy & Carbon in the Built Environment",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90088",
+  "name": "Graduate Research Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90033",
+  "name": "Solar Energy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90031",
+  "name": "Project Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90115",
+  "name": "Information Systems Res Project Pt 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC40018",
+  "name": "HPS Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40103",
+  "name": "Figured Bass Realisation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90058",
+  "name": "Asia-Pacific: Zone of Conflict or Peace?",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA90004",
+  "name": "Critical Asian Perspectives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90013",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20178",
+  "name": "Individual Performance Studies 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30022",
+  "name": "Special Studies",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM90007",
+  "name": "Environmental Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO20005",
+  "name": "User Interface Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "OTOL40001",
+  "name": "Otolaryngology Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90038",
+  "name": "Researching Media & Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40071",
+  "name": "Professional Project (Musicology)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20008",
+  "name": "Music Technology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40022",
+  "name": "Philosophy Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10011",
+  "name": "Experimental Design and Data Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "GEOM90010",
@@ -7579,915 +11796,282 @@
    "semester_1",
    "winter_term",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOM90013",
-  "name": "Spatial Information Research Project C",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90018",
-  "name": "Spatial Databases",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOM90020",
-  "name": "Spatial Information Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90023",
-  "name": "Spatial Information Research Project B",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90031",
-  "name": "Spatial Information Research Project D",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90038",
-  "name": "Advanced Imaging",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOM90039",
-  "name": "Advanced Surveying and Mapping",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOM90042",
-  "name": "Spatial Information Programming",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GEOM90043",
-  "name": "Spatial IT Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90045",
-  "name": "Residential Land Development",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM10001",
-  "name": "German 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM10004",
-  "name": "German 1",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term"
-  ]
- },
- {
-  "code": "GERM10006",
-  "name": "German 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM10008",
-  "name": "German 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM20001",
-  "name": "German 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM20003",
-  "name": "German Cultural Studies B",
+  "code": "PSYC90005",
+  "name": "Thesis (Masters/coursework)",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GERM20004",
-  "name": "German 3",
+  "code": "ABPL90421",
+  "name": "Design - Philosophy - Architecture",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GERM20007",
-  "name": "German 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM20009",
-  "name": "German 9",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM30001",
-  "name": "German Cultural Studies B",
+  "code": "MECM90033",
+  "name": "Marketing Communications Thesis Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GERM30002",
-  "name": "German Cultural Studies C",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM30003",
-  "name": "German 9",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM30005",
-  "name": "German 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM30021",
-  "name": "German 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM40010",
-  "name": "German Honours Language",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "GERM40016",
-  "name": "German Thesis Part 1",
+  "code": "GEND40006",
+  "name": "Gender Studies Thesis Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GERM40017",
-  "name": "German Thesis Part 2",
+  "code": "PHTY90040",
+  "name": "Physiotherapy Professional Portfolio",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GERM90003",
-  "name": "Graduate German A",
+  "code": "POPH90292",
+  "name": "M.Epidemiology Research Project - S",
   "offered": [
-   "semester_1"
-  ]
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
-  "code": "HEBR10001",
-  "name": "Hebrew 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HEBR10005",
-  "name": "Hebrew 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HEBR10011",
-  "name": "Hebrew 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HEBR20005",
-  "name": "Hebrew 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HEBR20007",
-  "name": "Hebrew 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HEBR30003",
-  "name": "Hebrew 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST10012",
-  "name": "The World Since World War II",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST10016",
-  "name": "Europe: From Black Death to New Worlds",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST20013",
-  "name": "The Holocaust & Genocide",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST20034",
-  "name": "Modern Southeast Asia",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST20059",
-  "name": "American History: Revolution to WWII",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST20065",
-  "name": "Rebels and Revolutionaries",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST20068",
-  "name": "The French Revolution",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST20072",
-  "name": "Pirates and their Enemies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST20089",
-  "name": "Britain's Empire: Power and Resistance",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST30015",
-  "name": "The Modern Middle East",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST30068",
-  "name": "A History of Violence",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST30074",
-  "name": "Global Histories of Indigenous Activism",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST30075",
-  "name": "Gender in History, 1800 to the Present",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST30076",
-  "name": "Stalinism",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST40030",
-  "name": "History for Historians",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST40039",
-  "name": "History Thesis Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST90023",
-  "name": "The Writing of Australian History",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST90024",
-  "name": "International History",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HIST90034",
+  "code": "ASIA90012",
   "name": "International Relations Thesis Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "HIST90035",
-  "name": "International Relations Thesis Part 2",
+  "code": "ACCT90015",
+  "name": "Legal Issues for Business",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV70030",
+  "name": "Narrative Projects 2A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90274",
+  "name": "Property Markets and Valuations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CONS30001",
+  "name": "Building Information Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90012",
+  "name": "Corporate Reporting",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "HLTH90006",
-  "name": "Basics of Digital Health for Clinicians",
+  "code": "FNCE90065",
+  "name": "Fundamentals of Finance",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "HLTH90014",
-  "name": "Healthcare Research-Principles & Designs",
+  "code": "MUSI30047",
+  "name": "Music Analysis",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "HLTH90019",
-  "name": "Indigenous Health and Nursing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HORT90008",
-  "name": "Horticultural Plant Science",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HORT90033",
-  "name": "Plants in the Landscape",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HORT90034",
-  "name": "Landscape Design",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HORT90038",
-  "name": "Food Production for Urban Landscapes",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HPSC10002",
-  "name": "Science and Pseudoscience",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HPSC20009",
-  "name": "Technology & Contemporary Life",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HPSC30023",
-  "name": "Science and Society",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HPSC30034",
-  "name": "Magic, Reason, New Worlds, 1450-1750",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HPSC40016",
-  "name": "History and Philosophy of Science",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "HPSC40018",
-  "name": "HPS Thesis Part 1",
+  "code": "VETS90037",
+  "name": "Abdominal & Urogenital Emergencies",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "HPSC40019",
-  "name": "HPS Thesis Part 2",
+  "code": "DENT90038",
+  "name": "Advanced Clinical Practice 4",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS40023",
+  "name": "Art History Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "HPSC90010",
   "name": "Environment and Knowledge",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "HPSC90013",
-  "name": "Science, Controversy and Public Policy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "IBUS90001",
-  "name": "Global Strategy",
+  "code": "POPH90288",
+  "name": "Biostatistics Research Project Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "IBUS90002",
-  "name": "Managing in Asia",
+  "code": "MUSI40104",
+  "name": "Dissertation Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "IBUS90003",
-  "name": "The Multinational",
+  "code": "MUSI90038",
+  "name": "Clinical Training in Music Therapy 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90008",
+  "name": "Statistical Techniques in Insurance",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "INDG10001",
-  "name": "Indigenous Australia",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDG20001",
-  "name": "Indigenous Treaties and Titles",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDG20004",
-  "name": "Racial Literacy: Indigeneity & Whiteness",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDG30002",
-  "name": "Indigenous Cultural Heritage",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDG30004",
-  "name": "Aboriginal Writing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDG40002",
-  "name": "Textual Revelations",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDG40003",
-  "name": "Indigenous Studies Thesis Pt1",
+  "code": "FNCE90060",
+  "name": "Financial Management",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "INDG40004",
-  "name": "Indigenous Studies Thesis Pt2",
+  "code": "AUDI90051",
+  "name": "Principles of Paediatric Audiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90085",
+  "name": "Volunteer Experience in I.T.",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "INDO10001",
-  "name": "Indonesian 3",
+  "code": "MUSI90036",
+  "name": "Music Psychology Research",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "INDO10003",
-  "name": "Indonesian 5",
+  "code": "PSYC90101",
+  "name": "Advanced Social Psychology",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "INDO10005",
-  "name": "Indonesian 1",
+  "code": "ARTS90014",
+  "name": "Researching Politics and Policy",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "INDO10012",
-  "name": "Literature: Reading Indonesian Lives",
+  "code": "MAST90084",
+  "name": "Statistical Modelling",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "INDO10014",
-  "name": "Indonesia in the World",
+  "code": "JAPN90002",
+  "name": "Graduate Japanese A",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "INDO20006",
-  "name": "Indonesian 3",
+  "code": "ENST90043",
+  "name": "Sustainable Landscapes",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "INDO20008",
-  "name": "Indonesian 5",
+  "code": "ABPL90066",
+  "name": "MSD Research Project Short (12.5 Points)",
   "offered": [
    "semester_1"
-  ]
- },
- {
-  "code": "INDO20015",
-  "name": "Literature: Reading Indonesian Lives",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDO20017",
-  "name": "Indonesia in the World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDO30006",
-  "name": "Literature: Reading Indonesian Lives",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDO30011",
-  "name": "Indonesian 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDO30020",
-  "name": "Indonesia in the World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDO40001",
-  "name": "Honours Indonesian A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INDO40003",
-  "name": "Topics in Indonesian Studies",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "INDO40008",
-  "name": "Indonesian Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "INDO40009",
-  "name": "Indonesian Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "INDO90002",
-  "name": "Graduate Indonesian A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INFO20003",
-  "name": "Database Systems",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "INFO20005",
-  "name": "User Interface Development",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INFO30005",
-  "name": "Web Information Technologies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INFO30009",
-  "name": "Game Design",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INFO90002",
-  "name": "Database Systems & Information Modelling",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "INFO90003",
-  "name": "Designing Novel Interactions",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INFO90004",
-  "name": "Evaluating the User Experience",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "INFO90008",
-  "name": "HCI Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "INFO90009",
-  "name": "HCI Project (Advanced)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "INFO90010",
-  "name": "Technology Innovation Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ISLM10003",
-  "name": "Islam and Muslim Societies: Introduction",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ISLM20016",
-  "name": "Introduction to Islamic Spirituality",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ISLM30018",
-  "name": "Diplomacy: Engaging the Muslim World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ISLM40001",
-  "name": "Topics in Arabic & Islamic Studies",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ISLM40011",
-  "name": "Islamic Studies Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ISLM40012",
-  "name": "Islamic Studies Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ISYS90026",
-  "name": "Fundamentals of Information Systems",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ISYS90032",
-  "name": "Emerging Technologies and Issues",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ISYS90035",
-  "name": "Knowledge Management Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ISYS90036",
-  "name": "Enterprise Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ISYS90038",
-  "name": "IS Strategy and Governance",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ISYS90043",
-  "name": "Enterprise Applications & Architectures",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ISYS90045",
-  "name": "Professional IS Consulting",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ISYS90048",
-  "name": "Managing ICT Infrastructure",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ISYS90049",
-  "name": "Digital Business Analysis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "ISYS90050",
@@ -8495,503 +12079,454 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90051",
-  "name": "Impact of Digitisation",
+  "code": "MUSI90198",
+  "name": "Professional Research Project Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90069",
-  "name": "Digital Transformation of Health",
+  "code": "SOLS40002",
+  "name": "Socio-Legal Studies Thesis Part 1",
   "offered": [
    "semester_1",
-   "june"
-  ]
+   "semester_2"
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90076",
-  "name": "IT Infrastructure for Digital Health",
+  "code": "GEOM90042",
+  "name": "Spatial Information Programming",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90077",
-  "name": "Designing Digital Health Solutions",
+  "code": "COMP90080",
+  "name": "Computer Science Research Project Part 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90067",
+  "name": "MSD Thesis -Semester Long (25 Points)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90078",
+  "name": "Internship for Agricultural Sciences",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90016",
+  "name": "Asset Management",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90079",
-  "name": "Health IT Project",
+  "code": "ACCT90002",
+  "name": "Financial Statement Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90002",
+  "name": "Microeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90039",
+  "name": "Understanding Media & Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST40030",
+  "name": "History for Historians",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90951",
+  "name": "Understanding Education Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90122",
+  "name": "Inference for Spatio-Temporal Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90148",
+  "name": "Probability and Distribution Theory",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40003",
+  "name": "Researching Audiences and Reception",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90020",
+  "name": "Risk Management and Citizen Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90363",
+  "name": "Property Research and Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO40003",
+  "name": "Topics in Indonesian Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90221",
+  "name": "Orchestral Performance Practicum 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS40009",
+  "name": "Russian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10016",
+  "name": "Mathematics for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ESLA90001",
+  "name": "Professional Speaking Communication",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN40006",
+  "name": "Chinese Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL40010",
+  "name": "Research Project - RMH Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30020",
+  "name": "Chamber Music 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90024",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING40016",
+  "name": "LAL Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90306",
+  "name": "MUP Independent Study",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90081",
-  "name": "Business Process Management",
+  "code": "LAWS90209",
+  "name": "Indigenous Legal Advocacy Clinic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90025",
+  "name": "Grattan Street Press (Extended)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90223",
+  "name": "Design Thinking",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90017",
+  "name": "Advanced Motion Control",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90057",
+  "name": "Advanced Valve and Aortic Pathology",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90100",
-  "name": "Information Systems Maj Res Project Pt 1",
+  "code": "MUSI40080",
+  "name": "Honours Ensemble 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90101",
-  "name": "Information Systems Maj Res Project Pt 1",
+  "code": "MUSI30163",
+  "name": "Baroque Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL40002",
+  "name": "Oral Health Research Project 4B",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90102",
-  "name": "Information Systems Maj Res Project Pt 1",
+  "code": "MAST90077",
+  "name": "Research Project Part C",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90103",
-  "name": "Information Systems Maj Res Project Pt 1",
+  "code": "MGMT90206",
+  "name": "Management & Marketing Special Topics 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90104",
-  "name": "Information Systems Maj Res Project Pt 2",
+  "code": "IBUS90003",
+  "name": "The Multinational",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90105",
-  "name": "Information Systems Maj Res Project Pt 2",
+  "code": "ECON90055",
+  "name": "Computational Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90053",
+  "name": "Clients with Complex Health States",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90058",
+  "name": "Industrial Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT40003",
+  "name": "Advances in Oral Health Research",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90106",
-  "name": "Information Systems Maj Res Project Pt 2",
+  "code": "PSYC90106",
+  "name": "Research Project",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90107",
-  "name": "Information Systems Maj Res Project Pt 3",
+  "code": "MULT90059",
+  "name": "Social Enterprise Incubator",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90108",
-  "name": "Information Systems Maj Res Project Pt 3",
+  "code": "MGMT90013",
+  "name": "Leadership and Team Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90033",
+  "name": "Law Apps",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90109",
-  "name": "Information Systems Min Res Project Pt 1",
+  "code": "MGMT10003",
+  "name": "Organisation and Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90027",
+  "name": "International Human Resources",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90110",
-  "name": "Information Systems Min Res Project Pt 2",
+  "code": "ACTL90018",
+  "name": "General Insurance Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90009",
+  "name": "International Relations Internship",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ISYS90112",
-  "name": "Business Process Analytics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL10001",
-  "name": "Italian 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL10004",
-  "name": "Italian 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL10006",
-  "name": "Italian 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL10009",
-  "name": "Italian 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL20002",
-  "name": "Italian 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL20007",
-  "name": "Italian 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL20011",
-  "name": "Italian 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL20012",
-  "name": "Italian 9",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL30001",
-  "name": "Italian 9",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL30003",
-  "name": "Italian 5A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL30007",
-  "name": "To Hell with Dante",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL30013",
-  "name": "Italian 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL30015",
-  "name": "Italian 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL40001",
-  "name": "Italian Honours Language Seminar 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ITAL40015",
-  "name": "Italian Thesis Part 1",
+  "code": "FNCE90056",
+  "name": "Investment Management",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "ITAL40016",
-  "name": "Italian Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ITAL90003",
-  "name": "Graduate Italian A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN10001",
-  "name": "Japanese 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN10003",
-  "name": "Japanese 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN10005",
-  "name": "Japanese 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN10007",
-  "name": "Japanese 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN10010",
-  "name": "Variation in Japanese Language",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN20003",
-  "name": "Japanese 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN20005",
-  "name": "Contemporary Japan",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN20007",
-  "name": "Japanese 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN20009",
-  "name": "Signs and Symbols in Japanese",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN20012",
-  "name": "Variation in Japanese Language",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN20013",
-  "name": "Japanese 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN20018",
-  "name": "Japanese Through the Media",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN30004",
-  "name": "Japanese through the Media",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN30005",
-  "name": "Japanese 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN30007",
-  "name": "Japanese 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN30010",
-  "name": "Signs and Symbols in Japanese",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN30012",
-  "name": "Variation in Japanese Language",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN40001",
-  "name": "Honours Japanese A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN40003",
-  "name": "Topics in Japanese Studies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JAPN40008",
-  "name": "Japanese Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "JAPN40009",
-  "name": "Japanese Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "JAPN90002",
-  "name": "Graduate Japanese A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JEWI20007",
-  "name": "Modern Israel: Good Bad and Disputed",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JOUR90001",
-  "name": "Researching/Writing Stories",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "JOUR90003",
-  "name": "Journalism Internship",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "JOUR90005",
-  "name": "Audio Journalism",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JOUR90010",
-  "name": "Newsroom-Applied Professional Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JOUR90015",
-  "name": "Journalism Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "JOUR90016",
-  "name": "Journalism Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "JOUR90017",
-  "name": "Journalism Project (Extended) Part 1",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "JOUR90018",
-  "name": "Journalism Project (Extended) Part 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JOUR90019",
-  "name": "Journalism Project (Extended) Part 3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "JOUR90020",
@@ -8999,179 +12534,186 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "JOUR90021",
-  "name": "International Traditions in Journalism",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "JOUR90025",
-  "name": "Journalism Project Part 1",
+  "code": "ARBC40007",
+  "name": "Arabic Studies Thesis Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "JOUR90026",
-  "name": "Journalism Project Part 2",
+  "code": "ATOC90013",
+  "name": "Atmospheric Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90072",
+  "name": "The Art of Scientific Computation",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "KORE10001",
-  "name": "Korean 1",
+  "code": "ABPL90369",
+  "name": "Architecture as Spectacle",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "KORE10003",
-  "name": "Korean 3",
+  "code": "ARTS90033",
+  "name": "Arts Research Internship",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "KORE20003",
-  "name": "Korean 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "KORE30002",
-  "name": "Two Koreas in the World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LANG40003",
-  "name": "Seminar in Languages 1",
+  "code": "CRIM40009",
+  "name": "Criminology Thesis Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LANG40004",
-  "name": "Seminar in Languages 2",
+  "code": "HPSC40019",
+  "name": "HPS Thesis Part 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LARC30001",
-  "name": "Site Tectonics",
+  "code": "AGRI10047",
+  "name": "Agriculture in Australia",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS20008",
-  "name": "Legal Language",
+  "code": "ABPL90034",
+  "name": "Property Securitisation",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS20014",
-  "name": "Intellectual Property Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50024",
-  "name": "Principles of Public Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50025",
-  "name": "Torts",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50026",
-  "name": "Obligations",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50030",
-  "name": "Property",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50032",
-  "name": "Administrative Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50036",
-  "name": "Remedies",
-  "offered": [
-   "semester_1",
-   "november"
-  ]
- },
- {
-  "code": "LAWS50037",
-  "name": "Evidence and Proof",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "LAWS50039",
-  "name": "Legal Research",
+  "code": "MUSI40107",
+  "name": "Capstone Music Project Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS50046",
-  "name": "Taxation Law and Policy",
+  "code": "MAST90060",
+  "name": "Mathematical Statistical Mechanics",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS50055",
-  "name": "Advocacy",
+  "code": "PUBL90003",
+  "name": "The Contemporary Publishing Industry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MREN90005",
+  "name": "Materials Engineering Research Project",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS50058",
-  "name": "Melbourne University Law Review",
+  "code": "MUSI20104",
+  "name": "Shakuhachi 1",
   "offered": [
-   "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40055",
+  "name": "Music Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90009",
+  "name": "Judging Crime",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90014",
+  "name": "Auditing and Assurance Services",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90288",
+  "name": "Architectural Cultures 1: Modernism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM30016",
+  "name": "Digital Media Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90052",
+  "name": "Advanced Signal Processing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90149",
+  "name": "Applied Instrumental and Vocal Teaching",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "LAWS50059",
@@ -9182,307 +12724,117 @@
    "june",
    "semester_2",
    "november"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS50060",
-  "name": "Melbourne Journal of International Law",
+  "code": "MUSI20215",
+  "name": "Medieval and Renaissance Ensemble 3",
   "offered": [
-   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10010",
+  "name": "Indigenous Astronomy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40002",
+  "name": "Advanced Macroeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYS30010",
+  "name": "Advanced Human Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90069",
+  "name": "Digital Transformation of Health",
+  "offered": [
    "semester_1",
-   "semester_2"
-  ]
+   "june"
+  ],
+  "online": false
  },
  {
-  "code": "LAWS50063",
-  "name": "Competition Law",
+  "code": "VETS90122",
+  "name": "Intro to the Veterinary Profession",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS50064",
-  "name": "Employment Law",
-  "offered": [
-   "february",
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50068",
-  "name": "Equality and Discrimination Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50075",
-  "name": "Trade Mark Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50078",
-  "name": "Environmental Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50094",
-  "name": "International Commercial Law & Disputes",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50101",
-  "name": "Refugee Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50119",
-  "name": "Sports Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50127",
-  "name": "Philosophical Foundations of Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS50130",
-  "name": "Advanced Torts",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS70003",
-  "name": "Minor Thesis (LLM) # P/T",
+  "code": "PSYC90117",
+  "name": "Research Project (Psych)",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70006",
-  "name": "International Tax: Principles, Structure",
-  "offered": [
-   "semester_1",
-   "november"
-  ]
- },
- {
-  "code": "LAWS70015",
-  "name": "Minor Thesis F/T LLM",
+  "code": "PSYC90120",
+  "name": "Research Project (Psych)",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70067",
-  "name": "International Legal Internship",
+  "code": "ECON90032",
+  "name": "Macroeconomics for Managers",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90010",
+  "name": "Technology Innovation Project",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70318",
-  "name": "Tax Practice: Writing Effectively",
+  "code": "ENGR90040",
+  "name": "Film and Engineering at the Crossroads",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70469",
-  "name": "Construction Law",
+  "code": "PADM20001",
+  "name": "Foundations of Digital Government",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS90033",
-  "name": "Law Apps",
+  "code": "ELEN90057",
+  "name": "Communication Systems",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "LAWS90039",
-  "name": "Mediation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS90074",
-  "name": "Copyright and Designs",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS90164",
-  "name": "MLS Tax Clinic",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "LAWS90209",
-  "name": "Indigenous Legal Advocacy Clinic",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS90212",
-  "name": "Law and Civil Society in Asia",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS90218",
-  "name": "Constitutions in Global Perspective",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LAWS90228",
-  "name": "International Capital Markets",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING10002",
-  "name": "Intercultural Communication",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING20005",
-  "name": "Phonetics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING20009",
-  "name": "Language in Aboriginal Australia",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING20011",
-  "name": "Grammar of English",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING30003",
-  "name": "First Language Acquisition",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING30007",
-  "name": "Semantics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING30014",
-  "name": "Australian Indigenous Languages",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING40002",
-  "name": "Issues in Linguistic Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING40008",
-  "name": "Experimental Phonetics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING40015",
-  "name": "LAL Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "LING40016",
-  "name": "LAL Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "LING90002",
-  "name": "Presenting Academic Discourse",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "LING90003",
-  "name": "Research in Applied Linguistics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING90005",
-  "name": "Quantitative Methods in Language Studies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING90009",
-  "name": "Language Testing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING90010",
-  "name": "Applied Linguistics Thesis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LING90012",
@@ -9490,658 +12842,448 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LING90016",
-  "name": "Grammar in Use",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING90018",
-  "name": "Sociolinguistics and Language Learning",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING90031",
-  "name": "Advanced Linguistics Analysis A",
+  "code": "MUSI90154",
+  "name": "Professional Practice 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LING90032",
-  "name": "Advanced Linguistics Analysis B",
+  "code": "MUSI30174",
+  "name": "Conservatorium Choir 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30265",
+  "name": "Italian Lyric Diction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90034",
+  "name": "Creating Innovative Engineering",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "LING90033",
-  "name": "Linguistics for Speech Pathology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "LING90039",
-  "name": "Concepts in Applied Linguistics",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "LTAM10001",
-  "name": "Latin America: Past, Politics & Culture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST10005",
-  "name": "Calculus 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST10006",
-  "name": "Calculus 2",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST10007",
-  "name": "Linear Algebra",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST10008",
-  "name": "Accelerated Mathematics 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST10011",
-  "name": "Experimental Design and Data Analysis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST10012",
-  "name": "Introduction to Mathematics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST10014",
-  "name": "Foundation Mathematics 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST10016",
-  "name": "Mathematics for Biomedicine",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST10022",
-  "name": "Linear Algebra: Advanced",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST20004",
-  "name": "Probability",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST20006",
-  "name": "Probability for Statistics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST20009",
-  "name": "Vector Calculus",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST20026",
-  "name": "Real Analysis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST20029",
-  "name": "Engineering Mathematics",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST20031",
-  "name": "Analysis of Biological Data",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST20032",
-  "name": "Vector Calculus: Advanced",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST20033",
-  "name": "Real Analysis: Advanced",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST30005",
-  "name": "Algebra",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST30011",
-  "name": "Graph Theory",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST30013",
-  "name": "Techniques in Operations Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST30020",
-  "name": "Probability for Inference",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST30021",
-  "name": "Complex Analysis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST30025",
-  "name": "Linear Statistical Models",
-  "offered": [
-   "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MAST30030",
   "name": "Applied Mathematical Modelling",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC30021",
+  "name": "Laboratory and Computational Physics 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "MAST30032",
   "name": "Biological Modelling and Simulation",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MAST90012",
-  "name": "Measure Theory",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90014",
-  "name": "Optimisation for Industry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90019",
-  "name": "Random Processes",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90029",
-  "name": "Differential Topology and Geometry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90031",
-  "name": "Enumerative Combinatorics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90042",
-  "name": "Research Project",
+  "code": "DEVT90008",
+  "name": "International Internship in Development",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MAST90044",
-  "name": "Thinking and Reasoning with Data",
+  "code": "HORT90034",
+  "name": "Landscape Design",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT90008",
+  "name": "Horticultural Plant Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90028",
+  "name": "Chemical Engineering Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV70020",
+  "name": "Narrative Projects 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG10001",
+  "name": "Famine: The Geography of Scarcity",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI30013",
+  "name": "Survey Design and Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC90003",
+  "name": "Graduate Arabic A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "KORE30002",
+  "name": "Two Koreas in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90036",
+  "name": "Enterprise Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CCDP10002",
+  "name": "The Electronic Arts: Vision and Sound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO40002",
+  "name": "Seminars in Languages and Linguistics A",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE10030",
+  "name": "Dance Lab 1: Studio Practices",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "KORE10001",
+  "name": "Korean 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BTCH30002",
+  "name": "Trends & Issues in Agrifood Biotech",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENVS10006",
+  "name": "Mapping Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PLAN30004",
+  "name": "Transit Oriented Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG20016",
+  "name": "Fertility, Mortality and Social Change",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC30019",
+  "name": "Astrophysics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90033",
+  "name": "Integrated Accounting Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90606",
+  "name": "Engagement and the Arts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90008",
+  "name": "HCI Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90049",
+  "name": "Introduction to Machine Learning",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE20034",
+  "name": "Dance Lab 3: Repertory Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE30026",
+  "name": "Dance Lab 5: Dance and Music",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE20035",
+  "name": "Knowing Dance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90309",
+  "name": "Supply Chains in Construction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30003",
+  "name": "Public Affairs Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM30016",
+  "name": "Reactivity and Mechanism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90080",
+  "name": "Applied Investment Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90047",
+  "name": "Financial Markets and Instruments",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90150",
+  "name": "Music Learning, Teaching and Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90129",
+  "name": "Nursing Science 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90068",
+  "name": "Health Assessment for Adv. Practice 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE90001",
+  "name": "Human Genetics & Genomics in Healthcare",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
  },
  {
   "code": "MAST90045",
   "name": "Systems Modelling and Simulation",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MAST90046",
-  "name": "Research Project",
+  "code": "ABPL90026",
+  "name": "Property Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10009",
+  "name": "Foundations of Physics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90140",
+  "name": "Architectural Practice",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MAST90047",
-  "name": "Research Project",
+  "code": "MUSI10068",
+  "name": "String Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH30002",
+  "name": "Design Studio Epsilon",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MAST90048",
-  "name": "Research Project",
+  "code": "GERM20001",
+  "name": "German 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10009",
+  "name": "Food for a Healthy Planet",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL20033",
+  "name": "Construction Analysis",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "MAST90057",
-  "name": "Elements of Probability",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90059",
-  "name": "Stochastic Calculus with Applications",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90060",
-  "name": "Mathematical Statistical Mechanics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90064",
-  "name": "Advanced Methods: Differential Equations",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90072",
-  "name": "Data and Decision Making",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90073",
-  "name": "Minor Research Project Part A",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST90074",
-  "name": "Minor Research Project Part B",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST90075",
-  "name": "Research Project Part A",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST90076",
-  "name": "Research Project Part B",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST90077",
-  "name": "Research Project Part C",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST90082",
-  "name": "Mathematical Statistics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90084",
-  "name": "Statistical Modelling",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90101",
-  "name": "Introduction to Statistical Computing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90105",
-  "name": "Methods of Mathematical Statistics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90106",
-  "name": "Data Science Project Pt1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90108",
-  "name": "Data Science Research Project Pt1",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST90109",
-  "name": "Data Science Research Project Pt2",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST90122",
-  "name": "Inference for Spatio-Temporal Processes",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90127",
-  "name": "Advanced Biological Modelling: Dynamics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90132",
-  "name": "Lie Algebras",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90137",
-  "name": "Mathematical Game Theory",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MAST90139",
-  "name": "Statistical Modelling for Data Science",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN30017",
-  "name": "Mechanics & Materials",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MCEN30018",
-  "name": "Thermodynamics and Fluid Mechanics",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MCEN30020",
-  "name": "Systems Modelling and Analysis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MCEN30021",
-  "name": "Mechanical Systems Design",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MCEN90012",
-  "name": "Design for Manufacture",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90014",
-  "name": "Materials",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90015",
-  "name": "Thermodynamics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90017",
-  "name": "Advanced Motion Control",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90018",
-  "name": "Advanced Fluid Dynamics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90028",
-  "name": "Robotics Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90029",
-  "name": "Advanced Solid Mechanics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90032",
-  "name": "Sensor Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90036",
-  "name": "Capstone Project A",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MCEN90038",
-  "name": "Dynamics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90045",
-  "name": "Aerospace Dynamics and Control",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90048",
-  "name": "Artificial Intelligence for Engineers",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90054",
-  "name": "Design and Manufacturing Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90055",
-  "name": "Manufacturing Processes and Technology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MCEN90058",
-  "name": "Industrial Engineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MECM10003",
-  "name": "Media and Society",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MECM10005",
-  "name": "Academic Writing and Communication",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM20006",
-  "name": "Understanding Australian Media",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MECM20010",
-  "name": "Comparing Media Systems",
-  "offered": [
-   "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MECM20012",
@@ -10150,1563 +13292,190 @@
    "february",
    "semester_1",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM20013",
-  "name": "Text and Audio Journalism",
+  "code": "BMEN30006",
+  "name": "Circuits and Systems",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM30015",
-  "name": "Media and Communications Project",
+  "code": "ZOOL20004",
+  "name": "Australian Wildlife Biology",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM30016",
-  "name": "Digital Media Research",
+  "code": "EDUC20068",
+  "name": "Sport, Education and the Media",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI30006",
+  "name": "Poetry and Poetics",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM40003",
-  "name": "Researching Audiences and Reception",
+  "code": "ISLM20016",
+  "name": "Introduction to Islamic Spirituality",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM40006",
-  "name": "Public Relations and Communications",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM40011",
-  "name": "Writing for the Media",
+  "code": "ABPL20035",
+  "name": "Cities: From Local to Global",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM40018",
-  "name": "Media & Communications Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM40019",
-  "name": "Media & Communications Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90002",
-  "name": "Global Data Policy & Governance",
+  "code": "CWRI10001",
+  "name": "Creative Writing: Ideas and Practice",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM90007",
-  "name": "Media Convergence and Digital Culture",
+  "code": "HIST30076",
+  "name": "Stalinism",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM90024",
-  "name": "Strategic Content Creation",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90026",
-  "name": "Advanced Industry Practice - Advertising",
+  "code": "JAPN10001",
+  "name": "Japanese 1",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MECM90029",
-  "name": "Media and Communications Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90030",
-  "name": "Media and Communications Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90031",
-  "name": "Audiovisual Communication",
-  "offered": [
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90032",
-  "name": "Marketing Communications Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90033",
-  "name": "Marketing Communications Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90034",
-  "name": "Marketing & Media in a Global Context",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90035",
-  "name": "Integrated Marketing Communications",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90036",
-  "name": "Foundations of Marketing & Communication",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90038",
-  "name": "Researching Media & Communications",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90039",
-  "name": "Understanding Media & Communications",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90041",
-  "name": "Political Economy of Digital Life",
+  "code": "PHIL20039",
+  "name": "The Nature of Reality",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDI40002",
-  "name": "Advanced Studies in Biomedicine",
+  "code": "MUSI30025",
+  "name": "Orchestration",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDI40004",
-  "name": "Seminars in Translational Medicine",
+  "code": "CHIN20007",
+  "name": "Chinese Studies: Culture and Empire",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDI40005",
-  "name": "Research Project - SVHM Part 1",
+  "code": "FREN10006",
+  "name": "French 5",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDI40006",
-  "name": "Biomedical Advanced Coursework",
+  "code": "HIST20013",
+  "name": "The Holocaust & Genocide",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDI40014",
-  "name": "Biomedicine Research Project Part 1",
+  "code": "GEOG20003",
+  "name": "Environmental Politics and Management",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDI40018",
-  "name": "Research Project – WH Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MEDI90046",
-  "name": "3-D Echocardiography & New Technologies",
+  "code": "DNCE10027",
+  "name": "Dancing the Dance 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MEDI90047",
-  "name": "Congenital,Obsetric& Medical Conditions",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90048",
-  "name": "Advanced Case Studies Practicum",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90049",
-  "name": "Principles of Ultrasound Heart Scan",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90050",
-  "name": "Doppler Echocardiography",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90051",
-  "name": "Ventricular Function",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90054",
-  "name": "Ultrasound Guided Procedures",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90056",
-  "name": "Advanced Anatomy and Doppler Analysis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90057",
-  "name": "Advanced Valve and Aortic Pathology",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90058",
-  "name": "Applications of Echocardiography",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90059",
-  "name": "Advanced Echocardiography Interpretation",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90083",
-  "name": "Research Methods & Ultrasound Literature",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90088",
-  "name": "Graduate Research Internship",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90100",
-  "name": "Abdominal and Peri-Arrest Ultrasound",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90101",
-  "name": "Obstetrics Gynaecology and Practicum",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90102",
-  "name": "Vessels Nerves Lungs and Musculoskeletal",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MEDI90103",
-  "name": "Prehabilitation and Risk Assessment",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MEDI90104",
-  "name": "Enhanced Recovery After Surgery",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT10002",
-  "name": "Principles of Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT10003",
-  "name": "Organisation and Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT20001",
-  "name": "Organisational Behaviour",
+  "code": "ACCT10002",
+  "name": "Introductory Financial Accounting",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT20002",
-  "name": "Managing Processes and Projects",
+  "code": "MCEN30018",
+  "name": "Thermodynamics and Fluid Mechanics",
   "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT30006",
-  "name": "Managing Entrepreneurship and Innovation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT30012",
-  "name": "Management Consulting",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT30013",
-  "name": "Managing for Competitive Advantage",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90010",
-  "name": "Strategic Human Resources",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90011",
-  "name": "Managing Stakeholders",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90013",
-  "name": "Leadership and Team Dynamics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90015",
-  "name": "Human Resource Fundamentals",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90016",
-  "name": "Performance & Reward Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90018",
-  "name": "Managing Behaviour in Organisations",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90025",
-  "name": "People and Change",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90026",
-  "name": "Supply Chain Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90027",
-  "name": "International Human Resources",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90030",
-  "name": "Managing Innovation",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90031",
-  "name": "Project Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90038",
-  "name": "Global Corporate Governance",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90129",
-  "name": "Group Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90130",
-  "name": "Internship I",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90131",
-  "name": "Internship II",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90140",
-  "name": "Management Competencies",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90141",
-  "name": "Business Analysis & Decision Making",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90146",
-  "name": "Strategic Management",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90148",
-  "name": "Consulting Fundamentals",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90164",
-  "name": "EMA Special Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90171",
-  "name": "Leadership in Science",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90197",
-  "name": "Advanced Organisational Behaviour",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90198",
-  "name": "Advanced Qualitative Research Methods",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90201",
-  "name": "Entrepreneurial Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90204",
-  "name": "Leading for Strategic Advantage",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90206",
-  "name": "Management & Marketing Special Topics 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90207",
-  "name": "Management & Marketing Special Topics 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90208",
-  "name": "Sustainable Business Practices",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90209",
-  "name": "EMA Career Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90223",
-  "name": "Design Thinking",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90224",
-  "name": "Garage Project",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90225",
-  "name": "Creating a Successful Business Model",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MGMT90235",
-  "name": "EMA Special Project (Year Long) Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90236",
-  "name": "EMA Special Project (Year Long) Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90237",
-  "name": "Research Report Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90238",
-  "name": "Research Report Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT90280",
-  "name": "Managerial Decision Analytics",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MIIM20001",
-  "name": "Principles of Microbiology & Immunology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MIIM30002",
-  "name": "Principles of Immunology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MIIM30011",
-  "name": "Medical Microbiology: Bacteriology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MIIM30016",
-  "name": "Techniques in Microbiology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MIIM40002",
-  "name": "Advanced Microbiology and Immunology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MIIM40005",
-  "name": "Micro & Immuno Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "MIIM40006",
-  "name": "Micro & Immuno Research Project Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MKTG10001",
-  "name": "Principles of Marketing",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MKTG20001",
-  "name": "Consumer Behaviour",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG20006",
-  "name": "Brand Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG30003",
-  "name": "Service and Relationship Marketing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG30006",
-  "name": "Retailing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG30012",
-  "name": "Business and Marketing Ethics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG90001",
-  "name": "Omnichannel Retail",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG90002",
-  "name": "New Product Development",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG90004",
-  "name": "Marketing Management",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MKTG90005",
-  "name": "Marketing Strategy",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MKTG90006",
-  "name": "Branding",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG90007",
-  "name": "Customer Experience Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG90008",
-  "name": "Consumers and Consumption",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MKTG90011",
-  "name": "Marketing Research",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MKTG90012",
-  "name": "International Marketing Management",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG90026",
-  "name": "Marketing Metrics",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MKTG90032",
-  "name": "Applied Syndicate Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MKTG90033",
-  "name": "Neuromarketing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MKTG90037",
-  "name": "Managing for Value Creation",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MREN90001",
-  "name": "Polymers and Composites",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MREN90003",
-  "name": "Electronic and Magnetic Materials",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MREN90005",
-  "name": "Materials Engineering Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT10011",
-  "name": "Introduction to Life, Earth and Universe",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MULT10014",
-  "name": "Identity",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MULT10015",
-  "name": "Language",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MULT10016",
-  "name": "Reason",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MULT10018",
-  "name": "Power",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MULT20003",
-  "name": "Critical Analytical Skills",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MULT20008",
-  "name": "Australian Indigenous Politics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MULT20010",
-  "name": "Arts Internship",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT20012",
-  "name": "Arts Internship: Not for Profit",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT30015",
-  "name": "Independent Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT30019",
-  "name": "Arts Internship",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT30020",
-  "name": "Arts Internship: Not for Profit",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT40007",
-  "name": "Special Research Topics",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT90002",
-  "name": "Supervised Reading (Asia Institute)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT90004",
-  "name": "Sustainability Governance and Leadership",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "MULT90018",
-  "name": "Internship I (Placement Only)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT90019",
-  "name": "Internship II (Semester Long)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT90059",
-  "name": "Social Enterprise Incubator",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT90061",
-  "name": "Internship II (Year Long) Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT90062",
-  "name": "Internship II (Year Long) Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT90063",
-  "name": "Introduction to Quantum Computing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MULT90064",
-  "name": "Industry Core and Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI10016",
-  "name": "Art of Piano Teaching",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10017",
-  "name": "Riffs: Guitar Cultures & Practice 1",
-  "offered": [
-   "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10037",
-  "name": "Music in Everyday Life",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10041",
-  "name": "Baroque Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10047",
-  "name": "Music History 1: Monteverdi to Mozart",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10052",
-  "name": "Brass Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10056",
-  "name": "Early Voices 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10058",
-  "name": "Conservatorium Choir 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10060",
-  "name": "Symphonic Ensembles 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10066",
-  "name": "Guitar Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10068",
-  "name": "String Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10076",
-  "name": "Piano Duo and Duet 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10092",
-  "name": "Vocal Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10159",
-  "name": "Choir 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10173",
-  "name": "Guitar Group 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10180",
-  "name": "Contextual Studies 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10181",
-  "name": "Ensemble Studies 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10182",
-  "name": "Individual Performance Studies 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10184",
-  "name": "Pop Song Writing 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI10191",
-  "name": "Interactive Composition 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10192",
-  "name": "Ensemble Studies 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI10195",
-  "name": "Music Making Laboratory 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10197",
-  "name": "Individual Performance Studies 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI10202",
-  "name": "Jazz: The Improvisatory Spirit",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10204",
-  "name": "Applied Aural Musicianship 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10207",
-  "name": "Medieval and Renaissance Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10219",
-  "name": "Rock Music: From Roots to Retro",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10220",
-  "name": "Practical Music 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI10221",
-  "name": "Practical Music 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI10225",
-  "name": "Chamber Choir 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI10229",
-  "name": "Sound Studies 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20008",
-  "name": "Music Technology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20013",
-  "name": "Chamber Music 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20014",
-  "name": "Chamber Music 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20025",
-  "name": "Minor Music Performance 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20026",
-  "name": "Minor Music Performance 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20055",
-  "name": "Composition 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20056",
-  "name": "Composition 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20069",
-  "name": "Baroque Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20071",
-  "name": "Big Band 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20073",
-  "name": "Brass Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20080",
-  "name": "Early Voices 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20082",
-  "name": "Conservatorium Choir 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20087",
-  "name": "MCM Indonesian Gamelan Ensemble 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20088",
-  "name": "MCM Indonesian Gamelan Ensemble 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20089",
-  "name": "Guitar Ensemble 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20091",
-  "name": "String Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20093",
-  "name": "Symphonic Ensembles 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20099",
-  "name": "Piano Duo and Duet 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20104",
-  "name": "Shakuhachi 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20105",
-  "name": "Shakuhachi 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20108",
-  "name": "MCM Chinese Music Ensemble",
-  "offered": [
-   "summer_term",
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "MUSI20112",
-  "name": "Vocal Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20122",
-  "name": "Composition Studies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20124",
-  "name": "University Symphonic Ensembles 1",
-  "offered": [
-   "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20134",
-  "name": "Melbourne Big Band 1",
+  "code": "CHIN10001",
+  "name": "Chinese 9",
   "offered": [
    "semester_1"
-  ]
- },
- {
-  "code": "MUSI20135",
-  "name": "Chinese Music Ensemble 1",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20138",
-  "name": "Indonesian Gamelan Ensemble",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20143",
-  "name": "World Music Choir",
+  "code": "GDES10001",
+  "name": "Graphic Design Studio 1: Image & Text",
   "offered": [
-   "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20149",
-  "name": "Music Psychology",
+  "code": "UNIB10006",
+  "name": "Critical Thinking With Data",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20156",
-  "name": "Practical Anatomy for Classical Voice 1",
+  "code": "CRIM20010",
+  "name": "Law, Justice and Social Change",
   "offered": [
    "semester_1"
-  ]
- },
- {
-  "code": "MUSI20160",
-  "name": "Applied Aural Musicianship 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20163",
-  "name": "Samba Band",
-  "offered": [
-   "february",
-   "semester_1",
-   "june",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MUSI20164",
@@ -11716,115 +13485,229 @@
    "semester_1",
    "june",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20173",
-  "name": "The Art of Game Music",
+  "code": "ENGL30016",
+  "name": "Decadent Literature",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20174",
-  "name": "The Laptop Recording Studio",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20175",
-  "name": "Individual Performance Studies 3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20176",
-  "name": "Ensemble Studies 3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20177",
-  "name": "Contextual Studies 3",
+  "code": "ARBC20002",
+  "name": "Arabic 7",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20178",
-  "name": "Individual Performance Studies 4",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20179",
-  "name": "Ensemble Studies 4",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20181",
-  "name": "Interactive Composition 3",
+  "code": "ANTH30009",
+  "name": "Anthropology of More-Than-Human Worlds",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20182",
-  "name": "Music Making Laboratory 3",
+  "code": "SOCI30009",
+  "name": "Living in a Risk Society",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20198",
-  "name": "Music History 2: C19th Music and Ideas",
+  "code": "PLAN10001",
+  "name": "Cities Past and Future",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH30003",
+  "name": "Lived Religion in an Uncertain World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE10002",
+  "name": "Principles of Finance",
   "offered": [
    "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH20004",
+  "name": "Digital Design",
+  "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20199",
-  "name": "Practical Music 3",
+  "code": "ITAL30013",
+  "name": "Italian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS20023",
+  "name": "Comparative Politics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM20011",
+  "name": "Environmental Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND20008",
+  "name": "Sex and Gender Present and Future",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL20030",
+  "name": "Modern and Contemporary Theatre",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MIIM30002",
+  "name": "Principles of Immunology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM20009",
+  "name": "German 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST10012",
+  "name": "The World Since World War II",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT20002",
+  "name": "Intermediate Financial Accounting",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20011",
+  "name": "French Cinema: The New Wave and Beyond",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS20018",
+  "name": "Popular Culture: From K-pop to Selfies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM10001",
+  "name": "Crime, Criminology, and Critique",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL20038",
+  "name": "Nietzsche and Critics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT30012",
+  "name": "Management Consulting",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20200",
-  "name": "Practical Music 4",
+  "code": "MUSI10219",
+  "name": "Rock Music: From Roots to Retro",
   "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+   "semester_1"
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20201",
-  "name": "Performance 3",
+  "code": "ENGL10002",
+  "name": "Literature and Performance",
   "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+   "semester_1"
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20202",
-  "name": "Performance 4",
+  "code": "PHIL20033",
+  "name": "The Philosophy of Mind",
   "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI20009",
+  "name": "Writing for Screen",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20065",
+  "name": "Knowledge, Learning and Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
  },
  {
   "code": "MUSI20209",
@@ -11832,1030 +13715,429 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20210",
-  "name": "Saxophone Ensemble",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI20213",
-  "name": "Chamber Choir 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20215",
-  "name": "Medieval and Renaissance Ensemble 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20220",
-  "name": "Sound Studies 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20223",
-  "name": "Music Performance Science",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI20228",
-  "name": "Optimising Personal Performance",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30019",
-  "name": "Chamber Music 3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30020",
-  "name": "Chamber Music 4",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30025",
-  "name": "Orchestration",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30030",
-  "name": "The Music Of Spain",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30031",
-  "name": "Electro-Acoustic Music",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30032",
-  "name": "Music Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30047",
-  "name": "Music Analysis",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30050",
-  "name": "Minor Music Performance 3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30051",
-  "name": "Minor Music Performance 4",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30053",
-  "name": "The Ethnography of Music",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30139",
-  "name": "Shakuhachi Ensemble 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30159",
-  "name": "Acting for Singers 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30163",
-  "name": "Baroque Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30165",
-  "name": "Big Band 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30167",
-  "name": "Brass Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30172",
-  "name": "Early Voices 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30174",
-  "name": "Conservatorium Choir 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30181",
-  "name": "Guitar Ensemble 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30183",
-  "name": "String Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30185",
-  "name": "Symphonic Ensembles 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30193",
-  "name": "Piano Duo and Duet 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30206",
-  "name": "Vocal Ensemble 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30213",
-  "name": "Composition 3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30214",
-  "name": "Composition 4",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30223",
-  "name": "Contextual Studies 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30225",
-  "name": "Ensemble Studies 5",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30226",
-  "name": "Ensemble Studies 6",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30227",
-  "name": "Individual Performance Studies 5",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30228",
-  "name": "Individual Performance Studies 6",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30229",
-  "name": "Interactive Composition 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30231",
-  "name": "Music Making Laboratory 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30236",
-  "name": "The Music Producer: From Brass to Beats",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30238",
-  "name": "Advanced Harmonic and Rhythmic Studies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30244",
-  "name": "Chamber Choir 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30249",
-  "name": "Music History 3:Impressionism to Present",
+  "code": "COMP10001",
+  "name": "Foundations of Computing",
   "offered": [
    "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30250",
-  "name": "Practical Music 5",
-  "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI30251",
-  "name": "Practical Music 6",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30252",
-  "name": "Performance 5",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30253",
-  "name": "Performance 6",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30257",
-  "name": "Figured Bass Realisation 1",
+  "code": "FREN20019",
+  "name": "French 7",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI30260",
-  "name": "Medieval and Renaissance Ensemble 5",
+  "code": "ARBC30006",
+  "name": "Arabic 7",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI30265",
-  "name": "Italian Lyric Diction",
+  "code": "MECM10003",
+  "name": "Media and Society",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI30267",
-  "name": "Interpretation of German Lieder",
+  "code": "ARCH10003",
+  "name": "Design Studio Alpha",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH30005",
+  "name": "Power, Ideology and Inequality",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40012",
-  "name": "GradDip Composition 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40013",
-  "name": "GradDip Composition 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40016",
-  "name": "Practical Study 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40017",
-  "name": "Practical Study 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40036",
-  "name": "Conducting",
+  "code": "ECON30005",
+  "name": "Money and Banking",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40055",
-  "name": "Music Analysis",
+  "code": "CHIN30002",
+  "name": "Taiwan & Beyond: Chinese Settler Culture",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40056",
-  "name": "Special Study",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40060",
-  "name": "Concerto",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40061",
-  "name": "Recital",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40062",
-  "name": "Honours Chamber Music 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40063",
-  "name": "Honours Ensemble 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40064",
-  "name": "The Research Process for Musicians",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40067",
-  "name": "Honours Composition 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40068",
-  "name": "Honours Composition 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40070",
-  "name": "Professional Project (Ethnomusicology)",
+  "code": "SPAN10007",
+  "name": "Spanish 5",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40071",
-  "name": "Professional Project (Musicology)",
+  "code": "ITAL10009",
+  "name": "Italian 7",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40073",
-  "name": "Composition Studies",
+  "code": "ACCT30002",
+  "name": "Enterprise Performance Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ESLA10003",
+  "name": "Academic English 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20003",
+  "name": "Chinese 5",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40075",
-  "name": "Music Psychology",
+  "code": "CHIN20006",
+  "name": "Great Chinese Classics",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40078",
-  "name": "Music Research (Honours)",
+  "code": "BLAW10001",
+  "name": "Principles of Business Law",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM30002",
+  "name": "Econometrics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING10002",
+  "name": "Intercultural Communication",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40079",
-  "name": "The Ethnography of Music (Honours)",
+  "code": "PHIL10002",
+  "name": "Philosophy: The Big Questions",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40080",
-  "name": "Honours Ensemble 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40081",
-  "name": "Honours Chamber Music 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40083",
-  "name": "Research Methods",
+  "code": "PSYC30018",
+  "name": "Neuroscience and the Mind",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40088",
-  "name": "Integrated Musical Practice 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40089",
-  "name": "Integrated Musical Practice 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40092",
-  "name": "Music Management and Enterprise",
+  "code": "MAST30013",
+  "name": "Techniques in Operations Research",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40095",
-  "name": "The Music of Spain",
+  "code": "CHIN10015",
+  "name": "Chinese 3",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40101",
-  "name": "Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40102",
-  "name": "Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40103",
-  "name": "Figured Bass Realisation 1",
+  "code": "GEOG20001",
+  "name": "Society and Environments",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI40104",
-  "name": "Dissertation Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40105",
-  "name": "Dissertation Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40107",
-  "name": "Capstone Music Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40108",
-  "name": "Capstone Music Project Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40110",
-  "name": "Honours Music Studies 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI40111",
-  "name": "Honours Music Studies 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90015",
-  "name": "Band Direction",
+  "code": "ECON30018",
+  "name": "Economics of the Law",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90032",
-  "name": "Music Therapy Methods 1",
+  "code": "GEOG20010",
+  "name": "China in Transition",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90036",
-  "name": "Music Psychology Research",
+  "code": "UNIB30002",
+  "name": "Global Health, Security & Sustainability",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90038",
-  "name": "Clinical Training in Music Therapy 1",
+  "code": "POLS20031",
+  "name": "Political Economy",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90040",
-  "name": "Clinical Training in Music Therapy 3",
+  "code": "MKTG30006",
+  "name": "Retailing",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90041",
-  "name": "Applications of Music in Therapy A",
+  "code": "MUSI10047",
+  "name": "Music History 1: Monteverdi to Mozart",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90043",
-  "name": "Applications of Music in Therapy C",
+  "code": "MULT10011",
+  "name": "Introduction to Life, Earth and Universe",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90044",
-  "name": "Objectivist Research in Music Therapy",
+  "code": "ECON10004",
+  "name": "Introductory Microeconomics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30001",
+  "name": "International Trade Policy",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90093",
-  "name": "Ensemble A",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90094",
-  "name": "Ensemble B",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90100",
-  "name": "Recital 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90144",
-  "name": "The Teacher as Conductor",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90147",
-  "name": "Performing to Teach 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90148",
-  "name": "Ensemble",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90149",
-  "name": "Applied Instrumental and Vocal Teaching",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90150",
-  "name": "Music Learning, Teaching and Research",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90151",
-  "name": "Music Performance Curriculum& Assessment",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90152",
-  "name": "Second Instrument / Vocal Study 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90153",
-  "name": "Professional Practice 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90154",
-  "name": "Professional Practice 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90155",
-  "name": "Second Instrument / Vocal Study 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90156",
-  "name": "Performing to Teach 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90157",
-  "name": "Pedagogue Recital",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90191",
-  "name": "The Research Process For Musicians (RHD)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90192",
-  "name": "Studio Teaching 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90193",
-  "name": "Studio Teaching 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90194",
-  "name": "Instrumental Pedagogy",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90195",
-  "name": "Professional Practice 3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90196",
-  "name": "Orchestration",
+  "code": "JOUR90005",
+  "name": "Audio Journalism",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90197",
-  "name": "Professional Research Project Part 1",
+  "code": "GERM20003",
+  "name": "German Cultural Studies B",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90198",
-  "name": "Professional Research Project Part 2",
+  "code": "CRIM30010",
+  "name": "Managing Justice: Agencies and the State",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO30011",
+  "name": "Indonesian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20007",
+  "name": "Globalisation and the World Economy",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90199",
-  "name": "Suzuki Practicum Part 1",
+  "code": "PSYC20008",
+  "name": "Developmental Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HEBR10011",
+  "name": "Hebrew 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS20011",
+  "name": "The Politics of Sex",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC30014",
+  "name": "The Psychopathology of Everyday Life",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI10001",
+  "name": "Understanding Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING20005",
+  "name": "Phonetics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30025",
+  "name": "Computational Economics and Business",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL40002",
+  "name": "Risk Theory I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO30009",
+  "name": "Game Design",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN30017",
+  "name": "Mechanics & Materials",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90200",
-  "name": "Suzuki Practicum Part 2",
+  "code": "CLAS10012",
+  "name": "Latin 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "WELF90004",
+  "name": "Principles of Counselling 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CEDB20003",
+  "name": "Fundamentals of Cell Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM30001",
+  "name": "German Cultural Studies B",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI90221",
-  "name": "Orchestral Performance Practicum 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI90224",
-  "name": "Orchestral Experience 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI90225",
-  "name": "Music Outreach & Social Entrepreneurship",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI90227",
-  "name": "Orchestral Performance Practicum 2",
+  "code": "ANAT20006",
+  "name": "Principles of Human Structure",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "MUSI90229",
-  "name": "Orchestral Performance Practicum 3",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI90231",
-  "name": "Core Skills In Opera 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI90234",
-  "name": "Core Skills in Opera 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI90237",
-  "name": "Major Role Preparation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI90239",
-  "name": "Lyric Diction for Opera",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI90245",
-  "name": "Orchestra Audition Preparation 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUST10013",
-  "name": "Music Theatre Contextual Studies 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUST10014",
-  "name": "Music Theatre Studio 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "MUST20010",
-  "name": "Singing and the Power of Pop Music",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "NEUR30002",
-  "name": "Neurophysiology: Neurons and Circuits",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NEUR30003",
-  "name": "Principles of Neuroscience",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NEUR90015",
-  "name": "Project in Neuroscience",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "NEUR90016",
-  "name": "Project in Neuroscience",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "NEUR90017",
-  "name": "Project in Neuroscience",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "NEUR90018",
@@ -12863,525 +14145,371 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "NRMT10007",
-  "name": "Land Resources and Management",
+  "code": "MAST10007",
+  "name": "Linear Algebra",
   "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NRMT90003",
-  "name": "Social Research Methods",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90002",
-  "name": "Independent Study",
-  "offered": [
+   "summer_term",
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "NURS90026",
-  "name": "Independent Study Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "NURS90052",
-  "name": "Nursing Science 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90053",
-  "name": "Clients with Complex Health States",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90059",
-  "name": "Nursing Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90066",
-  "name": "Foundations of Nursing",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90067",
-  "name": "Health Assessment for Advanced Practice1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90068",
-  "name": "Health Assessment for Adv. Practice 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90069",
-  "name": "Clinical Leadership in Context",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90086",
-  "name": "Quality and Safety in Healthcare",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90104",
-  "name": "Chronic Disease Management: Foundations",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "NURS90105",
-  "name": "Chronic Disease Management: In Practice",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "NURS90106",
-  "name": "Advanced Nursing Practice: Primary Care",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "NURS90129",
-  "name": "Nursing Science 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90130",
-  "name": "Nursing Assessment & Care",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NUTR30002",
-  "name": "Monitoring Food and Nutrition Intake",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NUTR30005",
-  "name": "Molecular Nutrition and Genomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "NUTR40001",
-  "name": "Human Nutrition Research Project Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "OPTO20004",
-  "name": "Perception, Illusions and Art",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "OPTO40012",
-  "name": "Vision Science Research Project Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "OPTO90016",
-  "name": "Glaucoma and Retinal Disease",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "OPTO90018",
-  "name": "The Eye and Vision: A Window to Disease",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "OPTO90019",
-  "name": "Project in Vision Science",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "OPTO90020",
-  "name": "Project in Vision Science",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "OPTO90021",
-  "name": "Project in Vision Science",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "OPTO90022",
-  "name": "Project in Vision Science",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "OPTO90031",
-  "name": "Research Studies in Optometry",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ORAL10001",
-  "name": "Society and Health 1A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ORAL20001",
-  "name": "Health Promotion 2A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "ORAL40001",
-  "name": "Oral Health Research Project 4A",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ORAL40002",
-  "name": "Oral Health Research Project 4B",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "OTOL40001",
-  "name": "Otolaryngology Research Project Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "OTOL40002",
-  "name": "Otolaryngology Advanced Coursework",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PADM20001",
-  "name": "Foundations of Digital Government",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PADM90004",
-  "name": "Public Administration Thesis",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PAED40001",
-  "name": "Paediatrics Research Project Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PAED90007",
-  "name": "Professional Practice in Context",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PATH20001",
-  "name": "Exploring Human Disease",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PATH30001",
-  "name": "Mechanisms of Human Disease",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PATH30002",
-  "name": "Techniques for Investigation of Disease",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PATH40001",
-  "name": "Pathology Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "june",
-   "semester_2"
-  ]
- },
- {
-  "code": "PATH40002",
-  "name": "Critical Analysis of Pathology Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PATH40005",
-  "name": "Pathology Research Project Part 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PATH40006",
-  "name": "Clinical Path Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PATH40007",
-  "name": "Clinical Path Research Project Part 2",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL10002",
-  "name": "Philosophy: The Big Questions",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL20001",
-  "name": "Science, Reason and Reality",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL20033",
-  "name": "The Philosophy of Mind",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL20038",
-  "name": "Nietzsche and Critics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL20039",
-  "name": "The Nature of Reality",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL20043",
-  "name": "History of Early Modern Philosophy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL30024",
-  "name": "The Foundations of Interpretation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL30043",
-  "name": "The Power and Limits of Logic",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL30053",
-  "name": "Philosophy of Language",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL40002",
-  "name": "Recent European Philosophy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL40004",
-  "name": "Value Theory",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL40020",
-  "name": "Reading and Writing Philosophy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL40021",
-  "name": "Philosophy Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PHIL40022",
-  "name": "Philosophy Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PHIL90007",
-  "name": "Literature Review",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL90021",
-  "name": "Critical and Creative Thinking",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL90034",
-  "name": "Philosophical Methodology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHIL90039",
-  "name": "Applied Ethics Thesis Part 2",
-  "offered": [
-   "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "PHRM30003",
   "name": "Drug Treatment of Disease",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHRM30009",
-  "name": "Drugs in Biomedical Experiments",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PHRM90002",
-  "name": "Pharmacology for Health Professionals",
+  "code": "JAPN30005",
+  "name": "Japanese 7",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHTY90040",
-  "name": "Physiotherapy Professional Portfolio",
+  "code": "ARCH10002",
+  "name": "Construction as Alchemy",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHYC10001",
-  "name": "Physics 1: Advanced",
+  "code": "ABPL90286",
+  "name": "Construction Methods A",
+  "offered": [
+   "february",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10017",
+  "name": "Animation History and Research",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHYC10003",
-  "name": "Physics 1",
+  "code": "FLTV30029",
+  "name": "Screenwriting Practices 3A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10018",
+  "name": "Writing Animation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90018",
+  "name": "Clinical Practice in Specialty 2",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA90018",
+  "name": "Indonesia Rising?",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90113",
+  "name": "Information Systems Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90032",
+  "name": "Sensor Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90057",
+  "name": "Elements of Probability",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90086",
+  "name": "Environmental Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90010",
+  "name": "Applied Linguistics Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90033",
+  "name": "Climate Change Mitigation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS40036",
+  "name": "Classics Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90083",
+  "name": "Data Analysis for Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90010",
+  "name": "Advanced Construction Technology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90027",
+  "name": "Systems and Synthetic Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM10008",
+  "name": "Foundation Studies in Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90206",
+  "name": "Management & Marketing Special Topics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90013",
+  "name": "Researching Media and Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE40004",
+  "name": "Research Methods in Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90005",
+  "name": "Marketing Strategy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90132",
+  "name": "Veterinary Professional Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90059",
+  "name": "Social Enterprise Incubator",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90006",
+  "name": "Life Insurance Models I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90013",
+  "name": "Leadership and Team Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT10003",
+  "name": "Organisation and Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30172",
+  "name": "Early Voices 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10056",
+  "name": "Early Voices 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90384",
+  "name": "MUP Studio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC90001",
+  "name": "Wildlife Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90360",
+  "name": "MUCH Heritage Industry Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90034",
+  "name": "Property Securitisation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90003",
+  "name": "The Contemporary Publishing Industry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90048",
+  "name": "Declarative Programming",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90077",
+  "name": "Grid Integration of Renewables",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90020",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS40037",
+  "name": "Classics Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HLTH90006",
+  "name": "Basics of Digital Health for Clinicians",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90037",
+  "name": "Managing for Value Creation",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "PHYC10007",
@@ -13389,993 +14517,557 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHYC10009",
-  "name": "Foundations of Physics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYC10010",
-  "name": "Indigenous Astronomy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYC20012",
-  "name": "Quantum and Thermal Physics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYC20013",
-  "name": "Laboratory and Computational Physics 2",
+  "code": "MUSI30227",
+  "name": "Individual Performance Studies 5",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHYC30016",
-  "name": "Electrodynamics",
+  "code": "VETS90130",
+  "name": "Veterinary Virology",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHYC30018",
-  "name": "Quantum Physics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYC30019",
-  "name": "Astrophysics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYC30021",
-  "name": "Laboratory and Computational Physics 3",
+  "code": "MUSI20199",
+  "name": "Practical Music 3",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHYC30023",
-  "name": "Light, Lasers, Optics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYC90007",
-  "name": "Quantum Mechanics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYC90008",
-  "name": "Quantum Field Theory",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYC90009",
-  "name": "Physical Cosmology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYC90010",
-  "name": "Statistical Mechanics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYC90021",
-  "name": "Research Project",
+  "code": "DEVT90060",
+  "name": "Internship in Development",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHYC90022",
-  "name": "Research Project",
+  "code": "ISLM40001",
+  "name": "Topics in Arabic & Islamic Studies",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHYC90023",
-  "name": "Research Project",
+  "code": "LAWS90209",
+  "name": "Indigenous Legal Advocacy Clinic",
   "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PHYC90024",
-  "name": "Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PHYS20008",
-  "name": "Human Physiology",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PHYS20009",
-  "name": "Research-Based Physiology",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PHYS30009",
-  "name": "Experimental Physiology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYS30010",
-  "name": "Advanced Human Physiology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PHYS40005",
-  "name": "Physiology Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "PHYS90008",
-  "name": "Advanced Seminars in Physiology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PLAN10001",
-  "name": "Cities Past and Future",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PLAN30001",
-  "name": "Planning Scenario and Policy Workshop",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PLAN30003",
-  "name": "Research Methods for Planners",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PLAN30004",
-  "name": "Transit Oriented Development",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS10001",
-  "name": "Australian Politics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS20011",
-  "name": "The Politics of Sex",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS20023",
-  "name": "Comparative Politics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS20031",
-  "name": "Political Economy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS30001",
-  "name": "Parliamentary Internship",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS30003",
-  "name": "Public Affairs Internship",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POLS30011",
-  "name": "Chinese Politics and Society",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS30015",
-  "name": "International Gender Politics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS30032",
-  "name": "Campaigns and Elections",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS30033",
-  "name": "Democracy and its Dilemmas",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS40021",
-  "name": "Politics & International Thesis Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS40024",
-  "name": "Key Debates in Political Science 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS90009",
-  "name": "International Relations Internship",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POLS90023",
-  "name": "International Governance and Law",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS90026",
-  "name": "International Political Economy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS90030",
-  "name": "Nuclear Weapons and Disarmament",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS90038",
-  "name": "Human Rights",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS90042",
-  "name": "Latin America in the World",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS90050",
-  "name": "Terrorism and Insurgency",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POLS90054",
-  "name": "International Relations Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POLS90055",
-  "name": "International Relations Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POLS90058",
-  "name": "Asia-Pacific: Zone of Conflict or Peace?",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH20001",
-  "name": "Genetics, Health, and Society",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH40005",
-  "name": "Population Health Research Project 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90013",
-  "name": "Biostatistics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90014",
-  "name": "Epidemiology 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90058",
-  "name": "Health Program Evaluation 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90070",
-  "name": "Clinical Sexual & Reproductive Health",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90094",
-  "name": "Health Economics 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90117",
-  "name": "Health Indicators and Health Surveys",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90118",
-  "name": "Clinical Biostatistics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90122",
-  "name": "Survival Analysis",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90123",
-  "name": "Longitudinal and Correlated Data",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90148",
-  "name": "Probability and Distribution Theory",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90149",
-  "name": "Biostatistics Research Project - S",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90151",
-  "name": "Biostatistics Research Project - D",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90167",
-  "name": "Young People in Context",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90168",
-  "name": "Vulnerable Young People",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90169",
-  "name": "Adolescent Sexuality and Sexual Health",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90170",
-  "name": "Adolescent Health Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90201",
-  "name": "Community-Based Participatory Research",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90226",
-  "name": "Societal Implications of Genomics",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90227",
-  "name": "Public Health in Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90239",
-  "name": "Professional Practice - S",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90255",
-  "name": "Research Project in Public Health - S",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90270",
-  "name": "Bioethics and Public Health",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "POPH90276",
-  "name": "M.Epidemiology Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90277",
-  "name": "M.Epidemiology Research Project Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90284",
-  "name": "Research Project in Public Health Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90285",
-  "name": "Research Project in Public Health Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90286",
-  "name": "Professional Practice - Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90287",
-  "name": "Professional Practice - Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90288",
-  "name": "Biostatistics Research Project Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90289",
-  "name": "Biostatistics Research Project Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "POPH90292",
-  "name": "M.Epidemiology Research Project - S",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PPMN10001",
-  "name": "Tackling Wicked Policy Problems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PPMN40006",
-  "name": "Public Policy & Management Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PPMN90035",
-  "name": "Public Consultation & Policy Negotiation",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PPMN90039",
-  "name": "Executive Internship",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PPMN90049",
-  "name": "Public /Social Policy Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PPMN90050",
-  "name": "Public /Social Policy Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PPMN90056",
-  "name": "Business and Government",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PROP20001",
-  "name": "Finance for Built Environment",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PROP20002",
-  "name": "Design and Property Principles",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PROP30001",
-  "name": "Valuation of Land and Buildings",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC10003",
-  "name": "Mind, Brain & Behaviour 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC20006",
-  "name": "Biological Psychology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC20008",
-  "name": "Developmental Psychology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC30012",
-  "name": "The Unconscious Mind",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC30013",
-  "name": "Research Methods for Human Inquiry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC30014",
-  "name": "The Psychopathology of Everyday Life",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC30017",
-  "name": "Perception, Memory and Cognition",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC30018",
-  "name": "Neuroscience and the Mind",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC40006",
-  "name": "Ethics and Evidence-Based Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC40014",
-  "name": "Advanced Research Methods In Psychology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90005",
-  "name": "Thesis (Masters/coursework)",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PSYC90006",
-  "name": "Basic Interventions",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90007",
-  "name": "Cognitive-Behaviour Therapy",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90010",
-  "name": "Mental Health Issues Across the Lifespan",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90023",
-  "name": "Child Psychopathology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90027",
-  "name": "Clinical Psychology in Medical Settings",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90030",
-  "name": "Principles of Psychological Assessment",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90084",
-  "name": "Neuroanatomy for Neuropsychologists",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90095",
-  "name": "Thesis (Masters/coursework) Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90101",
-  "name": "Advanced Social Psychology",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90104",
-  "name": "Thinking, Judgement and Decision Making",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90105",
-  "name": "Influence and Persuasion",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90106",
-  "name": "Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PSYC90107",
-  "name": "Internship",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PSYC90110",
-  "name": "Ethics & Psychological Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90111",
-  "name": "Well-being in Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYC90115",
-  "name": "Professional Psychology Placement 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYT90028",
-  "name": "Infant Observation 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYT90032",
-  "name": "Foundations of Working with Adolescents",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYT90038",
-  "name": "Foundations of Working with Families",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYT90040",
-  "name": "Clinical Practicum: Families",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PSYT90082",
-  "name": "Mental Health Disorders in Infancy",
-  "offered": [
    "semester_1"
-  ]
- },
- {
-  "code": "PSYT90086",
-  "name": "Mental Health Science Research Project 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PUBL90001",
-  "name": "Structural Editing",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PUBL90002",
-  "name": "Editorial English",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PUBL90003",
-  "name": "The Contemporary Publishing Industry",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PUBL90004",
-  "name": "Business and Professional Communications",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
- },
- {
-  "code": "PUBL90006",
-  "name": "Writing and Editing for Digital Media",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "PUBL90009",
-  "name": "Advanced Editing for Digital Media",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "PUBL90010",
-  "name": "Print Production and Design",
-  "offered": [
-   "semester_1",
-   "june"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "PUBL90013",
   "name": "Writing and Editing for Magazines",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PUBL90014",
-  "name": "Legal Issues in Arts and Media",
+  "code": "PUBL90025",
+  "name": "Grattan Street Press (Extended)",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PUBL90022",
-  "name": "Publishing and Communications Thesis Pt1",
+  "code": "DENT90031",
+  "name": "Research Design 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90057",
+  "name": "Advanced Valve and Aortic Pathology",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30050",
+  "name": "Minor Music Performance 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90053",
+  "name": "Clients with Complex Health States",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90413",
+  "name": "Construction Cost Planning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT40003",
+  "name": "Advances in Oral Health Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90011",
+  "name": "Managing Stakeholders",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90123",
+  "name": "Advanced Computational Design",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90033",
+  "name": "Law Apps",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10060",
+  "name": "Symphonic Ensembles 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90027",
+  "name": "International Human Resources",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90056",
+  "name": "Investment Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90020",
+  "name": "International Journalism - Key Skills",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90019",
+  "name": "Dramaturgy, Text and Performance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC40007",
+  "name": "Arabic Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90095",
+  "name": "Thesis (Masters/coursework) Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90369",
+  "name": "Architecture as Spectacle",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90010",
+  "name": "Researching Society and Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL40004",
+  "name": "Advanced Financial Mathematics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90016",
+  "name": "Pathologies of the Auditory System",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90204",
+  "name": "Leading for Strategic Advantage",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90033",
+  "name": "Neuromarketing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90001",
+  "name": "Translation and Interpreting as Product",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL10006",
+  "name": "Systems Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN40003",
+  "name": "Topics in Japanese Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90089",
+  "name": "Communication Design Clinic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90077",
+  "name": "Introduction to Transport and Land Use",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90196",
+  "name": "Orchestration",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90026",
+  "name": "Chemical Engineering Minor Research Proj",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90016",
+  "name": "Grammar in Use",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40016",
+  "name": "Practical Study 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90054",
+  "name": "Probability and Random Models",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90029",
+  "name": "Food Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90016",
+  "name": "Glaucoma and Retinal Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90223",
+  "name": "Design Thinking",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90017",
+  "name": "Advanced Motion Control",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV40005",
+  "name": "Research Methods (Animation)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40080",
+  "name": "Honours Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90006",
+  "name": "Basic Interventions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90102",
+  "name": "Vessels Nerves Lungs and Musculoskeletal",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90010",
+  "name": "International Migration",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90106",
+  "name": "Advanced Nursing Practice: Primary Care",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90092",
+  "name": "Agricultural Advisory Practice & Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90231",
+  "name": "Core Skills In Opera 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90076",
+  "name": "Research Project Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30059",
+  "name": "Property Case Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90147",
+  "name": "Design Futures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90058",
+  "name": "Health Program Evaluation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40108",
+  "name": "Capstone Music Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20179",
+  "name": "Ensemble Studies 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90140",
+  "name": "Management Competencies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90022",
+  "name": "International Internship in Environment",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90063",
+  "name": "Advanced Microeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90014",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90020",
+  "name": "Measured Drawings & Digital Heritage",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90334",
+  "name": "Minor Project in Education 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90048",
+  "name": "Advanced Case Studies Practicum",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "PUBL90023",
@@ -14383,180 +15075,964 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PUBL90025",
-  "name": "Grattan Street Press (Extended)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RADI90017",
-  "name": "Diagnostic Radiology 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RADI90019",
-  "name": "Diagnostic Radiology 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RADI90021",
-  "name": "Diagnostic Radiology 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RADI90022",
-  "name": "Diagnostic Radiology Minor Thesis 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RURA90008",
-  "name": "Utilising Knowledge in Aboriginal Health",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RUSS10001",
-  "name": "Russian 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RUSS20004",
-  "name": "Russian 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RUSS20006",
-  "name": "Russian 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RUSS30001",
-  "name": "Russian 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RUSS40006",
-  "name": "Russian Language & Culture 4A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "RUSS40009",
-  "name": "Russian Thesis Part 1",
+  "code": "ANTH40009",
+  "name": "Anthropology Thesis Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "RUSS40010",
-  "name": "Russian Thesis Part 2",
+  "code": "CHEN90038",
+  "name": "Product Design and Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40026",
+  "name": "English & Theatre Studies Thesis Part 1",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE10001",
-  "name": "Science: A Study of Life and Environment",
+  "code": "AGRI90086",
+  "name": "Communicating Agricultural Sciences",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE10003",
-  "name": "Science: Supporting Health and Wellbeing",
+  "code": "MUSI30231",
+  "name": "Music Making Laboratory 5",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE30001",
-  "name": "Science Research Project",
+  "code": "FLTV40008",
+  "name": "Research Methods (Film and Television)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST90076",
+  "name": "Short Research Project B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV20018",
+  "name": "Writing for the Youth Screen Market",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC40006",
+  "name": "Ethics and Evidence-Based Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30226",
+  "name": "Ensemble Studies 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90002",
+  "name": "New Product Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90076",
+  "name": "Social Policy and Development",
+  "offered": [
+   "semester_1",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90306",
+  "name": "MUP Independent Study",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE30002",
-  "name": "Science and Technology Internship",
+  "code": "AGRI90091",
+  "name": "Advanced Plant Breeding and Improvement",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90037",
+  "name": "Advanced Clinical Practice 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10197",
+  "name": "Individual Performance Studies 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90073",
+  "name": "Minor Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90017",
+  "name": "Clinical Practice in Specialty 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM40011",
+  "name": "Islamic Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20099",
+  "name": "Piano Duo and Duet 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90058",
+  "name": "Industrial Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90024",
+  "name": "Strategic Content Creation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90106",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT90016",
+  "name": "Anatomy and Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90151",
+  "name": "Biostatistics Research Project - D",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90728",
+  "name": "Innovative Spaces and Pedagogy",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL10004",
+  "name": "Indigenous Literature",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90072",
+  "name": "The Art of Scientific Computation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90016",
+  "name": "Taxation for Business Decision Making",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90040",
+  "name": "Clinical Training in Music Therapy 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90099",
+  "name": "Infections and Immunity A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90032",
+  "name": "Geography Minor Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90008",
+  "name": "Translating in a Chinese Context",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30067",
+  "name": "Design Workshop",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90013",
+  "name": "Social Policy Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40103",
+  "name": "Figured Bass Realisation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90054",
+  "name": "International Relations Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90030",
+  "name": "Managing Innovation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90058",
+  "name": "Asia-Pacific: Zone of Conflict or Peace?",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA90004",
+  "name": "Critical Asian Perspectives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30022",
+  "name": "Special Studies",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE30003",
-  "name": "Science Research Project Abroad",
+  "code": "BIOM90013",
+  "name": "Research Project (SBS)",
   "offered": [
-   "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE40001",
-  "name": "Critical Thinking in Research",
+  "code": "MUSI40071",
+  "name": "Professional Project (Musicology)",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE90005",
-  "name": "Ethics and Responsibility in Science",
+  "code": "OTOL40001",
+  "name": "Otolaryngology Research Project Part 1",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE90011",
-  "name": "From Lab to Life",
+  "code": "MREN90003",
+  "name": "Electronic and Magnetic Materials",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE90013",
-  "name": "Communication for Research Scientists",
+  "code": "FINA60011",
+  "name": "Contemporary Art Practice A",
   "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE90019",
+  "name": "Genes Molecules and Cells",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90119",
+  "name": "Veterinary Principles: Digestive System",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90127",
+  "name": "Advanced Biological Modelling: Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90045",
+  "name": "Vet Public Health Research Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90032",
+  "name": "Marketing Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90048",
+  "name": "Principles of Clinical Audiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90128",
+  "name": "Vet Bioscience: Integument and Immunity",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90049",
+  "name": "Property Development and Investment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90047",
+  "name": "Congenital,Obsetric& Medical Conditions",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90003",
+  "name": "Designing Novel Interactions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA40004",
+  "name": "Research Methods (Visual Art)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90039",
+  "name": "Concepts in Applied Linguistics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90011",
+  "name": "Applied Dramaturgy 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90019",
+  "name": "Minor Thesis 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30260",
+  "name": "Medieval and Renaissance Ensemble 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM10032",
+  "name": "Contextual Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90118",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90004",
+  "name": "Evaluating the User Experience",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90100",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90133",
+  "name": "Animal Production Systems: Epidemiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW40017",
+  "name": "Ancient World Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90405",
+  "name": "Energy & Carbon in the Built Environment",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40081",
+  "name": "Honours Chamber Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90033",
+  "name": "Solar Energy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90031",
+  "name": "Enumerative Combinatorics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN40002",
+  "name": "Contemporary Film Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90074",
+  "name": "Minor Research Project Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90036",
+  "name": "Conservation Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90084",
+  "name": "Neuroanatomy for Neuropsychologists",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO40008",
+  "name": "Indonesian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90129",
+  "name": "Group Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90072",
+  "name": "Landscape Studio 5:Sustainable Urbanism",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90341",
+  "name": "Urban Environmental Policy and Planning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90417",
+  "name": "Environment Behavior Methods for Design",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90033",
+  "name": "Research Project 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50130",
+  "name": "Advanced Torts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90130",
+  "name": "Planning Law & Statutory Planning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90072",
+  "name": "Data and Decision Making",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST10014",
+  "name": "Music Theatre Studio 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30214",
+  "name": "Composition 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30015",
+  "name": "Independent Research Project",
+  "offered": [
+   "summer_term",
    "semester_1",
    "winter_term",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE90017",
-  "name": "Science and Technology Internship",
+  "code": "MEDI90051",
+  "name": "Ventricular Function",
   "offered": [
-   "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM40001",
+  "name": "Research Methods (Theatre Practice)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90026",
+  "name": "Advanced Industry Practice - Advertising",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90007",
+  "name": "Macroeconometrics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50032",
+  "name": "Administrative Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30238",
+  "name": "Advanced Harmonic and Rhythmic Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90052",
+  "name": "Nursing Science 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90023",
+  "name": "Food Microbiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20213",
+  "name": "Chamber Choir 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90002",
+  "name": "Database Systems & Information Modelling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN90016",
+  "name": "Software Processes and Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90119",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10195",
+  "name": "Music Making Laboratory 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN90001",
+  "name": "Honours Chinese A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI40014",
+  "name": "Biomedicine Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90120",
+  "name": "Vet Bioscience: Digestive System",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40011",
+  "name": "Graphic Narratives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE40002",
+  "name": "Advanced Investments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90238",
+  "name": "Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90088",
+  "name": "Graduate Research Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90031",
+  "name": "Project Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90115",
+  "name": "Information Systems Res Project Pt 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC40018",
+  "name": "HPS Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS30009",
+  "name": "Production Practice 3 - Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN40001",
+  "name": "Honours Japanese A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90390",
+  "name": "Architectural Engineering Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "SCIE90018",
@@ -14565,7 +16041,6611 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90155",
+  "name": "Second Instrument / Vocal Study 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90016",
+  "name": "Environmental Research Project (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS70002",
+  "name": "MVSc (Clinical) Practicum # PT",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL40006",
+  "name": "Actuarial Practice and Control I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN90004",
+  "name": "Modelling Complex Software Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90032",
+  "name": "Emerging Technologies and Issues",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90015",
+  "name": "Managerial Economics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90065",
+  "name": "Advanced Studies in Economics 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30159",
+  "name": "Acting for Singers 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90083",
+  "name": "Electrical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90028",
+  "name": "Criminology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO40009",
+  "name": "Indonesian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90061",
+  "name": "Internship II (Year Long) Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90164",
+  "name": "MLS Tax Clinic",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV70026",
+  "name": "Scriptwriting 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50026",
+  "name": "Obligations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90010",
+  "name": "Translation Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40018",
+  "name": "Economics Research Essay Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90307",
+  "name": "MSD Vocational Placement",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "may",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90013",
+  "name": "Process Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10180",
+  "name": "Contextual Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10007",
+  "name": "Screenwriting 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90037",
+  "name": "Engineering Capstone Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30019",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30001",
+  "name": "Parliamentary Internship",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE30002",
+  "name": "Science and Technology Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM20013",
+  "name": "Text and Audio Journalism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90036",
+  "name": "Enterprise Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90199",
+  "name": "Suzuki Practicum Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90014",
+  "name": "The World of Engineering Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH20001",
+  "name": "Exploring Human Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE30011",
+  "name": "Essentials of Corporate Valuation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN90003",
+  "name": "Graduate Spanish A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BTCH30002",
+  "name": "Trends & Issues in Agrifood Biotech",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENVS10006",
+  "name": "Mapping Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PLAN30004",
+  "name": "Transit Oriented Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG20016",
+  "name": "Fertility, Mortality and Social Change",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10023",
+  "name": "Introduction to Screenwriting Practices",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG10001",
+  "name": "Indigenous Australia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10025",
+  "name": "Sustainable and Equitable Energy Futures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LARC30001",
+  "name": "Site Tectonics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI30015",
+  "name": "Sociology of Work: The Future of Work",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10060",
+  "name": "Introduction to Indigenous Education",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10022",
+  "name": "Entrepreneurship Principles and Tools",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC10003",
+  "name": "Mind, Brain & Behaviour 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20084",
+  "name": "Staging Theatre for Youth Audiences",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90011",
+  "name": "Derivative Securities",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30029",
+  "name": "Geographies of Migration",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90050",
+  "name": "Advanced Database Systems",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90004",
+  "name": "Insurance Risk Models",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM20026",
+  "name": "Principles of Chemical Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90059",
+  "name": "Nursing Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC30023",
+  "name": "Light, Lasers, Optics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI20043",
+  "name": "Biochemistry in Agricultural Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90036",
+  "name": "Foundations of Marketing & Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS90005",
+  "name": "History and Philosophy of Museums",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90036",
+  "name": "Disorders of Fluency",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA90017",
+  "name": "Contemporary China",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM20001",
+  "name": "Molecular and Cellular Biomedicine",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90025",
+  "name": "Communication Across the Lifespan",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BTCH90010",
+  "name": "Genetically Modified Organisms",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20069",
+  "name": "Baroque Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20091",
+  "name": "String Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH20001",
+  "name": "Genetics, Health, and Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS20008",
+  "name": "Legal Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE30001",
+  "name": "Investments",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS10001",
+  "name": "Russian 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN20018",
+  "name": "Spanish 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN10010",
+  "name": "Variation in Japanese Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR30002",
+  "name": "Neurophysiology: Neurons and Circuits",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG20001",
+  "name": "Indigenous Treaties and Titles",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10011",
+  "name": "The Secret Life of the Body 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30022",
+  "name": "Space Studio",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH20001",
+  "name": "Design Studio Beta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM10007",
+  "name": "Fundamentals of Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20064",
+  "name": "Concepts of Childhood",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL20003",
+  "name": "Earth Composition, Minerals and Magmas",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC20002",
+  "name": "Arabic 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI30009",
+  "name": "Living in a Risk Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20059",
+  "name": "American History: Revolution to WWII",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI20012",
+  "name": "Writing Identity and Difference",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90041",
+  "name": "Political Economy of Digital Life",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ATOC20001",
+  "name": "Weather and Climate Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10005",
+  "name": "Chinese 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10184",
+  "name": "Pop Song Writing 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10048",
+  "name": "Creativity, Play and the Arts",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH20004",
+  "name": "Digital Design",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20007",
+  "name": "Globalisation and the World Economy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC20008",
+  "name": "Developmental Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM20011",
+  "name": "Environmental Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND20008",
+  "name": "Sex and Gender Present and Future",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PLAN30001",
+  "name": "Planning Scenario and Policy Workshop",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT20002",
+  "name": "Intermediate Financial Accounting",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20011",
+  "name": "French Cinema: The New Wave and Beyond",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS20018",
+  "name": "Popular Culture: From K-pop to Selfies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM10001",
+  "name": "Crime, Criminology, and Critique",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20138",
+  "name": "Indonesian Gamelan Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL20001",
+  "name": "Introductory Financial Mathematics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90077",
+  "name": "Advanced Algorithms and Data Structures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20029",
+  "name": "Engineering Mathematics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS20029",
+  "name": "Latin 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST30076",
+  "name": "Stalinism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN10001",
+  "name": "Japanese 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL20039",
+  "name": "The Nature of Reality",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20007",
+  "name": "Chinese Studies: Culture and Empire",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10006",
+  "name": "Critical Thinking With Data",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20164",
+  "name": "Free Play New Music Improvisation Ensem",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30016",
+  "name": "Decadent Literature",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN30018",
+  "name": "Thermodynamics and Fluid Mechanics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PLAN10001",
+  "name": "Cities Past and Future",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20072",
+  "name": "Pirates and their Enemies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20005",
+  "name": "Contemporary Japan",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30006",
+  "name": "Global Literature and Postcolonialism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC10005",
+  "name": "Arabic 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN30010",
+  "name": "Digital System Design",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM30010",
+  "name": "Managing Justice: Agencies and the State",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20065",
+  "name": "Rebels and Revolutionaries",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PROP30001",
+  "name": "Valuation of Land and Buildings",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20135",
+  "name": "Chinese Music Ensemble 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS20014",
+  "name": "Intellectual Property Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT10001",
+  "name": "Accounting Reports and Analysis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS30006",
+  "name": "Global Cultures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN10001",
+  "name": "Introduction to Screen Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM30011",
+  "name": "Young People, Crime and Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GDES30001",
+  "name": "Infographics Studio",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL10009",
+  "name": "Biology: Life's Machinery",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30007",
+  "name": "Popular Fiction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG30004",
+  "name": "Aboriginal Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING20009",
+  "name": "Language in Aboriginal Australia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20003",
+  "name": "Japanese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW30011",
+  "name": "Underworld and Afterlife",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20068",
+  "name": "The French Revolution",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN30002",
+  "name": "Intro to Sustainable Water Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN30001",
+  "name": "Reactor Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL20036",
+  "name": "Environmental Building Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT30004",
+  "name": "Auditing and Assurance Services",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB30011",
+  "name": "Cellular Metabolism and Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "WELF90009",
+  "name": "Genetic Counselling Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10001",
+  "name": "German 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS10006",
+  "name": "Latin 1",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20012",
+  "name": "Water for Sustainable Futures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20013",
+  "name": "Japanese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE30001",
+  "name": "Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EVSC30003",
+  "name": "Environmental Risk Assessment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO20003",
+  "name": "Memory & Memoirs of 20th Century Europe",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10001",
+  "name": "Physics 1: Advanced",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN30014",
+  "name": "French Travel Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM10003",
+  "name": "Islam and Muslim Societies: Introduction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30020",
+  "name": "Arts Internship: Not for Profit",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20003",
+  "name": "Critical Analytical Skills",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20010",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20149",
+  "name": "Music Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM10003",
+  "name": "Chemistry 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20173",
+  "name": "The Art of Game Music",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30012",
+  "name": "Variation in Japanese Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HEBR20007",
+  "name": "Hebrew 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30010",
+  "name": "Microeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST10012",
+  "name": "The World Since World War II",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HEBR10011",
+  "name": "Hebrew 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL20038",
+  "name": "Nietzsche and Critics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS20011",
+  "name": "The Politics of Sex",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC30014",
+  "name": "The Psychopathology of Everyday Life",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI10001",
+  "name": "Understanding Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING20005",
+  "name": "Phonetics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL40002",
+  "name": "Risk Theory I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO30009",
+  "name": "Game Design",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN30017",
+  "name": "Mechanics & Materials",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS10012",
+  "name": "Latin 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "WELF90004",
+  "name": "Principles of Counselling 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "CEDB20003",
+  "name": "Fundamentals of Cell Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM30001",
+  "name": "German Cultural Studies B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT20006",
+  "name": "Principles of Human Structure",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30005",
+  "name": "Japanese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR90018",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH10002",
+  "name": "Construction as Alchemy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV30023",
+  "name": "Animation Studio 3A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10012",
+  "name": "Screenwriting Practices 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20014",
+  "name": "Animation Research 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20019",
+  "name": "Writing Animation 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV30021",
+  "name": "Collaborative Production",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10014",
+  "name": "Pictures, Sounds, Words",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90245",
+  "name": "Orchestra Audition Preparation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90026",
+  "name": "Minor Thesis 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90141",
+  "name": "Business Analysis & Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90024",
+  "name": "International History",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20080",
+  "name": "Early Voices 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40083",
+  "name": "Research Methods",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90001",
+  "name": "Researching/Writing Stories",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90295",
+  "name": "Construction Regulations and Control",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90018",
+  "name": "Contemporary Geographical Thought",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90014",
+  "name": "Epidemiology 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90193",
+  "name": "Studio Teaching 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI40006",
+  "name": "Biomedical Advanced Coursework",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90234",
+  "name": "Core Skills in Opera 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90003",
+  "name": "Research in Applied Linguistics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90025",
+  "name": "Research Project In Geoscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90018",
+  "name": "Advanced Fluid Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO40001",
+  "name": "Honours Indonesian A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90011",
+  "name": "Anatomy and Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90001",
+  "name": "Mathematics of Finance I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90106",
+  "name": "Data Science Project Pt1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40101",
+  "name": "Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90013",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20201",
+  "name": "Performance 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90026",
+  "name": "Extreme Loading of Structures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90024",
+  "name": "Production Collaboration",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90047",
+  "name": "OMS Clinical Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90026",
+  "name": "Introduction to Optimisation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90397",
+  "name": "MSD Minor Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90018",
+  "name": "Particle Mechanics and Processing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90104",
+  "name": "Chronic Disease Management: Foundations",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90082",
+  "name": "Software Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90078",
+  "name": "Computer Science Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90100",
+  "name": "Recital 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90048",
+  "name": "Second Language Teaching Methodology",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90197",
+  "name": "Professional Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90046",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90066",
+  "name": "Soil Science and Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW40014",
+  "name": "Research in Ancient World Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90022",
+  "name": "Research Methods",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40102",
+  "name": "Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90021",
+  "name": "Medical Imaging",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90110",
+  "name": "Information Systems Min Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT40001",
+  "name": "Research in Financial Accounting",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90058",
+  "name": "Applications of Echocardiography",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90032",
+  "name": "Applied Syndicate Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90077",
+  "name": "Empirical Investments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10066",
+  "name": "Guitar Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90033",
+  "name": "Linguistics for Speech Pathology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50064",
+  "name": "Employment Law",
+  "offered": [
+   "february",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50075",
+  "name": "Trade Mark Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90050",
+  "name": "Public /Social Policy Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90361",
+  "name": "ExLaB: Experimental Furniture Futures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RADI90022",
+  "name": "Diagnostic Radiology Minor Thesis 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90023",
+  "name": "Practical Earth Science B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90105",
+  "name": "Chronic Disease Management: In Practice",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW40012",
+  "name": "The Roman Way of Life",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90101",
+  "name": "Obstetrics Gynaecology and Practicum",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI90018",
+  "name": "Advanced Writing Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG40002",
+  "name": "Textual Revelations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90001",
+  "name": "Principles of Arts Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40067",
+  "name": "Honours Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90009",
+  "name": "Researching Texts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90100",
+  "name": "Abdominal and Peri-Arrest Ultrasound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40095",
+  "name": "The Music of Spain",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30068",
+  "name": "Design Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90010",
+  "name": "Performing Arts Research Methodologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV30011",
+  "name": "Screen Culture and Aesthetics 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90028",
+  "name": "Geography Practical",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90237",
+  "name": "Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30033",
+  "name": "Farm Management Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90020",
+  "name": "Environmental Industry Research (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90022",
+  "name": "Practical Earth Science A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40062",
+  "name": "Honours Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30028",
+  "name": "Studio Studies 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90869",
+  "name": "Doctor of Education Thesis Proposal",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90111",
+  "name": "Well-being in Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL90007",
+  "name": "Literature Review",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90016",
+  "name": "Environmental Economics and Strategy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN90003",
+  "name": "Graduate French A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG40003",
+  "name": "Advancing Geography & Environmental Stud",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90081",
+  "name": "Minor Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20177",
+  "name": "Contextual Studies 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90075",
+  "name": "Economic Analysis and Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20044",
+  "name": "Microbiology in Agriculture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA10025",
+  "name": "Studio Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90229",
+  "name": "Orchestral Performance Practicum 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM90003",
+  "name": "Graduate German A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90930",
+  "name": "Local Literacies in Global Contexts",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50119",
+  "name": "Sports Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90013",
+  "name": "Case Studies in Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM40006",
+  "name": "Micro & Immuno Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90006",
+  "name": "Conservation Internship and Projects",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90168",
+  "name": "Vulnerable Young People",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40060",
+  "name": "Concerto",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90064",
+  "name": "Emerging Markets Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90868",
+  "name": "Advanced Methodology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90287",
+  "name": "Professional Practice - Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90015",
+  "name": "Researching Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM40018",
+  "name": "Media & Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90005",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM40016",
+  "name": "German Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND40008",
+  "name": "Queer Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN40017",
+  "name": "Screen & Cultural Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40027",
+  "name": "English & Theatre Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90011",
+  "name": "Researching Images",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90239",
+  "name": "Professional Practice - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90046",
+  "name": "Treasury Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90012",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90021",
+  "name": "Conservation and Cultural Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90026",
+  "name": "Interdisciplinary Industry Project 1",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM40005",
+  "name": "Punishment and Detention: New Challenges",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI40002",
+  "name": "Advanced Studies in Biomedicine",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90030",
+  "name": "Media and Communications Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90284",
+  "name": "Research Project in Public Health Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN40007",
+  "name": "Spanish & Latin American Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40018",
+  "name": "Don Juan: Our Contemporary",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90072",
+  "name": "Major Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90105",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90064",
+  "name": "Advanced Methods: Differential Equations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN40008",
+  "name": "Spanish & Latin American Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20181",
+  "name": "Interactive Composition 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV40011",
+  "name": "Research Methods (Screenwriting)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90029",
+  "name": "Advanced Solid Mechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RADI90021",
+  "name": "Diagnostic Radiology 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90021",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING40002",
+  "name": "Issues in Linguistic Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90021",
+  "name": "Translation, Interpreting, Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90520",
+  "name": "Data Wrangling and Visualisation",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90019",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20089",
+  "name": "Guitar Ensemble 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40001",
+  "name": "Actuarial Studies Research Essay",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90044",
+  "name": "Research Methods",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10076",
+  "name": "Piano Duo and Duet 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90085",
+  "name": "Communicating Current Issues in Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90037",
+  "name": "MFPI Internship Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90039",
+  "name": "Executive Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90020",
+  "name": "Distributed Algorithms",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90043",
+  "name": "Gastrointestinal Tract Pancreas Adrenals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40017",
+  "name": "Practical Study 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10052",
+  "name": "Brass Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT40007",
+  "name": "Special Research Topics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90368",
+  "name": "Architecture and Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90015",
+  "name": "Journalism Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM40011",
+  "name": "Writing for the Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90048",
+  "name": "Project Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40004",
+  "name": "Value Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90079",
+  "name": "Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90016",
+  "name": "Engineering Management Capstone",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90043",
+  "name": "Enterprise Applications & Architectures",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIEN90003",
+  "name": "Biochemical Engineering Minor Thesis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30253",
+  "name": "Performance 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90225",
+  "name": "Music Outreach & Social Entrepreneurship",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP90017",
+  "name": "Immunisation and Travel Health",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90025",
+  "name": "Minor Thesis 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM10005",
+  "name": "Academic Writing and Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90013",
+  "name": "Spatial Information Research Project C",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90083",
+  "name": "Research Methods & Ultrasound Literature",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA60013",
+  "name": "Critical Issues in Contemporary Art A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA40004",
+  "name": "Asian Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90043",
+  "name": "Spatial IT Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40024",
+  "name": "Renaissance Drama",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90002",
+  "name": "Managing in Asia",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40038",
+  "name": "Ancient Greek Honours Seminar 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90948",
+  "name": "Mathematics: Improving Learning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90066",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC90020",
+  "name": "Environmental Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE10003",
+  "name": "Science: Supporting Health and Wellbeing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90389",
+  "name": "Urban Design Studio C",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90042",
+  "name": "Liver, Spleen and Sampling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90063",
+  "name": "Introduction to Quantum Computing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC90010",
+  "name": "Statistics in Climate Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90064",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90207",
+  "name": "Management & Marketing Special Topics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90015",
+  "name": "Industry Investigation Project A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90028",
+  "name": "Arts Management Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90057",
+  "name": "Education Capstone Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90016",
+  "name": "Principles of Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90105",
+  "name": "Methods of Mathematical Statistics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90021",
+  "name": "International Traditions in Journalism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90029",
+  "name": "Differential Topology and Geometry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10229",
+  "name": "Sound Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90038",
+  "name": "Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90001",
+  "name": "Electrophysiological Assessment B",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SURG40002",
+  "name": "Advanced Studies in Biomedicine: Surgery",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90081",
+  "name": "Business Process Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90027",
+  "name": "Arts Management Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS40024",
+  "name": "Key Debates in Political Science 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90010",
+  "name": "Strategic Human Resources",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90010",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RADI90019",
+  "name": "Diagnostic Radiology 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90025",
+  "name": "Consecutive Interpreting",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30167",
+  "name": "Brass Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50024",
+  "name": "Principles of Public Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90022",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10221",
+  "name": "Practical Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50127",
+  "name": "Philosophical Foundations of Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70006",
+  "name": "International Tax: Principles, Structure",
+  "offered": [
+   "semester_1",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MREN90001",
+  "name": "Polymers and Composites",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE40001",
+  "name": "Critical Thinking in Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50078",
+  "name": "Environmental Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB20024",
+  "name": "Designer Humans - Prospects & Perils",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90026",
+  "name": "Supply Chain Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90041",
+  "name": "The Politics of Food",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90038",
+  "name": "Human Rights",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC90015",
+  "name": "Environmental Impact Assessment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN40011",
+  "name": "French Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS20011",
+  "name": "Production Studio 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90047",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90103",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90004",
+  "name": "Accounting for Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90003",
+  "name": "Journalism Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90929",
+  "name": "Understanding Education in Context",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70469",
+  "name": "Construction Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90018",
+  "name": "Internship I (Placement Only)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90035",
+  "name": "Risk in Construction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO40012",
+  "name": "Vision Science Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN90031",
+  "name": "Quantitative Environmental Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR40006",
+  "name": "Research Methods (Music Theatre)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90014",
+  "name": "Screen Design Projects A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90135",
+  "name": "Analytical Methods",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90083",
+  "name": "Internship for Agricultural Sciences Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90201",
+  "name": "Entrepreneurial Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90016",
+  "name": "International Financial Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP60002",
+  "name": "Preventive Health Care",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT40008",
+  "name": "Honours Research Essay Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30019",
+  "name": "Chamber Music 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90049",
+  "name": "Principles of Ultrasound Heart Scan",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90029",
+  "name": "Analysing Energy Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90031",
+  "name": "Energy Systems Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20013",
+  "name": "Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90324",
+  "name": "Materials and Structures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG40004",
+  "name": "Indigenous Studies Thesis Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90013",
+  "name": "Communication for Research Scientists",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10207",
+  "name": "Medieval and Renaissance Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50036",
+  "name": "Remedies",
+  "offered": [
+   "semester_1",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90007",
+  "name": "Stakeholders and Fundraising in the Arts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90090",
+  "name": "Autonomous Systems Clinic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90048",
+  "name": "Managing ICT Infrastructure",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN90010",
+  "name": "High Integrity Systems Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90026",
+  "name": "Fundamentals of Information Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90051",
+  "name": "Advanced Communication Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90112",
+  "name": "Business Process Analytics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90039",
+  "name": "Creating Innovative Professionals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90021",
+  "name": "Critical Communication for Engineers",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90041",
+  "name": "Engineering Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL30008",
+  "name": "Actuarial Analytics and Data I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN30020",
+  "name": "Systems Modelling and Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90042",
+  "name": "Accounting and Finance for Actuaries",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG30012",
+  "name": "Business and Marketing Ethics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20082",
+  "name": "Conservatorium Choir 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20108",
+  "name": "MCM Chinese Music Ensemble",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90033",
+  "name": "Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN30021",
+  "name": "Mechanical Systems Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30008",
+  "name": "Street Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90041",
+  "name": "Applications of Music in Therapy A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90153",
+  "name": "Professional Practice 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90044",
+  "name": "Objectivist Research in Music Therapy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20088",
+  "name": "MCM Indonesian Gamelan Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST30002",
+  "name": "Land And Environment Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC20013",
+  "name": "Laboratory and Computational Physics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NUTR30005",
+  "name": "Molecular Nutrition and Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI40007",
+  "name": "Sociology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90013",
+  "name": "Strategy Execution for Engineers",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90038",
+  "name": "Engineering Capstone Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90035",
+  "name": "Victims and Criminal Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40020",
+  "name": "Reading and Writing Philosophy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90892",
+  "name": "Clinical Teaching Practice (EC) 1",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP10003",
+  "name": "Video Games: Remaking Reality",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH40001",
+  "name": "Pathology Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90025",
+  "name": "Journalism Project Part 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN20006",
+  "name": "Digital Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP40002",
+  "name": "Introduction to Primary Care Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS30030",
+  "name": "Introduction to Professional Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS20019",
+  "name": "Frontiers in Veterinary Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM30018",
+  "name": "Diplomacy: Engaging the Muslim World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30019",
+  "name": "Sustainable Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST30074",
+  "name": "Global Histories of Indigenous Activism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH40006",
+  "name": "Clinical Path Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90030",
+  "name": "Information Processes & Control",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE30027",
+  "name": "Inter-disciplinary Project",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC30006",
+  "name": "Production Animal Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90037",
+  "name": "Bioengineering Data Analytics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90055",
+  "name": "Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50055",
+  "name": "Advocacy",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30027",
+  "name": "Chinese 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN30010",
+  "name": "Mechanics for Bioengineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS30009",
+  "name": "Experimental Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90018",
+  "name": "Corporate Financial Policy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20031",
+  "name": "Analysis of Biological Data",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90005",
+  "name": "Ethics and Responsibility in Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SKIL90004",
+  "name": "Project Management in Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90007",
+  "name": "Project Management Practices",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC30001",
+  "name": "Animal Disease Biotechnology 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30037",
+  "name": "Soil Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90086",
+  "name": "Quality and Safety in Healthcare",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90069",
+  "name": "Clinical Leadership in Context",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90067",
+  "name": "Health Assessment for Advanced Practice1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP40000",
+  "name": "Primary Care Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30007",
+  "name": "Japanese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE20003",
+  "name": "Korean 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOL30007",
+  "name": "Marine Ecosystems: Ecology & Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG20002",
+  "name": "Landscapes and Environmental Change",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC20006",
+  "name": "Biological Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO20003",
+  "name": "Database Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30032",
+  "name": "Campaigns and Elections",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD30007",
+  "name": "Food Processing & Preservation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30139",
+  "name": "Shakuhachi Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA20001",
+  "name": "Green Planet: Plants and the Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30015",
+  "name": "International Gender Politics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30053",
+  "name": "Formative Ideas in Architecture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20124",
+  "name": "University Symphonic Ensembles 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP20001",
+  "name": "Street Art",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20029",
+  "name": "Critical and Theoretical Studies 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS30001",
+  "name": "Russian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30004",
+  "name": "Japanese through the Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20025",
+  "name": "Archaeology of the Roman World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90226",
+  "name": "Societal Implications of Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB20018",
+  "name": "Going Places - Travelling Smarter",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20163",
+  "name": "Samba Band",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS30020",
+  "name": "Contemporary Art",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20073",
+  "name": "Links Between Health and Learning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10002",
+  "name": "Logic: Language and Information",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10173",
+  "name": "Guitar Group 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM10008",
+  "name": "German 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH20011",
+  "name": "Ethnic Nationalism and the Modern World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10003",
+  "name": "Chinese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL30043",
+  "name": "The Power and Limits of Logic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS10001",
+  "name": "Art History: Theory and Controversy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO10012",
+  "name": "Literature: Reading Indonesian Lives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING20011",
+  "name": "Grammar of English",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN20009",
+  "name": "Transport Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL30024",
+  "name": "The Foundations of Interpretation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10003",
+  "name": "Physics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BLAW20001",
+  "name": "Corporate Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10006",
+  "name": "Calculus 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10004",
+  "name": "Ancient Greek 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS20008",
+  "name": "Human Physiology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA20001",
+  "name": "Media and Urban Culture in Asia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20174",
+  "name": "The Laptop Recording Studio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20012",
+  "name": "Chinese 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20012",
+  "name": "French Travel Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC30004",
+  "name": "Applied Animal Reproduction & Genetics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG30003",
+  "name": "Service and Relationship Marketing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC10002",
+  "name": "Science and Pseudoscience",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN20022",
+  "name": "Spanish 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20070",
+  "name": "Learning via Sport and Outdoor Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10058",
+  "name": "Music, Learning and Popular Musicians",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL30015",
+  "name": "Italian 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR90015",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN20005",
+  "name": "Foundations of Electrical Networks",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE30002",
+  "name": "Genes: Organisation and Function",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30020",
+  "name": "Mathematical Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10026",
+  "name": "Disability, Diversity and Inclusion",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL10004",
+  "name": "Global Foundations of Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30011",
+  "name": "Chinese Politics and Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI20005",
+  "name": "Creative Non Fiction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC20012",
+  "name": "Quantum and Thermal Physics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AIND10004",
+  "name": "Art and Indigenous Voice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS20011",
+  "name": "European Renaissance Art",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH20007",
+  "name": "Working with Value",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20077",
+  "name": "Printing, Collage and Social Engagement",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30013",
+  "name": "Economic Analysis and Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA30000",
+  "name": "Business Judgement",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL10006",
+  "name": "Italian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH30001",
+  "name": "Design Studio Delta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20012",
+  "name": "Arts Internship: Not for Profit",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC20005",
+  "name": "Companion Animal Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC20006",
+  "name": "Arabic 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN30016",
+  "name": "Spanish 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC30008",
+  "name": "Atmospheric Processes and Composition",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30005",
+  "name": "Algebra",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS30003",
+  "name": "European Art & Absolute Power 1660-1815",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20008",
+  "name": "Australian Indigenous Politics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30017",
+  "name": "Perception, Memory and Cognition",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA10001",
+  "name": "Language and Power in Asian Societies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN10003",
+  "name": "Spanish 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC20004",
+  "name": "Arabic 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90004",
+  "name": "Sustainability Governance and Leadership",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL10002",
+  "name": "Biomolecules and Cells",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90042",
+  "name": "Natural Language Processing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN40002",
+  "name": "Spanish Honours Language Seminar 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP10002",
+  "name": "Foundations of Algorithms",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM20018",
+  "name": "Chemistry: Reactions and Synthesis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20017",
+  "name": "Indonesia in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20009",
+  "name": "Vector Calculus",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30025",
+  "name": "Linear Statistical Models",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30046",
+  "name": "Steel and Concrete Structural Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB30003",
+  "name": "Molecular Aspects of Cell Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB30010",
+  "name": "Advanced Techniques in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH30001",
+  "name": "Mechanisms of Human Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL30046",
+  "name": "Romancing the Medieval",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR10005",
+  "name": "Hebrew 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10056",
+  "name": "Learning and the Digital Generations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30011",
+  "name": "Graph Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20023",
+  "name": "Ancient Egyptian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR90017",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS20013",
+  "name": "Ancient Greek 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL30001",
+  "name": "Actuarial Modelling I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30011",
+  "name": "Great Chinese Classics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20022",
+  "name": "Advanced Seminar in Chinese",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90002",
+  "name": "Art Museums and Curatorship",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR10004",
+  "name": "Engineering Technology and Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM30016",
+  "name": "Techniques in Microbiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20026",
+  "name": "Real Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30020",
+  "name": "Probability for Inference",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO30006",
+  "name": "Literature: Reading Indonesian Lives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB40012",
+  "name": "Biochemistry Research Project Part 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN10007",
+  "name": "Japanese 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20007",
+  "name": "Japanese 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70041",
+  "name": "Storytelling Workshop",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70042",
+  "name": "Cinematic Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20015",
+  "name": "Animation Studio 2A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST40039",
+  "name": "History Thesis Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90191",
+  "name": "The Research Process For Musicians (RHD)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN30006",
+  "name": "Software Modelling and Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN30014",
+  "name": "Analog and Digital Electronics Concepts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB20005",
+  "name": "Techniques in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB40009",
+  "name": "Biochemistry Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90015",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20006",
+  "name": "Probability for Statistics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20009",
+  "name": "Chinese Economic Documents",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30024",
+  "name": "Economics of Financial Markets",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM30017",
+  "name": "Specialised Topics in Chemistry A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM30015",
+  "name": "Advanced Practical Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20001",
+  "name": "Chinese 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL20012",
+  "name": "Italian 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV30023",
+  "name": "Animation Studio 3A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10012",
+  "name": "Screenwriting Practices 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20014",
+  "name": "Animation Research 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20019",
+  "name": "Writing Animation 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV30021",
+  "name": "Collaborative Production",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10014",
+  "name": "Pictures, Sounds, Words",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90245",
+  "name": "Orchestra Audition Preparation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90026",
+  "name": "Minor Thesis 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90131",
+  "name": "Veterinary Parasitology A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90018",
+  "name": "Journalism Project (Extended) Part 2",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50039",
+  "name": "Legal Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90314",
+  "name": "Property Agency and Marketing (PG)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90002",
+  "name": "Research for Hearing and Speech Sciences",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI40005",
+  "name": "Research Project - SVHM Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90058",
+  "name": "Signal Processing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHRM90002",
+  "name": "Pharmacology for Health Professionals",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90009",
+  "name": "Physical Cosmology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90002",
+  "name": "Editorial English",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90103",
+  "name": "Prehabilitation and Risk Assessment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30250",
+  "name": "Practical Music 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90031",
+  "name": "Advanced Linguistics Analysis A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90030",
+  "name": "Criminology & Sociology Internship Pt 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90038",
+  "name": "IS Strategy and Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90197",
+  "name": "Professional Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90046",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90066",
+  "name": "Soil Science and Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW40014",
+  "name": "Research in Ancient World Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90022",
+  "name": "Research Methods",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90011",
+  "name": "Research Design 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI40017",
+  "name": "Agric.Science Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS40021",
+  "name": "Politics & International Thesis Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90054",
+  "name": "Ultrasound Guided Procedures",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CREA90002",
+  "name": "Arts for Health and Wellbeing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90005",
+  "name": "Advanced Econometric Techniques",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90035",
+  "name": "International Relations Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA90013",
+  "name": "International Relations Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90018",
+  "name": "Biomedical Engineering Capstone Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30051",
+  "name": "Minor Music Performance 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LANG40003",
+  "name": "Seminar in Languages 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90237",
+  "name": "Major Role Preparation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90148",
+  "name": "Consulting Fundamentals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90029",
+  "name": "Vet Public Health Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90156",
+  "name": "Performing to Teach 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90024",
+  "name": "Adv Clinical Practice in Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90025",
+  "name": "Environmental Industry Research (25)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS40010",
+  "name": "Russian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90079",
+  "name": "Health IT Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90059",
+  "name": "Advanced Echocardiography Interpretation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90001",
+  "name": "Principles of Arts Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40067",
+  "name": "Honours Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90009",
+  "name": "Researching Texts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90100",
+  "name": "Abdominal and Peri-Arrest Ultrasound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40095",
+  "name": "The Music of Spain",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30068",
+  "name": "Design Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90010",
+  "name": "Performing Arts Research Methodologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV30011",
+  "name": "Screen Culture and Aesthetics 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90028",
+  "name": "Geography Practical",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90237",
+  "name": "Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30033",
+  "name": "Farm Management Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90020",
+  "name": "Environmental Industry Research (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90022",
+  "name": "Practical Earth Science A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40062",
+  "name": "Honours Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30028",
+  "name": "Studio Studies 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM40003",
+  "name": "Drugs and Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10006",
+  "name": "Screen Practice 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90074",
+  "name": "Introduction to Power Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL40016",
+  "name": "Italian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90069",
+  "name": "Electrical Power Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90107",
+  "name": "Landscape Studio 1: Design Techniques",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90014",
+  "name": "Optimisation for Industry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10191",
+  "name": "Interactive Composition 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90148",
+  "name": "Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90024",
+  "name": "Industry Core and Placement",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90273",
+  "name": "Urban Design Studio B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90033",
+  "name": "Geography Minor Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10220",
+  "name": "Practical Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90020",
+  "name": "Spatial Information Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM30002",
+  "name": "Biomedicine: Molecule to Malady",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30229",
+  "name": "Interactive Composition 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30257",
+  "name": "Figured Bass Realisation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIEN90001",
+  "name": "Biochemical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40061",
+  "name": "Recital",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD40001",
+  "name": "Food Science Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90425",
+  "name": "Informal Settlement",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90015",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC40008",
+  "name": "Arabic Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90069",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30193",
+  "name": "Piano Duo and Duet 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90106",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90289",
+  "name": "Biostatistics Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90035",
+  "name": "Advanced Clinical Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90131",
+  "name": "Veterinary Parasitology A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90018",
+  "name": "Journalism Project (Extended) Part 2",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50039",
+  "name": "Legal Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90001",
+  "name": "Global Strategy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90314",
+  "name": "Property Agency and Marketing (PG)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90002",
+  "name": "Research for Hearing and Speech Sciences",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI40005",
+  "name": "Research Project - SVHM Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHRM90002",
+  "name": "Pharmacology for Health Professionals",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90058",
+  "name": "Signal Processing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90009",
+  "name": "Physical Cosmology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90031",
+  "name": "Advanced Linguistics Analysis A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90038",
+  "name": "IS Strategy and Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90002",
+  "name": "Editorial English",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90103",
+  "name": "Prehabilitation and Risk Assessment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30250",
+  "name": "Practical Music 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90030",
+  "name": "Criminology & Sociology Internship Pt 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90197",
+  "name": "Professional Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW40019",
+  "name": "Frontiers of the Greek World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90043",
+  "name": "Gastrointestinal Tract Pancreas Adrenals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10052",
+  "name": "Brass Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT40007",
+  "name": "Special Research Topics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90368",
+  "name": "Architecture and Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90015",
+  "name": "Researching Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM40011",
+  "name": "Writing for the Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90015",
+  "name": "Journalism Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90048",
+  "name": "Project Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN40017",
+  "name": "Screen & Cultural Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM40016",
+  "name": "German Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND40008",
+  "name": "Queer Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40027",
+  "name": "English & Theatre Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90239",
+  "name": "Professional Practice - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90011",
+  "name": "Researching Images",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90046",
+  "name": "Treasury Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIEN90003",
+  "name": "Biochemical Engineering Minor Thesis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30253",
+  "name": "Performance 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90225",
+  "name": "Music Outreach & Social Entrepreneurship",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90012",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90043",
+  "name": "Enterprise Applications & Architectures",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90021",
+  "name": "Conservation and Cultural Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90026",
+  "name": "Interdisciplinary Industry Project 1",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM40005",
+  "name": "Punishment and Detention: New Challenges",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI40002",
+  "name": "Advanced Studies in Biomedicine",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90025",
+  "name": "Minor Thesis 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP90017",
+  "name": "Immunisation and Travel Health",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90030",
+  "name": "Media and Communications Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90284",
+  "name": "Research Project in Public Health Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30225",
+  "name": "Ensemble Studies 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90013",
+  "name": "Spatial Information Research Project C",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM10005",
+  "name": "Academic Writing and Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90059",
+  "name": "Lightwave Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90070",
+  "name": "Minor Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90031",
+  "name": "Spatial Information Research Project D",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA60013",
+  "name": "Critical Issues in Contemporary Art A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA40004",
+  "name": "Asian Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90083",
+  "name": "Research Methods & Ultrasound Literature",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40012",
+  "name": "GradDip Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90071",
+  "name": "DRFS Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90043",
+  "name": "Spatial IT Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90029",
+  "name": "Adv Clinical Practice in Specialty 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90070",
+  "name": "Clinical Sexual & Reproductive Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50025",
+  "name": "Torts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40013",
+  "name": "GradDip Composition 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90414",
+  "name": "Lean Construction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40024",
+  "name": "Renaissance Drama",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90044",
+  "name": "Thinking and Reasoning with Data",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90013",
+  "name": "Econometrics 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90002",
+  "name": "Managing in Asia",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40038",
+  "name": "Ancient Greek Honours Seminar 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90118",
+  "name": "Applied Architectural Technology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90948",
+  "name": "Mathematics: Improving Learning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90066",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90224",
+  "name": "Orchestral Experience 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10027",
+  "name": "Everyday Morality",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20026",
+  "name": "Minor Music Performance 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90042",
+  "name": "Liver, Spleen and Sampling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC90020",
+  "name": "Environmental Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE10003",
+  "name": "Science: Supporting Health and Wellbeing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90011",
+  "name": "Economic Analysis for Engineers",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90022",
+  "name": "Collaboration in Action",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "WELF90006",
+  "name": "Fitness to Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90055",
+  "name": "Control Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH40010",
+  "name": "Anthropology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90131",
+  "name": "Internship II",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
  },
  {
   "code": "SCIE90027",
@@ -14574,762 +22654,138 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCIE90034",
-  "name": "Communicating Science at Work",
+  "code": "ABPL90420",
+  "name": "Interactive Architecture",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCRN10001",
-  "name": "Introduction to Screen Studies",
+  "code": "MUST10013",
+  "name": "Music Theatre Contextual Studies 1",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCRN20011",
-  "name": "Hollywood and Entertainment",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SCRN30005",
-  "name": "The Digital Screenscape",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SCRN40002",
-  "name": "Contemporary Film Theory",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SCRN40010",
-  "name": "Dream Screen: Film and Psychoanalysis",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SCRN40017",
-  "name": "Screen & Cultural Studies Thesis Part 1",
+  "code": "MGMT90018",
+  "name": "Managing Behaviour in Organisations",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCRN40018",
-  "name": "Screen & Cultural Studies Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "SKIL90004",
-  "name": "Project Management in Science",
+  "code": "ECON90047",
+  "name": "Macroeconomics 2",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SOCI10001",
-  "name": "Understanding Society",
+  "code": "LAWS50063",
+  "name": "Competition Law",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SOCI20017",
-  "name": "Sexualising Society: Sociology of Sex",
+  "code": "VETS90068",
+  "name": "Applications in Animal Health 2 Part A",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SOCI30001",
-  "name": "Contemporary Sociological Theory",
+  "code": "MUSI30223",
+  "name": "Contextual Studies 5",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SOCI30005",
-  "name": "Sociology Internship",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "SOCI30009",
-  "name": "Living in a Risk Society",
+  "code": "CHEM90055",
+  "name": "Chemical Regulations and Safety",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SOCI30012",
-  "name": "Digital Technology and Social Change",
+  "code": "DPSS20010",
+  "name": "Production Practice 1",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SOCI30013",
-  "name": "Survey Design and Analysis",
+  "code": "POLS90026",
+  "name": "International Political Economy",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SOCI30015",
-  "name": "Sociology of Work: The Future of Work",
+  "code": "POPH90118",
+  "name": "Clinical Biostatistics",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SOCI40006",
-  "name": "Sociology Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "SOCI40007",
-  "name": "Sociology Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "SOCI40008",
-  "name": "Reading Sociology",
+  "code": "CRIM40002",
+  "name": "Qualitative Research Methods",
   "offered": [
    "semester_1"
-  ]
- },
- {
-  "code": "SOCI90010",
-  "name": "International Migration",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SOCI90013",
-  "name": "Social Policy Internship",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "SOCI90021",
-  "name": "Social Policy Special Topics B",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SOLS40002",
-  "name": "Socio-Legal Studies Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "SOTH20002",
-  "name": "Classical Sociological Theory",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SOTH40001",
-  "name": "Relationships in Modernity",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SPAN10001",
-  "name": "Spanish 1",
-  "offered": [
-   "semester_1",
-   "winter_term"
-  ]
- },
- {
-  "code": "SPAN10003",
-  "name": "Spanish 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SPAN10007",
-  "name": "Spanish 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SPAN20002",
-  "name": "Spanish 3",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SPAN20018",
-  "name": "Spanish 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SPAN20022",
-  "name": "Spanish 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SPAN30014",
-  "name": "Spanish 5",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SPAN30016",
-  "name": "Spanish 7",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SPAN30021",
-  "name": "Exploring Latin America",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SPAN40007",
-  "name": "Spanish & Latin American Thesis Part 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "SPAN40008",
-  "name": "Spanish & Latin American Thesis Part 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "SPAN90003",
-  "name": "Graduate Spanish A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SURG40002",
-  "name": "Advanced Studies in Biomedicine: Surgery",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SURG40005",
-  "name": "Surgery Research Project Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SURG90021",
-  "name": "Contemporary Surgical Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SURG90022",
-  "name": "Fundamentals of Peri-Operative Care",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SURG90023",
-  "name": "Fundamentals of Surgery I",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SURG90025",
-  "name": "Fundamentals of Surgery III",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SURG90026",
-  "name": "Surgical Research I",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SWEN20003",
-  "name": "Object Oriented Software Development",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "SWEN30006",
-  "name": "Software Modelling and Design",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "SWEN90004",
-  "name": "Modelling Complex Software Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SWEN90009",
-  "name": "Software Requirements Analysis",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SWEN90010",
-  "name": "High Integrity Systems Engineering",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "SWEN90016",
-  "name": "Software Processes and Management",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "THTR10019",
-  "name": "Clear Speech and Communication",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "THTR40006",
-  "name": "Research Methods (Music Theatre)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "THTR40009",
-  "name": "Research Methods (Production)",
-  "offered": [
-   "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
   "code": "THTR70006",
   "name": "Research and New Performance Writing",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "THTR70008",
-  "name": "Writing for Performance 1 (Solo)",
+  "code": "MGMT90016",
+  "name": "Performance & Reward Management",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "THTR70009",
-  "name": "Writing for Performance 2 (Collab)",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "TRAN90001",
-  "name": "Translation and Interpreting as Product",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "TRAN90006",
-  "name": "Translating in an Australian Context",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "TRAN90008",
-  "name": "Translating in a Chinese Context",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "TRAN90010",
-  "name": "Translation Internship",
+  "code": "LAWS70015",
+  "name": "Minor Thesis F/T LLM",
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "TRAN90012",
-  "name": "Translation and Interpreting Thesis 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "TRAN90013",
-  "name": "Translation and Interpreting Thesis 2",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "TRAN90020",
-  "name": "Business and Legal Translation",
+  "code": "VETS90082",
+  "name": "Animal Management and Veterinary Health",
   "offered": [
    "semester_1"
-  ]
- },
- {
-  "code": "TRAN90021",
-  "name": "Translation, Interpreting, Communication",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "TRAN90022",
-  "name": "Translation Industry Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "TRAN90023",
-  "name": "Translation Technologies",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "TRAN90024",
-  "name": "Teaching Translation and Interpreting",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "TRAN90025",
-  "name": "Consecutive Interpreting",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB10002",
-  "name": "Logic: Language and Information",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB10003",
-  "name": "An Ecological History of Humanity",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB10006",
-  "name": "Critical Thinking With Data",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB10009",
-  "name": "Food for a Healthy Planet",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB10011",
-  "name": "The Secret Life of the Body 1",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "UNIB10022",
-  "name": "Entrepreneurship Principles and Tools",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "UNIB10023",
-  "name": "The Making of Melbourne",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "UNIB10024",
-  "name": "Sustainability: hope for the Earth?",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB10025",
-  "name": "Sustainable and Equitable Energy Futures",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB10026",
-  "name": "Disability, Diversity and Inclusion",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB10027",
-  "name": "Everyday Morality",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB20001",
-  "name": "Climate Change ll",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB20012",
-  "name": "Water for Sustainable Futures",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB20018",
-  "name": "Going Places - Travelling Smarter",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "UNIB20024",
-  "name": "Designer Humans - Prospects & Perils",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB30002",
-  "name": "Global Health, Security & Sustainability",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "UNIB30010",
-  "name": "Food for a Healthy Planet III",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS20019",
-  "name": "Frontiers in Veterinary Science",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS30016",
-  "name": "Veterinary Bioscience: Digestive System",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS30029",
-  "name": "Veterinary Bioscience: Cells to Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS30030",
-  "name": "Introduction to Professional Practice",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS30031",
-  "name": "Animal Production Systems 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS40020",
-  "name": "Vet Bioscience Research Project Part 1",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS70001",
-  "name": "MVSc (Clinical) Practicum # FT",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "VETS70002",
-  "name": "MVSc (Clinical) Practicum # PT",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "VETS90029",
-  "name": "Vet Public Health Research Project",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "VETS90036",
-  "name": "Cardiovascular & Respiratory Emergencies",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "VETS90037",
-  "name": "Abdominal & Urogenital Emergencies",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "VETS90038",
-  "name": "Haemato, Neurologic & Global Conditions",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "VETS90039",
-  "name": "CPR, Eye Emergencies & Practical ECC",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "VETS90040",
-  "name": "General Principles and FAST Techniques",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "VETS90041",
-  "name": "Urinary Reproductive Tracts Lymph Nodes",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "VETS90042",
-  "name": "Liver, Spleen and Sampling",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "VETS90043",
-  "name": "Gastrointestinal Tract Pancreas Adrenals",
-  "offered": [
-   "semester_1",
-   "semester_2"
-  ]
+  ],
+  "online": true
  },
  {
   "code": "VETS90044",
@@ -15337,7 +22793,6212 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90277",
+  "name": "M.Epidemiology Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90019",
+  "name": "Advanced Heat & Mass Transport Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50094",
+  "name": "International Commercial Law & Disputes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90045",
+  "name": "Professional IS Consulting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90130",
+  "name": "Nursing Assessment & Care",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CREA90003",
+  "name": "Evaluation of Wellbeing in Creative Arts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90002",
+  "name": "Effective University Teaching",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS40020",
+  "name": "Vet Bioscience Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90045",
+  "name": "Spatial Tools for Ecosystem Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC40014",
+  "name": "Advanced Research Methods In Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90016",
+  "name": "Journalism Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90023",
+  "name": "Adv Clinical Practice in Specialty 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90079",
+  "name": "Advanced Experimental Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90058",
+  "name": "Veterinary Bioscience 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90017",
+  "name": "Marketing the Arts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE40005",
+  "name": "Research Methods (Dance)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10229",
+  "name": "Sound Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90001",
+  "name": "Electrophysiological Assessment B",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS40024",
+  "name": "Key Debates in Political Science 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90010",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70006",
+  "name": "International Tax: Principles, Structure",
+  "offered": [
+   "semester_1",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90103",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS20011",
+  "name": "Production Studio 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90047",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN40011",
+  "name": "French Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN90031",
+  "name": "Quantitative Environmental Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR40006",
+  "name": "Research Methods (Music Theatre)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90201",
+  "name": "Entrepreneurial Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT40008",
+  "name": "Honours Research Essay Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90016",
+  "name": "International Financial Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP60002",
+  "name": "Preventive Health Care",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90090",
+  "name": "Autonomous Systems Clinic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90048",
+  "name": "Managing ICT Infrastructure",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN90010",
+  "name": "High Integrity Systems Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90051",
+  "name": "Advanced Communication Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90112",
+  "name": "Business Process Analytics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90153",
+  "name": "Professional Practice 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90044",
+  "name": "Objectivist Research in Music Therapy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90041",
+  "name": "Applications of Music in Therapy A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20088",
+  "name": "MCM Indonesian Gamelan Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90013",
+  "name": "Strategy Execution for Engineers",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90038",
+  "name": "Engineering Capstone Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC20013",
+  "name": "Laboratory and Computational Physics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NUTR30005",
+  "name": "Molecular Nutrition and Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST30002",
+  "name": "Land And Environment Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90035",
+  "name": "Victims and Criminal Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40020",
+  "name": "Reading and Writing Philosophy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90023",
+  "name": "Child Psychopathology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90222",
+  "name": "Ex_Lab: Timber Furniture",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90101",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90005",
+  "name": "Hydrogeology/Environmental Geochemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR70009",
+  "name": "Writing for Performance 2 (Collab)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90004",
+  "name": "Public Administration Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90061",
+  "name": "Global Urban Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10050",
+  "name": "Agricultural Systems Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90018",
+  "name": "Research Project (MMS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO90002",
+  "name": "Graduate Indonesian A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90007",
+  "name": "Collection Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90007",
+  "name": "Cognitive-Behaviour Therapy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30042",
+  "name": "Landscape Studio: Urban Open Space",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90050",
+  "name": "Geotechnical Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP10003",
+  "name": "Video Games: Remaking Reality",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN20006",
+  "name": "Digital Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP40002",
+  "name": "Introduction to Primary Care Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90892",
+  "name": "Clinical Teaching Practice (EC) 1",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90025",
+  "name": "Journalism Project Part 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH40001",
+  "name": "Pathology Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI20017",
+  "name": "Sexualising Society: Sociology of Sex",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20223",
+  "name": "Music Performance Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM30018",
+  "name": "Diplomacy: Engaging the Muslim World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH40006",
+  "name": "Clinical Path Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30019",
+  "name": "Sustainable Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS30030",
+  "name": "Introduction to Professional Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90030",
+  "name": "Information Processes & Control",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS20019",
+  "name": "Frontiers in Veterinary Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST30074",
+  "name": "Global Histories of Indigenous Activism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90037",
+  "name": "Bioengineering Data Analytics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90055",
+  "name": "Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE30027",
+  "name": "Inter-disciplinary Project",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC30006",
+  "name": "Production Animal Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50055",
+  "name": "Advocacy",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN30010",
+  "name": "Mechanics for Bioengineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC30001",
+  "name": "Animal Disease Biotechnology 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30037",
+  "name": "Soil Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20031",
+  "name": "Analysis of Biological Data",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS30009",
+  "name": "Experimental Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90007",
+  "name": "Project Management Practices",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30027",
+  "name": "Chinese 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90086",
+  "name": "Quality and Safety in Healthcare",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90069",
+  "name": "Clinical Leadership in Context",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90067",
+  "name": "Health Assessment for Advanced Practice1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP40000",
+  "name": "Primary Care Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90018",
+  "name": "Corporate Financial Policy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90005",
+  "name": "Ethics and Responsibility in Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SKIL90004",
+  "name": "Project Management in Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE20003",
+  "name": "Korean 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30007",
+  "name": "Japanese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOL30007",
+  "name": "Marine Ecosystems: Ecology & Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD10001",
+  "name": "Beer Styles and Sensory Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM20010",
+  "name": "Comparing Media Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GDES20001",
+  "name": "Graphic Design Studio 2: Image & Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT20001",
+  "name": "Cost Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30041",
+  "name": "Construction Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM20002",
+  "name": "Criminal Law and Political Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB20001",
+  "name": "Climate Change ll",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN30013",
+  "name": "French Cinema: The New Wave and Beyond",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN30008",
+  "name": "Engineering Risk Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR30002",
+  "name": "Fluid Mechanics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10006",
+  "name": "Calculus 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10004",
+  "name": "Ancient Greek 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM20001",
+  "name": "Principles of Microbiology & Immunology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS20008",
+  "name": "Human Physiology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20080",
+  "name": "School Experience as Breadth",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN30005",
+  "name": "The Environmental Screenscape",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO10003",
+  "name": "Indonesian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA20001",
+  "name": "Media and Urban Culture in Asia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC20006",
+  "name": "Biological Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO20003",
+  "name": "Database Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30032",
+  "name": "Campaigns and Elections",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD30007",
+  "name": "Food Processing & Preservation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30139",
+  "name": "Shakuhachi Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP20001",
+  "name": "Street Art",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN10001",
+  "name": "French 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10012",
+  "name": "Introduction to Mathematics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC30034",
+  "name": "Magic, Reason, New Worlds, 1450-1750",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM30005",
+  "name": "Corporate Power and White Collar Crime",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20026",
+  "name": "Painting Techniques",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL10004",
+  "name": "Global Foundations of Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10026",
+  "name": "Disability, Diversity and Inclusion",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10056",
+  "name": "Learning and the Digital Generations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW10006",
+  "name": "Ancient Egyptian 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD30008",
+  "name": "Advanced Food Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS20004",
+  "name": "Russian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN10003",
+  "name": "Japanese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG20001",
+  "name": "Consumer Behaviour",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA20003",
+  "name": "Genders and Desires in Asia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN30009",
+  "name": "Electrical Network Analysis and Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL10005",
+  "name": "Understanding the Built Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC10001",
+  "name": "Arabic 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30008",
+  "name": "Chinese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20025",
+  "name": "Human Rights in East and Southeast Asia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30053",
+  "name": "Formative Ideas in Architecture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA20001",
+  "name": "Green Planet: Plants and the Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30015",
+  "name": "International Gender Politics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20124",
+  "name": "University Symphonic Ensembles 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20029",
+  "name": "Critical and Theoretical Studies 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG20002",
+  "name": "Landscapes and Environmental Change",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS30001",
+  "name": "Russian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI30012",
+  "name": "Digital Technology and Social Change",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR10005",
+  "name": "Hebrew 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL30046",
+  "name": "Romancing the Medieval",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG20004",
+  "name": "Racial Literacy: Indigeneity & Whiteness",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT20002",
+  "name": "Managing Processes and Projects",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20043",
+  "name": "History of Early Modern Philosophy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30011",
+  "name": "Graph Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL10008",
+  "name": "Introductory Biology: Life's Machinery",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20006",
+  "name": "Indonesian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30013",
+  "name": "Managing for Competitive Advantage",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH20002",
+  "name": "Design Studio Gamma",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20086",
+  "name": "Modern China in Global History 1949-1999",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL30048",
+  "name": "Performance and the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM20007",
+  "name": "German 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30001",
+  "name": "Geomorphology: Catchment to Coast",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL20007",
+  "name": "Italian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GDES30002",
+  "name": "Branding",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CREA10001",
+  "name": "Contemporary Art and Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10021",
+  "name": "Interactive Art Media 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC30004",
+  "name": "Applied Animal Reproduction & Genetics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG30003",
+  "name": "Service and Relationship Marketing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN20003",
+  "name": "Object Oriented Software Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20012",
+  "name": "French Travel Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20174",
+  "name": "The Laptop Recording Studio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20012",
+  "name": "Chinese 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENVS10001",
+  "name": "Natural Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM10006",
+  "name": "German 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20027",
+  "name": "Chinese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20023",
+  "name": "Ancient Egyptian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR90017",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH40005",
+  "name": "Pathology Research Project Part 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM30016",
+  "name": "Techniques in Microbiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30020",
+  "name": "Probability for Inference",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL30001",
+  "name": "Actuarial Modelling I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30011",
+  "name": "Great Chinese Classics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN10007",
+  "name": "Japanese 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20007",
+  "name": "Japanese 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20015",
+  "name": "French 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO10001",
+  "name": "Indonesian 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL20011",
+  "name": "Italian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM30002",
+  "name": "German Cultural Studies C",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20026",
+  "name": "Plant Growth Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC20012",
+  "name": "Quantum and Thermal Physics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI20005",
+  "name": "Creative Non Fiction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30011",
+  "name": "Chinese Politics and Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20025",
+  "name": "Archaeology of the Roman World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AIND10004",
+  "name": "Art and Indigenous Voice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS30020",
+  "name": "Contemporary Art",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL10002",
+  "name": "Biomolecules and Cells",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90042",
+  "name": "Natural Language Processing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN30014",
+  "name": "Analog and Digital Electronics Concepts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN40002",
+  "name": "Spanish Honours Language Seminar 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP10002",
+  "name": "Foundations of Algorithms",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR90015",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM20018",
+  "name": "Chemistry: Reactions and Synthesis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20017",
+  "name": "Indonesia in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20009",
+  "name": "Vector Calculus",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30025",
+  "name": "Linear Statistical Models",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB20005",
+  "name": "Techniques in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB40009",
+  "name": "Biochemistry Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90015",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN20005",
+  "name": "Foundations of Electrical Networks",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE30002",
+  "name": "Genes: Organisation and Function",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30020",
+  "name": "Mathematical Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB30010",
+  "name": "Advanced Techniques in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH30001",
+  "name": "Mechanisms of Human Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30046",
+  "name": "Steel and Concrete Structural Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB30003",
+  "name": "Molecular Aspects of Cell Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC30006",
+  "name": "Ecology of Urban Landscapes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20022",
+  "name": "Advanced Seminar in Chinese",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90002",
+  "name": "Art Museums and Curatorship",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB40012",
+  "name": "Biochemistry Research Project Part 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO30006",
+  "name": "Literature: Reading Indonesian Lives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR10004",
+  "name": "Engineering Technology and Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20026",
+  "name": "Real Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70028",
+  "name": "Documentary Projects 2A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90022",
+  "name": "Business of Producing 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20012",
+  "name": "Screenwriting Practices 2A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV30009",
+  "name": "Languages of the Screen",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV30025",
+  "name": "Screen Practice 3A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90227",
+  "name": "Orchestral Performance Practicum 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90035",
+  "name": "Knowledge Management Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90065",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90056",
+  "name": "Urban Transport Politics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40068",
+  "name": "Honours Composition 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI90015",
+  "name": "Creative Writing Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90989",
+  "name": "Capstone Professional Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90055",
+  "name": "International Relations Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90083",
+  "name": "Data Analysis for Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90010",
+  "name": "Advanced Construction Technology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20073",
+  "name": "Brass Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM10008",
+  "name": "Foundation Studies in Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90027",
+  "name": "Systems and Synthetic Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90027",
+  "name": "Advanced Seminars in Specialty 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90132",
+  "name": "Lie Algebras",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90093",
+  "name": "Ensemble A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RADI90017",
+  "name": "Diagnostic Radiology 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90276",
+  "name": "M.Epidemiology Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10092",
+  "name": "Vocal Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90020",
+  "name": "Business and Legal Translation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90004",
+  "name": "Anatomy and Physiology for Audiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90076",
+  "name": "IT Infrastructure for Digital Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90422",
+  "name": "SI-Lab: Scanning and Virtual Reality",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI40004",
+  "name": "Thinking Writing: Theory and Creativity",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS30008",
+  "name": "Production Practice 3 - Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI90021",
+  "name": "Social Policy Special Topics B",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90055",
+  "name": "Development Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90151",
+  "name": "Music Performance Curriculum& Assessment",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90066",
+  "name": "Foundations of Nursing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS90008",
+  "name": "Advanced Seminars in Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NUTR40001",
+  "name": "Human Nutrition Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90022",
+  "name": "Economics for Actuaries",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN40007",
+  "name": "Chinese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50101",
+  "name": "Refugee Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90008",
+  "name": "Consumers and Consumption",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90059",
+  "name": "Stochastic Calculus with Applications",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90071",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL90034",
+  "name": "Philosophical Methodology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90038",
+  "name": "Global Corporate Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP40001",
+  "name": "Research Methods (Social Practice)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90144",
+  "name": "The Teacher as Conductor",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90023",
+  "name": "Data Analytics in Insurance 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90078",
+  "name": "Contemporary Landscape Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI40006",
+  "name": "Sociology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90062",
+  "name": "Internship II (Year Long) Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90026",
+  "name": "Screen Language 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90020",
+  "name": "Directing Methodologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90011",
+  "name": "Marketing Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90076",
+  "name": "Short Research Project B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20018",
+  "name": "Writing for the Youth Screen Market",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC40006",
+  "name": "Ethics and Evidence-Based Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90003",
+  "name": "Integrated River & Catchment Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90039",
+  "name": "Forensic Odontology 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC90017",
+  "name": "Advanced Past Climates",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90009",
+  "name": "Language Testing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90010",
+  "name": "Art Curatorship Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20210",
+  "name": "Saxophone Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40105",
+  "name": "Dissertation Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30226",
+  "name": "Ensemble Studies 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90010",
+  "name": "Mental Health Issues Across the Lifespan",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC90013",
+  "name": "Science, Controversy and Public Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90002",
+  "name": "New Product Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90094",
+  "name": "Ensemble B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90001",
+  "name": "Omnichannel Retail",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90167",
+  "name": "Design Communications Workshop (P/G)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90023",
+  "name": "Chemical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90021",
+  "name": "Advanced Seminars in Specialty 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90010",
+  "name": "Statistical Mechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90036",
+  "name": "Capstone Project A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30165",
+  "name": "Big Band 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90020",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90041",
+  "name": "Urinary Reproductive Tracts Lymph Nodes",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90107",
+  "name": "Information Systems Maj Res Project Pt 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90074",
+  "name": "Economics Thesis Workshop Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10023",
+  "name": "Introduction to Screenwriting Practices",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN90004",
+  "name": "Modelling Complex Software Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90032",
+  "name": "Emerging Technologies and Issues",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90015",
+  "name": "Managerial Economics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90048",
+  "name": "Artificial Intelligence for Engineers",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90018",
+  "name": "Science Research Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90009",
+  "name": "Development Theories",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN40001",
+  "name": "Honours Japanese A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90010",
+  "name": "Print Production and Design",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40006",
+  "name": "Actuarial Practice and Control I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90013",
+  "name": "Independent Dramaturgy Project",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90117",
+  "name": "Health Indicators and Health Surveys",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50068",
+  "name": "Equality and Discrimination Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90390",
+  "name": "Architectural Engineering Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90035",
+  "name": "Public Consultation & Policy Negotiation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL40015",
+  "name": "Italian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90155",
+  "name": "Second Instrument / Vocal Study 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90016",
+  "name": "Environmental Research Project (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS70002",
+  "name": "MVSc (Clinical) Practicum # PT",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM20023",
+  "name": "Contextual Studies 2 Theory in Action",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90034",
+  "name": "Planning and Integrating Intervention",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW40016",
+  "name": "Ancient World Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90149",
+  "name": "Biostatistics Research Project - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20014",
+  "name": "Chamber Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90021",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN40006",
+  "name": "Public Policy & Management Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10225",
+  "name": "Chamber Choir 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90009",
+  "name": "Art Curatorship Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90034",
+  "name": "International Relations Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90074",
+  "name": "Copyright and Designs",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90003",
+  "name": "Mathematics of Finance III",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90285",
+  "name": "Research Project in Public Health Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90227",
+  "name": "Public Health in Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90147",
+  "name": "Performing to Teach 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90002",
+  "name": "Microeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90039",
+  "name": "Understanding Media & Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50058",
+  "name": "Melbourne University Law Review",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30251",
+  "name": "Practical Music 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90013",
+  "name": "Biostatistics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90017",
+  "name": "Urban Design Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90197",
+  "name": "Advanced Organisational Behaviour",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40002",
+  "name": "Recent European Philosophy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN90005",
+  "name": "Graduate Chinese A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90030",
+  "name": "Adv Clinical Practice in Specialty 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90050",
+  "name": "Terrorism and Insurgency",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40015",
+  "name": "American Fiction: The 20th Century",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90286",
+  "name": "Professional Practice - Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90039",
+  "name": "CPR, Eye Emergencies & Practical ECC",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90016",
+  "name": "Computational Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG40003",
+  "name": "Indigenous Studies Thesis Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90022",
+  "name": "Translation Industry Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20025",
+  "name": "Minor Music Performance 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ESLA90003",
+  "name": "Professional Literacies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90018",
+  "name": "Spatial Databases",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90029",
+  "name": "Criminology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20156",
+  "name": "Practical Anatomy for Classical Voice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90032",
+  "name": "Biomed Eng Capstone Proj Part 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90065",
+  "name": "Managing Global City Regions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90023",
+  "name": "The Writing of Australian History",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CREA90014",
+  "name": "Creative Arts Therapies Research 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90031",
+  "name": "Criminology & Sociology Internship Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90012",
+  "name": "Corporate Restructuring and Valuation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90041",
+  "name": "Property Law (PG)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90001",
+  "name": "Basic Econometrics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT40011",
+  "name": "Oral Health Sci Research Proj Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90039",
+  "name": "Mediation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90028",
+  "name": "Robotics Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90004",
+  "name": "States, Governments and the Arts",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90101",
+  "name": "Advanced Social Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90036",
+  "name": "Music Psychology Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90084",
+  "name": "Statistical Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90014",
+  "name": "Researching Politics and Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN90002",
+  "name": "Graduate Japanese A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90067",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91021",
+  "name": "Clinical Teaching Practice (GD EC) 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90039",
+  "name": "Advanced Surveying and Mapping",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90280",
+  "name": "Managerial Decision Analytics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90001",
+  "name": "Structural Editing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90067",
+  "name": "MSD Thesis -Semester Long (25 Points)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOLS40002",
+  "name": "Socio-Legal Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90066",
+  "name": "MSD Research Project Short (12.5 Points)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90050",
+  "name": "IT Project and Change Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90198",
+  "name": "Professional Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90024",
+  "name": "Computational Fluid Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90042",
+  "name": "Spatial Information Programming",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90080",
+  "name": "Computer Science Research Project Part 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM40019",
+  "name": "Media & Communications Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST40030",
+  "name": "History for Historians",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RURA90008",
+  "name": "Utilising Knowledge in Aboriginal Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90951",
+  "name": "Understanding Education Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90122",
+  "name": "Inference for Spatio-Temporal Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND90011",
+  "name": "Gender and Development Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90121",
+  "name": "Vet Bioscience: Cells to Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90017",
+  "name": "Actuarial Science Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO40009",
+  "name": "Indonesian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90033",
+  "name": "Research Project 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50130",
+  "name": "Advanced Torts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90072",
+  "name": "Data and Decision Making",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90061",
+  "name": "Internship II (Year Long) Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUST10014",
+  "name": "Music Theatre Studio 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30214",
+  "name": "Composition 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90209",
+  "name": "EMA Career Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30015",
+  "name": "Independent Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90051",
+  "name": "Ventricular Function",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM40001",
+  "name": "Research Methods (Theatre Practice)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90007",
+  "name": "Internet Technologies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT10015",
+  "name": "Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40092",
+  "name": "Music Management and Enterprise",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90012",
+  "name": "Researching Ideas",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90108",
+  "name": "Information Systems Maj Res Project Pt 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20112",
+  "name": "Vocal Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL40013",
+  "name": "Research Project - RMH Part 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90101",
+  "name": "Introduction to Statistical Computing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90033",
+  "name": "Bioinstrumentation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40063",
+  "name": "Honours Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA90008",
+  "name": "Perspectives in Art & Cultural Theory 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90024",
+  "name": "Teaching Translation and Interpreting",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS40006",
+  "name": "Russian Language & Culture 4A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90009",
+  "name": "Quantitative Methods for Business",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10014",
+  "name": "Foundation Mathematics 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90031",
+  "name": "Audiovisual Communication",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70003",
+  "name": "Minor Thesis (LLM) # P/T",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BTCH90009",
+  "name": "Genomics and Bioinformatics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30032",
+  "name": "Music Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90038",
+  "name": "MFPI Internship Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90525",
+  "name": "Business and Economics Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90010",
+  "name": "Newsroom-Applied Professional Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90043",
+  "name": "Sustainable Landscapes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90024",
+  "name": "Cultural Festivals and Special Events",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50060",
+  "name": "Melbourne Journal of International Law",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90224",
+  "name": "Garage Project",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90104",
+  "name": "Enhanced Recovery After Surgery",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90002",
+  "name": "Presenting Academic Discourse",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90005",
+  "name": "Thesis (Masters/coursework)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90086",
+  "name": "Communicating Agricultural Sciences",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90341",
+  "name": "Urban Environmental Policy and Planning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90084",
+  "name": "Neuroanatomy for Neuropsychologists",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50026",
+  "name": "Obligations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90039",
+  "name": "Biomedical Eng Management & Regulations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20182",
+  "name": "Music Making Laboratory 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30252",
+  "name": "Performance 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SURG40005",
+  "name": "Surgery Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90020",
+  "name": "Computational Economics and Business",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90034",
+  "name": "Marketing & Media in a Global Context",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90101",
+  "name": "Multilingual Practices in Global Times",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT10014",
+  "name": "Identity",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90239",
+  "name": "Lyric Diction for Opera",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90014",
+  "name": "Research Proposal 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PAED90007",
+  "name": "Professional Practice in Context",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BINF90002",
+  "name": "Elements of Bioinformatics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40079",
+  "name": "The Ethnography of Music (Honours)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40110",
+  "name": "Honours Music Studies 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90117",
+  "name": "Applications in Animal Health A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90070",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90002",
+  "name": "Econometrics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40040",
+  "name": "Latin Honours Seminar 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90116",
+  "name": "Information Systems Res Project Pt 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90023",
+  "name": "Publishing and Communications Thesis Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90038",
+  "name": "Haemato, Neurologic & Global Conditions",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH40009",
+  "name": "Anthropology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90036",
+  "name": "Conservation Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90417",
+  "name": "Environment Behavior Methods for Design",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90130",
+  "name": "Planning Law & Statutory Planning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90082",
+  "name": "Mathematical Statistics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90022",
+  "name": "Publishing and Communications Thesis Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90021",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90026",
+  "name": "Advanced Industry Practice - Advertising",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90195",
+  "name": "Professional Practice 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10058",
+  "name": "Conservatorium Choir 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90043",
+  "name": "Applications of Music in Therapy C",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20087",
+  "name": "MCM Indonesian Gamelan Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90035",
+  "name": "Graduate Research Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90036",
+  "name": "Leadership for Innovation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM30003",
+  "name": "Biomedical Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS40023",
+  "name": "Art History Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90288",
+  "name": "Biostatistics Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90048",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90122",
+  "name": "Intro to the Veterinary Profession",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90117",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90120",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90010",
+  "name": "Technology Innovation Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90221",
+  "name": "Orchestral Performance Practicum 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS40009",
+  "name": "Russian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN40006",
+  "name": "Chinese Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ESLA90001",
+  "name": "Professional Speaking Communication",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90274",
+  "name": "Property Markets and Valuations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CONS30001",
+  "name": "Building Information Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90009",
+  "name": "Judging Crime",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30047",
+  "name": "Music Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90038",
+  "name": "Advanced Clinical Practice 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90149",
+  "name": "Applied Instrumental and Vocal Teaching",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90109",
+  "name": "Information Systems Min Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90051",
+  "name": "Principles of Paediatric Audiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50059",
+  "name": "Legal Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "june",
+   "semester_2",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90059",
+  "name": "Nursing Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BTCH90010",
+  "name": "Genetically Modified Organisms",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM20001",
+  "name": "Molecular and Cellular Biomedicine",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90004",
+  "name": "Insurance Risk Models",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM20026",
+  "name": "Principles of Chemical Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30023",
+  "name": "Light, Lasers, Optics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90036",
+  "name": "Disorders of Fluency",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA90017",
+  "name": "Contemporary China",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20069",
+  "name": "Baroque Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20091",
+  "name": "String Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH20001",
+  "name": "Genetics, Health, and Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10057",
+  "name": "Wellbeing, Motivation and Performance",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS20006",
+  "name": "Russian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS10001",
+  "name": "Australian Politics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30007",
+  "name": "Derivative Securities",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA10026",
+  "name": "Critical and Theoretical Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN10004",
+  "name": "French 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP20007",
+  "name": "Design of Algorithms",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC30004",
+  "name": "Dynamical Meteorology and Oceanography",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10159",
+  "name": "Choir 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70020",
+  "name": "Narrative Projects 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC90003",
+  "name": "Graduate Arabic A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG10001",
+  "name": "Famine: The Geography of Scarcity",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE30002",
+  "name": "Two Koreas in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT20007",
+  "name": "Accounting Information: Risks & Controls",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS30002",
+  "name": "Introduction to Language Translation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI30013",
+  "name": "Survey Design and Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST30003",
+  "name": "Urban Forest Ecosystems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP30027",
+  "name": "Machine Learning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10024",
+  "name": "Sustainability: hope for the Earth?",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20085",
+  "name": "Singing, Song Writing and Youth Music",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS30029",
+  "name": "Veterinary Bioscience: Cells to Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS30031",
+  "name": "Animal Production Systems 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS30016",
+  "name": "Veterinary Bioscience: Digestive System",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90066",
+  "name": "Embedded System Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA70008",
+  "name": "Professional Perspectives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90041",
+  "name": "Programming and Software Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90051",
+  "name": "Statistical Machine Learning",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90015",
+  "name": "Distributed Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90005",
+  "name": "Quantitative Methods in Language Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20043",
+  "name": "Light in Performance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20031",
+  "name": "Literature, Adaptation, Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30051",
+  "name": "Urban Morphological Mapping",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR20005",
+  "name": "Hebrew 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PROP30001",
+  "name": "Valuation of Land and Buildings",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT10001",
+  "name": "Accounting Reports and Analysis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM30011",
+  "name": "Young People, Crime and Justice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30030",
+  "name": "Livestock Production Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GDES30001",
+  "name": "Infographics Studio",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS20016",
+  "name": "Art and Revolution",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL30053",
+  "name": "Philosophy of Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10017",
+  "name": "Chinese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ZOOL30006",
+  "name": "Animal Behaviour",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR10019",
+  "name": "Clear Speech and Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM10001",
+  "name": "German 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10006",
+  "name": "Latin 1",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB20012",
+  "name": "Water for Sustainable Futures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10001",
+  "name": "Physics 1: Advanced",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20013",
+  "name": "Japanese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE30001",
+  "name": "Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC30003",
+  "name": "Environmental Risk Assessment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO20003",
+  "name": "Memory & Memoirs of 20th Century Europe",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN30014",
+  "name": "French Travel Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS20008",
+  "name": "Legal Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30001",
+  "name": "Investments",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM10003",
+  "name": "Islam and Muslim Societies: Introduction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PROP20002",
+  "name": "Design and Property Principles",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30020",
+  "name": "Arts Internship: Not for Profit",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20003",
+  "name": "Critical Analytical Skills",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20149",
+  "name": "Music Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM10003",
+  "name": "Chemistry 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM20006",
+  "name": "Understanding Australian Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20173",
+  "name": "The Art of Game Music",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH20001",
+  "name": "Design Studio Beta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10011",
+  "name": "The Secret Life of the Body 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL20003",
+  "name": "Earth Composition, Minerals and Magmas",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30022",
+  "name": "Space Studio",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20001",
+  "name": "Science, Reason and Reality",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20009",
+  "name": "The Australian Imaginary",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD20003",
+  "name": "Intro to Food Science & Human Nutrition",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30012",
+  "name": "The Unconscious Mind",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CULS30004",
+  "name": "Thinking Sex",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN10005",
+  "name": "Japanese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20135",
+  "name": "Chinese Music Ensemble 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO10014",
+  "name": "Indonesia in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP10003",
+  "name": "Media Computation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JEWI20007",
+  "name": "Modern Israel: Good Bad and Disputed",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30023",
+  "name": "Space in Performance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW10001",
+  "name": "Ancient Egypt and Mesopotamia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN20002",
+  "name": "Earth Processes for Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH30001",
+  "name": "Hydrogeology/Environmental Geochemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN30005",
+  "name": "Introduction to Biomechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS20014",
+  "name": "Intellectual Property Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CULS30006",
+  "name": "Global Cultures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BLAW30003",
+  "name": "Taxation Law II",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN10001",
+  "name": "Introduction to Screen Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS30005",
+  "name": "Contemporary Aboriginal Art",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST20001",
+  "name": "Human Behaviour and Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL10009",
+  "name": "Biology: Life's Machinery",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG30004",
+  "name": "Aboriginal Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20003",
+  "name": "Japanese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20068",
+  "name": "The French Revolution",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20134",
+  "name": "Melbourne Big Band 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL30007",
+  "name": "Popular Fiction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING20009",
+  "name": "Language in Aboriginal Australia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW30011",
+  "name": "Underworld and Afterlife",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN30002",
+  "name": "Intro to Sustainable Water Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30007",
+  "name": "Advanced Seminar in Chinese",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20036",
+  "name": "Environmental Building Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB30011",
+  "name": "Cellular Metabolism and Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN30001",
+  "name": "Reactor Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG20006",
+  "name": "Brand Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT30004",
+  "name": "Auditing and Assurance Services",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "WELF90009",
+  "name": "Genetic Counselling Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90012",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN30012",
+  "name": "Signals and Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ZOOL20005",
+  "name": "Animal Structure and Function",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10019",
+  "name": "Contemporary Chinese Literature",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10022",
+  "name": "Linear Algebra: Advanced",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30012",
+  "name": "Chinese Economic Documents",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30002",
+  "name": "Taiwan & Beyond: Chinese Settler Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BTCH30003",
+  "name": "Biotechnology in Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN10007",
+  "name": "Spanish 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM20003",
+  "name": "Policing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL10002",
+  "name": "Philosophy: The Big Questions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BLAW10001",
+  "name": "Principles of Business Law",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING30003",
+  "name": "First Language Acquisition",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM30002",
+  "name": "Econometrics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING10002",
+  "name": "Intercultural Communication",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PLAN30003",
+  "name": "Research Methods for Planners",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10047",
+  "name": "Music History 1: Monteverdi to Mozart",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10004",
+  "name": "Introductory Microeconomics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30001",
+  "name": "International Trade Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90005",
+  "name": "Audio Journalism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM20003",
+  "name": "German Cultural Studies B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR20005",
+  "name": "Numerical Methods in Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR90016",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO30005",
+  "name": "Web Information Technologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO30020",
+  "name": "Indonesia in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT30007",
+  "name": "Human Locomotor Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB30012",
+  "name": "Current Advances in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT40001",
+  "name": "Anatomy & Neurosci Research Proj Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HLTH90014",
+  "name": "Healthcare Research-Principles & Designs",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE20001",
+  "name": "Foundations of Genetics and Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL30002",
+  "name": "Actuarial Modelling II",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20012",
+  "name": "Variation in Japanese Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN30010",
+  "name": "Systems Modelling and Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS40005",
+  "name": "Physiology Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90013",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS30013",
+  "name": "Latin 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR30003",
+  "name": "Principles of Neuroscience",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20015",
+  "name": "Literature: Reading Indonesian Lives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90014",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL30001",
+  "name": "Italian 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90013",
+  "name": "Theory of Financial Accounting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90284",
+  "name": "Master of Architecture Studio A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90025",
+  "name": "Documentary Projects 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70043",
+  "name": "Writing for Television",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90038",
+  "name": "Food Production for Urban Landscapes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90018",
+  "name": "Sociolinguistics and Language Learning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90007",
+  "name": "Chemical Engineering Thermodynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90045",
+  "name": "Residential Land Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI90016",
+  "name": "Creative Writing Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90016",
+  "name": "Actuarial Science Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40070",
+  "name": "Professional Project (Ethnomusicology)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90023",
+  "name": "Translation Technologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90121",
+  "name": "Vet Bioscience: Cells to Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90032",
+  "name": "Advanced Linguistics Analysis B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN90005",
+  "name": "Graduate Chinese A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40002",
+  "name": "Recent European Philosophy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90382",
+  "name": "Urban and Cultural Heritage Minor Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40015",
+  "name": "American Fiction: The 20th Century",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NRMT10007",
+  "name": "Land Resources and Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90078",
+  "name": "Contemporary Landscape Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40111",
+  "name": "Honours Music Studies 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS20021",
+  "name": "Arts of East Asia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90024",
+  "name": "Project In Geoscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90026",
+  "name": "Screen Language 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90020",
+  "name": "Directing Methodologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CULS40001",
+  "name": "Cultural Policy and Power",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90023",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90012",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90013",
+  "name": "Research Proposal 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90065",
+  "name": "Managing Global City Regions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90023",
+  "name": "The Writing of Australian History",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90012",
+  "name": "Corporate Restructuring and Valuation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90041",
+  "name": "Property Law (PG)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90039",
+  "name": "Mediation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90028",
+  "name": "Robotics Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOTH40001",
+  "name": "Relationships in Modernity",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90028",
+  "name": "Project Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90989",
+  "name": "Capstone Professional Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90218",
+  "name": "Constitutions in Global Perspective",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90019",
+  "name": "Journalism Project (Extended) Part 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NUTR40001",
+  "name": "Human Nutrition Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90022",
+  "name": "Economics for Actuaries",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS90008",
+  "name": "Advanced Seminars in Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90066",
+  "name": "Foundations of Nursing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90077",
+  "name": "Long Research Project B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN40007",
+  "name": "Chinese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90008",
+  "name": "Consumers and Consumption",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90059",
+  "name": "Stochastic Calculus with Applications",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND90011",
+  "name": "Gender and Development Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90017",
+  "name": "Actuarial Science Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90038",
+  "name": "Global Corporate Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL90034",
+  "name": "Philosophical Methodology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90030",
+  "name": "Adv Clinical Practice in Specialty 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90050",
+  "name": "Terrorism and Insurgency",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP40001",
+  "name": "Research Methods (Social Practice)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90046",
+  "name": "3-D Echocardiography & New Technologies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90016",
+  "name": "Computational Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90029",
+  "name": "Economics For Public Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90018",
+  "name": "Spatial Databases",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90017",
+  "name": "Science and Technology Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20071",
+  "name": "Big Band 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN40008",
+  "name": "Japanese Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90004",
+  "name": "Design Realisation and Collaboration A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90003",
+  "name": "Macroeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20156",
+  "name": "Practical Anatomy for Classical Voice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90061",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA90008",
+  "name": "Perspectives in Art & Cultural Theory 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90169",
+  "name": "Adolescent Sexuality and Sexual Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90056",
+  "name": "Urban Transport Politics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90227",
+  "name": "Orchestral Performance Practicum 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40068",
+  "name": "Honours Composition 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI40004",
+  "name": "Seminars in Translational Medicine",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL40011",
+  "name": "Research Project - RMH Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90359",
+  "name": "Research Practicum in Construction",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40078",
+  "name": "Music Research (Honours)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40075",
+  "name": "Music Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40088",
+  "name": "Integrated Musical Practice 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90049",
+  "name": "Principles of Hearing Rehabilitation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90017",
+  "name": "Journalism Project (Extended) Part 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90376",
+  "name": "Urban Design Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50101",
+  "name": "Refugee Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90063",
+  "name": "Transport System Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40056",
+  "name": "Special Study",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90071",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90034",
+  "name": "Economics of Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR70008",
+  "name": "Writing for Performance 1 (Solo)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA60011",
+  "name": "Contemporary Art Practice A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90044",
+  "name": "Engineering Site Characterisation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90019",
+  "name": "Genes Molecules and Cells",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90017",
+  "name": "Earthquake Resistant Design of Buildings",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90086",
+  "name": "Behavioural Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
  },
  {
   "code": "VETS90045",
@@ -15345,223 +29006,5978 @@
   "offered": [
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS90058",
-  "name": "Veterinary Bioscience 1A",
+  "code": "MKTG90012",
+  "name": "International Marketing Management",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS90060",
-  "name": "Applications in Animal Health A",
+  "code": "POPH90122",
+  "name": "Survival Analysis",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS90062",
-  "name": "Principles of Veterinary Bioscience",
+  "code": "MECM90032",
+  "name": "Marketing Communications Thesis Part 1",
   "offered": [
-   "semester_1"
-  ]
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
  },
  {
-  "code": "VETS90064",
-  "name": "Veterinary Bioscience 2A",
+  "code": "MEDI90047",
+  "name": "Congenital,Obsetric& Medical Conditions",
   "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90066",
-  "name": "Infections Population & Pub. Health PtA",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90068",
-  "name": "Applications in Animal Health 2 Part A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90082",
-  "name": "Animal Management and Veterinary Health",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90097",
-  "name": "Production, Herd and Public Health A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90099",
-  "name": "Infections and Immunity A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90115",
-  "name": "Veterinary Bioscience 1A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90117",
-  "name": "Applications in Animal Health A",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90119",
-  "name": "Veterinary Principles: Digestive System",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90120",
-  "name": "Vet Bioscience: Digestive System",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90121",
-  "name": "Vet Bioscience: Cells to Systems",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90122",
-  "name": "Intro to the Veterinary Profession",
-  "offered": [
-   "semester_1"
-  ]
- },
- {
-  "code": "VETS90123",
-  "name": "Animal Production Systems: Extensive",
-  "offered": [
-   "semester_1"
-  ]
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
  },
  {
   "code": "VETS90128",
   "name": "Vet Bioscience: Integument and Immunity",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS90129",
-  "name": "Vet Bioscience: Locomotion",
+  "code": "INFO90003",
+  "name": "Designing Novel Interactions",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS90130",
-  "name": "Veterinary Virology",
+  "code": "FINA40004",
+  "name": "Research Methods (Visual Art)",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS90131",
-  "name": "Veterinary Parasitology A",
+  "code": "LAWS50032",
+  "name": "Administrative Law",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS90132",
-  "name": "Veterinary Professional Practice 1",
+  "code": "MECM90007",
+  "name": "Media Convergence and Digital Culture",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS90133",
-  "name": "Animal Production Systems: Epidemiology",
+  "code": "MUSI30238",
+  "name": "Advanced Harmonic and Rhythmic Studies",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "WELF90004",
-  "name": "Principles of Counselling 1",
+  "code": "MUSI10195",
+  "name": "Music Making Laboratory 1",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "WELF90006",
-  "name": "Fitness to Practice 1",
+  "code": "CHIN90001",
+  "name": "Honours Chinese A",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "WELF90009",
-  "name": "Genetic Counselling Practice 1",
+  "code": "TRAN90008",
+  "name": "Translating in a Chinese Context",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "ZOOL20004",
-  "name": "Australian Wildlife Biology",
+  "code": "ABPL30067",
+  "name": "Design Workshop",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "ZOOL20005",
-  "name": "Animal Structure and Function",
+  "code": "COMP90062",
+  "name": "Computer Science Research Project Pt1",
   "offered": [
-   "semester_1"
-  ]
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
  },
  {
-  "code": "ZOOL30004",
-  "name": "Evolution and the Human Condition",
+  "code": "RUSS40006",
+  "name": "Russian Language & Culture 4A",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "ZOOL30006",
-  "name": "Animal Behaviour",
+  "code": "ECOM90009",
+  "name": "Quantitative Methods for Business",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90077",
+  "name": "Designing Digital Health Solutions",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND90012",
+  "name": "Gender and Development Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90192",
+  "name": "Studio Teaching 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90027",
+  "name": "Clinical Processes A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90042",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90039",
+  "name": "Advanced Surveying and Mapping",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90067",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90001",
+  "name": "Structural Editing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90024",
+  "name": "Computational Fluid Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90064",
+  "name": "Advanced Studies in Economics 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90024",
+  "name": "Cultural Festivals and Special Events",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT40002",
+  "name": "Research in Management Accounting",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70146",
+  "name": "Tax Treaties",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90212",
+  "name": "Law and Civil Society in Asia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90224",
+  "name": "Garage Project",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90104",
+  "name": "Enhanced Recovery After Surgery",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90002",
+  "name": "Presenting Academic Discourse",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20176",
+  "name": "Ensemble Studies 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90335",
+  "name": "Minor Project in Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90255",
+  "name": "Research Project in Public Health - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90031",
+  "name": "Bioprocess Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90053",
+  "name": "Intervening in Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90139",
+  "name": "Statistical Modelling for Data Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90074",
+  "name": "Laboratory Rotation 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90024",
+  "name": "Cluster and Cloud Computing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90002",
+  "name": "Global Data Policy & Governance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90119",
+  "name": "Veterinary Principles: Digestive System",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90127",
+  "name": "Advanced Biological Modelling: Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90048",
+  "name": "Principles of Clinical Audiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE40003",
+  "name": "Numerical Techniques in Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90049",
+  "name": "Property Development and Investment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30181",
+  "name": "Guitar Ensemble 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL90003",
+  "name": "Graduate Italian A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90039",
+  "name": "Concepts in Applied Linguistics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90052",
+  "name": "Nursing Science 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20213",
+  "name": "Chamber Choir 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90002",
+  "name": "Database Systems & Information Modelling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90032",
+  "name": "Energy Supply and Value Chains",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90167",
+  "name": "Young People in Context",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90077",
+  "name": "Introduction to Transport and Land Use",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90196",
+  "name": "Orchestration",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90089",
+  "name": "Communication Design Clinic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90026",
+  "name": "Chemical Engineering Minor Research Proj",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90016",
+  "name": "Grammar in Use",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90054",
+  "name": "Probability and Random Models",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM40001",
+  "name": "Topics in Arabic & Islamic Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20199",
+  "name": "Practical Music 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90060",
+  "name": "Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90029",
+  "name": "Food Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90073",
+  "name": "Minor Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90006",
+  "name": "Basic Interventions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90013",
+  "name": "Researching Media and Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90102",
+  "name": "Vessels Nerves Lungs and Musculoskeletal",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI90010",
+  "name": "International Migration",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE40004",
+  "name": "Research Methods in Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90092",
+  "name": "Agricultural Advisory Practice & Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90231",
+  "name": "Core Skills In Opera 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90016",
+  "name": "Asset Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90002",
+  "name": "Financial Statement Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90002",
+  "name": "Microeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90039",
+  "name": "Understanding Media & Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST40030",
+  "name": "History for Historians",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90951",
+  "name": "Understanding Education Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90122",
+  "name": "Inference for Spatio-Temporal Processes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90148",
+  "name": "Probability and Distribution Theory",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM40003",
+  "name": "Researching Audiences and Reception",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90020",
+  "name": "Risk Management and Citizen Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90363",
+  "name": "Property Research and Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO40003",
+  "name": "Topics in Indonesian Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90221",
+  "name": "Orchestral Performance Practicum 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS40009",
+  "name": "Russian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10016",
+  "name": "Mathematics for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ESLA90001",
+  "name": "Professional Speaking Communication",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN40006",
+  "name": "Chinese Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL40010",
+  "name": "Research Project - RMH Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30020",
+  "name": "Chamber Music 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90024",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING40016",
+  "name": "LAL Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90306",
+  "name": "MUP Independent Study",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90209",
+  "name": "Indigenous Legal Advocacy Clinic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90025",
+  "name": "Grattan Street Press (Extended)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90223",
+  "name": "Design Thinking",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90017",
+  "name": "Advanced Motion Control",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90057",
+  "name": "Advanced Valve and Aortic Pathology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40080",
+  "name": "Honours Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30163",
+  "name": "Baroque Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL40002",
+  "name": "Oral Health Research Project 4B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90077",
+  "name": "Research Project Part C",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90206",
+  "name": "Management & Marketing Special Topics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90003",
+  "name": "The Multinational",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90055",
+  "name": "Computational Economics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90053",
+  "name": "Clients with Complex Health States",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90058",
+  "name": "Industrial Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT40003",
+  "name": "Advances in Oral Health Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90106",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90059",
+  "name": "Social Enterprise Incubator",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90013",
+  "name": "Leadership and Team Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90033",
+  "name": "Law Apps",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT10003",
+  "name": "Organisation and Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90027",
+  "name": "International Human Resources",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90018",
+  "name": "General Insurance Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90009",
+  "name": "International Relations Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90056",
+  "name": "Investment Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90020",
+  "name": "International Journalism - Key Skills",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC40007",
+  "name": "Arabic Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC90013",
+  "name": "Atmospheric Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90072",
+  "name": "The Art of Scientific Computation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90369",
+  "name": "Architecture as Spectacle",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90033",
+  "name": "Arts Research Internship",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM40009",
+  "name": "Criminology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC40019",
+  "name": "HPS Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10047",
+  "name": "Agriculture in Australia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90034",
+  "name": "Property Securitisation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40107",
+  "name": "Capstone Music Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90060",
+  "name": "Mathematical Statistical Mechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90003",
+  "name": "The Contemporary Publishing Industry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MREN90005",
+  "name": "Materials Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20104",
+  "name": "Shakuhachi 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40055",
+  "name": "Music Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90009",
+  "name": "Judging Crime",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90014",
+  "name": "Auditing and Assurance Services",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90288",
+  "name": "Architectural Cultures 1: Modernism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM30016",
+  "name": "Digital Media Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90052",
+  "name": "Advanced Signal Processing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90149",
+  "name": "Applied Instrumental and Vocal Teaching",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50059",
+  "name": "Legal Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "june",
+   "semester_2",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20215",
+  "name": "Medieval and Renaissance Ensemble 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10010",
+  "name": "Indigenous Astronomy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40002",
+  "name": "Advanced Macroeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS30010",
+  "name": "Advanced Human Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90069",
+  "name": "Digital Transformation of Health",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90122",
+  "name": "Intro to the Veterinary Profession",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90117",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90120",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90032",
+  "name": "Macroeconomics for Managers",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90010",
+  "name": "Technology Innovation Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90040",
+  "name": "Film and Engineering at the Crossroads",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90050",
+  "name": "Acoustics and Perception of Speech",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90270",
+  "name": "Bioethics and Public Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS40008",
+  "name": "Twentieth-Century Italian Art: 1909-1969",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20200",
+  "name": "Practical Music 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90040",
+  "name": "Clinical Training in Music Therapy 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90100",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90099",
+  "name": "Infections and Immunity A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90013",
+  "name": "Process Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10180",
+  "name": "Contextual Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10007",
+  "name": "Screenwriting 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90037",
+  "name": "Engineering Capstone Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90014",
+  "name": "The World of Engineering Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH20001",
+  "name": "Exploring Human Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30019",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30001",
+  "name": "Parliamentary Internship",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE30002",
+  "name": "Science and Technology Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM20013",
+  "name": "Text and Audio Journalism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30011",
+  "name": "Essentials of Corporate Valuation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN90003",
+  "name": "Graduate Spanish A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90199",
+  "name": "Suzuki Practicum Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90036",
+  "name": "Enterprise Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP10002",
+  "name": "The Electronic Arts: Vision and Sound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO40002",
+  "name": "Seminars in Languages and Linguistics A",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE10030",
+  "name": "Dance Lab 1: Studio Practices",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE10001",
+  "name": "Korean 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BTCH30002",
+  "name": "Trends & Issues in Agrifood Biotech",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENVS10006",
+  "name": "Mapping Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PLAN30004",
+  "name": "Transit Oriented Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG20016",
+  "name": "Fertility, Mortality and Social Change",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30019",
+  "name": "Astrophysics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90033",
+  "name": "Integrated Accounting Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90606",
+  "name": "Engagement and the Arts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90008",
+  "name": "HCI Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90049",
+  "name": "Introduction to Machine Learning",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE20034",
+  "name": "Dance Lab 3: Repertory Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE30026",
+  "name": "Dance Lab 5: Dance and Music",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE20035",
+  "name": "Knowing Dance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90309",
+  "name": "Supply Chains in Construction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30003",
+  "name": "Public Affairs Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM30016",
+  "name": "Reactivity and Mechanism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10041",
+  "name": "Baroque Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM40006",
+  "name": "Public Relations and Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM40008",
+  "name": "Criminology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS90007",
+  "name": "Biennales, Triennales and Documentas",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90026",
+  "name": "Journalism Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90031",
+  "name": "Research Studies in Optometry",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90021",
+  "name": "Advanced Clinical Genomics 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20032",
+  "name": "Vector Calculus: Advanced",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
  },
  {
   "code": "ZOOL30007",
   "name": "Experimental Animal Behaviour",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "ZOOL90007",
-  "name": "Graduate Seminar in Ecology & Evolution",
+  "code": "GENE90018",
+  "name": "Advanced Topics in Genetics",
   "offered": [
    "semester_1"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90026",
+  "name": "Independent Study Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30183",
+  "name": "String Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI10002",
+  "name": "Knowledge Practices 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE10003",
+  "name": "Korean 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC10001",
+  "name": "The Global Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM20013",
+  "name": "Applications of GIS",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB30010",
+  "name": "Food for a Healthy Planet III",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM20001",
+  "name": "Econometrics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30249",
+  "name": "Music History 3:Impressionism to Present",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP30023",
+  "name": "Computer Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM20016",
+  "name": "Introduction to Islamic Spirituality",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20035",
+  "name": "Cities: From Local to Global",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI10001",
+  "name": "Creative Writing: Ideas and Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST30076",
+  "name": "Stalinism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN10001",
+  "name": "Japanese 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20039",
+  "name": "The Nature of Reality",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30025",
+  "name": "Orchestration",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20007",
+  "name": "Chinese Studies: Culture and Empire",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN10006",
+  "name": "French 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20013",
+  "name": "The Holocaust & Genocide",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG20003",
+  "name": "Environmental Politics and Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE10027",
+  "name": "Dancing the Dance 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT10002",
+  "name": "Introductory Financial Accounting",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN30018",
+  "name": "Thermodynamics and Fluid Mechanics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10001",
+  "name": "Chinese 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GDES10001",
+  "name": "Graphic Design Studio 1: Image & Text",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10006",
+  "name": "Critical Thinking With Data",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM20010",
+  "name": "Law, Justice and Social Change",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20164",
+  "name": "Free Play New Music Improvisation Ensem",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL30016",
+  "name": "Decadent Literature",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30010",
+  "name": "Signs and Symbols in Japanese",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PLAN30003",
+  "name": "Research Methods for Planners",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH10001",
+  "name": "Foundations of Design: Representation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL30003",
+  "name": "Italian 5A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10051",
+  "name": "Sports Coaching: Theory and Practice",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW30016",
+  "name": "The Age of Alexander the Great",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30016",
+  "name": "Electrodynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC20001",
+  "name": "Arabic in Context 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO30005",
+  "name": "Web Information Technologies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO30020",
+  "name": "Indonesia in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB30012",
+  "name": "Current Advances in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT40001",
+  "name": "Anatomy & Neurosci Research Proj Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR90016",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HLTH90014",
+  "name": "Healthcare Research-Principles & Designs",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20012",
+  "name": "Variation in Japanese Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN30010",
+  "name": "Systems Modelling and Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE20001",
+  "name": "Foundations of Genetics and Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS40005",
+  "name": "Physiology Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM30009",
+  "name": "Imaging the Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR30003",
+  "name": "Hebrew 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30012",
+  "name": "Management Consulting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10219",
+  "name": "Rock Music: From Roots to Retro",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL10002",
+  "name": "Literature and Performance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20033",
+  "name": "The Philosophy of Mind",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI20009",
+  "name": "Writing for Screen",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20065",
+  "name": "Knowledge, Learning and Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20209",
+  "name": "Chinese Music Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP10001",
+  "name": "Foundations of Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20019",
+  "name": "French 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC30006",
+  "name": "Arabic 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM10003",
+  "name": "Media and Society",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH10003",
+  "name": "Design Studio Alpha",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH30005",
+  "name": "Power, Ideology and Inequality",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30005",
+  "name": "Money and Banking",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30002",
+  "name": "Taiwan & Beyond: Chinese Settler Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN10007",
+  "name": "Spanish 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL10009",
+  "name": "Italian 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT30002",
+  "name": "Enterprise Performance Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ESLA10003",
+  "name": "Academic English 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20003",
+  "name": "Chinese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20006",
+  "name": "Great Chinese Classics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BLAW10001",
+  "name": "Principles of Business Law",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM30002",
+  "name": "Econometrics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING10002",
+  "name": "Intercultural Communication",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL10002",
+  "name": "Philosophy: The Big Questions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30018",
+  "name": "Neuroscience and the Mind",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30013",
+  "name": "Techniques in Operations Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10015",
+  "name": "Chinese 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG20001",
+  "name": "Society and Environments",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30018",
+  "name": "Economics of the Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG20010",
+  "name": "China in Transition",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB30002",
+  "name": "Global Health, Security & Sustainability",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS20031",
+  "name": "Political Economy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG30006",
+  "name": "Retailing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10047",
+  "name": "Music History 1: Monteverdi to Mozart",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT10011",
+  "name": "Introduction to Life, Earth and Universe",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10004",
+  "name": "Introductory Microeconomics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30001",
+  "name": "International Trade Policy",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90005",
+  "name": "Audio Journalism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM20003",
+  "name": "German Cultural Studies B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR20005",
+  "name": "Numerical Methods in Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT30007",
+  "name": "Human Locomotor Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL30002",
+  "name": "Actuarial Modelling II",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS30013",
+  "name": "Latin 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20015",
+  "name": "Literature: Reading Indonesian Lives",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90014",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90013",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR30003",
+  "name": "Principles of Neuroscience",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL30001",
+  "name": "Italian 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90013",
+  "name": "Theory of Financial Accounting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90284",
+  "name": "Master of Architecture Studio A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70043",
+  "name": "Writing for Television",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE10029",
+  "name": "Body Knowledges: Dance Science",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90025",
+  "name": "Documentary Projects 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90038",
+  "name": "Food Production for Urban Landscapes",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90018",
+  "name": "Sociolinguistics and Language Learning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20006",
+  "name": "Screen Practice 2A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10016",
+  "name": "Animation Studio 1A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV30018",
+  "name": "Animation Lab 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90033",
+  "name": "Arts Research Internship",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHRM30003",
+  "name": "Drug Treatment of Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30005",
+  "name": "Japanese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH10002",
+  "name": "Construction as Alchemy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90286",
+  "name": "Construction Methods A",
+  "offered": [
+   "february",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10017",
+  "name": "Animation History and Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV30029",
+  "name": "Screenwriting Practices 3A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10018",
+  "name": "Writing Animation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90018",
+  "name": "Clinical Practice in Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA90018",
+  "name": "Indonesia Rising?",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90113",
+  "name": "Information Systems Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90032",
+  "name": "Sensor Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90057",
+  "name": "Elements of Probability",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90086",
+  "name": "Environmental Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90010",
+  "name": "Applied Linguistics Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90033",
+  "name": "Climate Change Mitigation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40036",
+  "name": "Classics Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90083",
+  "name": "Data Analysis for Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90010",
+  "name": "Advanced Construction Technology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90027",
+  "name": "Systems and Synthetic Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM10008",
+  "name": "Foundation Studies in Chemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90206",
+  "name": "Management & Marketing Special Topics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90013",
+  "name": "Researching Media and Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE40004",
+  "name": "Research Methods in Finance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90005",
+  "name": "Marketing Strategy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90132",
+  "name": "Veterinary Professional Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90059",
+  "name": "Social Enterprise Incubator",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90006",
+  "name": "Life Insurance Models I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90013",
+  "name": "Leadership and Team Dynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT10003",
+  "name": "Organisation and Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30172",
+  "name": "Early Voices 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10056",
+  "name": "Early Voices 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90384",
+  "name": "MUP Studio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC90001",
+  "name": "Wildlife Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90360",
+  "name": "MUCH Heritage Industry Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90034",
+  "name": "Property Securitisation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90003",
+  "name": "The Contemporary Publishing Industry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90048",
+  "name": "Declarative Programming",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90077",
+  "name": "Grid Integration of Renewables",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90020",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40037",
+  "name": "Classics Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HLTH90006",
+  "name": "Basics of Digital Health for Clinicians",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90037",
+  "name": "Managing for Value Creation",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10007",
+  "name": "Physics for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30227",
+  "name": "Individual Performance Studies 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90130",
+  "name": "Veterinary Virology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20199",
+  "name": "Practical Music 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90060",
+  "name": "Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM40001",
+  "name": "Topics in Arabic & Islamic Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90209",
+  "name": "Indigenous Legal Advocacy Clinic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90013",
+  "name": "Writing and Editing for Magazines",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90025",
+  "name": "Grattan Street Press (Extended)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90031",
+  "name": "Research Design 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90057",
+  "name": "Advanced Valve and Aortic Pathology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30050",
+  "name": "Minor Music Performance 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90053",
+  "name": "Clients with Complex Health States",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90413",
+  "name": "Construction Cost Planning",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT40003",
+  "name": "Advances in Oral Health Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90011",
+  "name": "Managing Stakeholders",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90123",
+  "name": "Advanced Computational Design",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90033",
+  "name": "Law Apps",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10060",
+  "name": "Symphonic Ensembles 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90027",
+  "name": "International Human Resources",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90056",
+  "name": "Investment Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90020",
+  "name": "International Journalism - Key Skills",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90019",
+  "name": "Dramaturgy, Text and Performance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC40007",
+  "name": "Arabic Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90095",
+  "name": "Thesis (Masters/coursework) Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90369",
+  "name": "Architecture as Spectacle",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90010",
+  "name": "Researching Society and Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40004",
+  "name": "Advanced Financial Mathematics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90016",
+  "name": "Pathologies of the Auditory System",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90204",
+  "name": "Leading for Strategic Advantage",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90033",
+  "name": "Neuromarketing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90001",
+  "name": "Translation and Interpreting as Product",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL10006",
+  "name": "Systems Biology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN40003",
+  "name": "Topics in Japanese Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90089",
+  "name": "Communication Design Clinic",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90077",
+  "name": "Introduction to Transport and Land Use",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90196",
+  "name": "Orchestration",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90026",
+  "name": "Chemical Engineering Minor Research Proj",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90016",
+  "name": "Grammar in Use",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40016",
+  "name": "Practical Study 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90054",
+  "name": "Probability and Random Models",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90029",
+  "name": "Food Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90016",
+  "name": "Glaucoma and Retinal Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90223",
+  "name": "Design Thinking",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90017",
+  "name": "Advanced Motion Control",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV40005",
+  "name": "Research Methods (Animation)",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40080",
+  "name": "Honours Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90006",
+  "name": "Basic Interventions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90102",
+  "name": "Vessels Nerves Lungs and Musculoskeletal",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI90010",
+  "name": "International Migration",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90106",
+  "name": "Advanced Nursing Practice: Primary Care",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90092",
+  "name": "Agricultural Advisory Practice & Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90231",
+  "name": "Core Skills In Opera 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90076",
+  "name": "Research Project Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30059",
+  "name": "Property Case Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90147",
+  "name": "Design Futures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90058",
+  "name": "Health Program Evaluation 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40108",
+  "name": "Capstone Music Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90018",
+  "name": "General Insurance Practice",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90009",
+  "name": "International Relations Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30031",
+  "name": "Electro-Acoustic Music",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC90013",
+  "name": "Atmospheric Modelling",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90050",
+  "name": "Acoustics and Perception of Speech",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90073",
+  "name": "Economics Thesis Workshop Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90270",
+  "name": "Bioethics and Public Health",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS40008",
+  "name": "Twentieth-Century Italian Art: 1909-1969",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20200",
+  "name": "Practical Music 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM40009",
+  "name": "Criminology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90167",
+  "name": "Young People in Context",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90032",
+  "name": "Energy Supply and Value Chains",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90089",
+  "name": "Australian Architecture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM40002",
+  "name": "Advanced Microbiology and Immunology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90015",
+  "name": "Thermodynamics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90002",
+  "name": "Independent Study",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING40016",
+  "name": "LAL Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90010",
+  "name": "Strategic Performance Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10016",
+  "name": "Art of Piano Teaching",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90045",
+  "name": "Research Project 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90076",
+  "name": "Social Policy and Development",
+  "offered": [
+   "semester_1",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90306",
+  "name": "MUP Independent Study",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90091",
+  "name": "Advanced Plant Breeding and Improvement",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90037",
+  "name": "Advanced Clinical Practice 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10197",
+  "name": "Individual Performance Studies 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90073",
+  "name": "Minor Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90017",
+  "name": "Clinical Practice in Specialty 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM40011",
+  "name": "Islamic Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20099",
+  "name": "Piano Duo and Duet 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90058",
+  "name": "Industrial Engineering",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90024",
+  "name": "Strategic Content Creation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90106",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90016",
+  "name": "Anatomy and Physiology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90151",
+  "name": "Biostatistics Research Project - D",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90728",
+  "name": "Innovative Spaces and Pedagogy",
+  "offered": [
+   "semester_1",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL10004",
+  "name": "Indigenous Literature",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90072",
+  "name": "The Art of Scientific Computation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90016",
+  "name": "Taxation for Business Decision Making",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90040",
+  "name": "Clinical Training in Music Therapy 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90099",
+  "name": "Infections and Immunity A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM40012",
+  "name": "Islamic Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90087",
+  "name": "The Ethics of Artificial Intelligence",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90036",
+  "name": "MFPI Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN40009",
+  "name": "Japanese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90038",
+  "name": "Haemato, Neurologic & Global Conditions",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40010",
+  "name": "Actuarial Studies Projects Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90104",
+  "name": "Thinking, Judgement and Decision Making",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90012",
+  "name": "Measure Theory",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA90006",
+  "name": "Perspectives in Art & Cultural Theory 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90084",
+  "name": "Internship for Agricultural Sciences Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90022",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90075",
+  "name": "Research Methods For Life Sciences",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PAED40001",
+  "name": "Paediatrics Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90201",
+  "name": "Community-Based Participatory Research",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90097",
+  "name": "Production, Herd and Public Health A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE10001",
+  "name": "Science: A Study of Life and Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90292",
+  "name": "Construction of Buildings",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90009",
+  "name": "Language Testing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90010",
+  "name": "Art Curatorship Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90023",
+  "name": "Chemical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90021",
+  "name": "Advanced Seminars in Specialty 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90001",
+  "name": "Omnichannel Retail",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT10015",
+  "name": "Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90007",
+  "name": "Internet Technologies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN40006",
+  "name": "Public Policy & Management Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10225",
+  "name": "Chamber Choir 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90009",
+  "name": "Art Curatorship Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90023",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE30003",
+  "name": "Science Research Project Abroad",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA60008",
+  "name": "Studio Materials and Methods A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90362",
+  "name": "Research Thesis - Property",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90032",
+  "name": "Research Design 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90070",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90002",
+  "name": "Econometrics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40040",
+  "name": "Latin Honours Seminar 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC40001",
+  "name": "Animal Sci & Mgt Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90116",
+  "name": "Information Systems Res Project Pt 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT40010",
+  "name": "Oral Health Sci Research Proj Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40089",
+  "name": "Integrated Musical Practice 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91029",
+  "name": "Understanding the Student as Learner",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90081",
+  "name": "Computer Science Research Project Part 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90027",
+  "name": "Interdisciplinary Industry Project 2",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20178",
+  "name": "Individual Performance Studies 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90032",
+  "name": "Sustainability and Behaviour Change",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL40001",
+  "name": "Oral Health Research Project 4A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90060",
+  "name": "Applications in Animal Health A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO20005",
+  "name": "User Interface Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90024",
+  "name": "Forecasting in Economics and Business",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40022",
+  "name": "Philosophy Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10011",
+  "name": "Experimental Design and Data Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20176",
+  "name": "Ensemble Studies 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90335",
+  "name": "Minor Project in Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20008",
+  "name": "Music Technology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90123",
+  "name": "Longitudinal and Correlated Data",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL90021",
+  "name": "Critical and Creative Thinking",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90003",
+  "name": "The Political Ecology of Development",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90002",
+  "name": "Global Data Policy & Governance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90012",
+  "name": "International Marketing Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90122",
+  "name": "Survival Analysis",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90007",
+  "name": "Media Convergence and Digital Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90370",
+  "name": "Design Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90035",
+  "name": "Speech and Language Disorders - Advanced",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90033",
+  "name": "Plants in the Landscape",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50068",
+  "name": "Equality and Discrimination Law",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90035",
+  "name": "Public Consultation & Policy Negotiation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90009",
+  "name": "Development Theories",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL40015",
+  "name": "Italian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM20023",
+  "name": "Contextual Studies 2 Theory in Action",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90048",
+  "name": "Artificial Intelligence for Engineers",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10192",
+  "name": "Ensemble Studies 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90007",
+  "name": "Quantum Mechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90010",
+  "name": "Actuarial Practice And Control I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90082",
+  "name": "Mathematical Statistics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30244",
+  "name": "Chamber Choir 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90039",
+  "name": "Biomedical Eng Management & Regulations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20182",
+  "name": "Music Making Laboratory 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI40015",
+  "name": "Creative Writing Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90208",
+  "name": "Sustainable Business Practices",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90022",
+  "name": "Publishing and Communications Thesis Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90021",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN40001",
+  "name": "Honours Japanese A",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90390",
+  "name": "Architectural Engineering Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90018",
+  "name": "Science Research Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90155",
+  "name": "Second Instrument / Vocal Study 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90016",
+  "name": "Environmental Research Project (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS70002",
+  "name": "MVSc (Clinical) Practicum # PT",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40006",
+  "name": "Actuarial Practice and Control I",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN90004",
+  "name": "Modelling Complex Software Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90032",
+  "name": "Emerging Technologies and Issues",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90015",
+  "name": "Managerial Economics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90065",
+  "name": "Advanced Studies in Economics 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30159",
+  "name": "Acting for Singers 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90083",
+  "name": "Electrical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90028",
+  "name": "Criminology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO40009",
+  "name": "Indonesian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90061",
+  "name": "Internship II (Year Long) Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90164",
+  "name": "MLS Tax Clinic",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70026",
+  "name": "Scriptwriting 2",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50026",
+  "name": "Obligations",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90010",
+  "name": "Translation Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90209",
+  "name": "EMA Career Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LANG40004",
+  "name": "Seminar in Languages 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC90017",
+  "name": "Global Environmental Change",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70318",
+  "name": "Tax Practice: Writing Effectively",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90020",
+  "name": "Chemical Engineering Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90010",
+  "name": "Print Production and Design",
+  "offered": [
+   "semester_1",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90013",
+  "name": "Independent Dramaturgy Project",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90117",
+  "name": "Health Indicators and Health Surveys",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10058",
+  "name": "Conservatorium Choir 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90195",
+  "name": "Professional Practice 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90043",
+  "name": "Applications of Music in Therapy C",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20087",
+  "name": "MCM Indonesian Gamelan Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90035",
+  "name": "Graduate Research Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM30003",
+  "name": "Biomedical Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10005",
+  "name": "Languages of the Screen 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM40005",
+  "name": "Micro & Immuno Research Project Part 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90009",
+  "name": "Strategic Cost Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90036",
+  "name": "Leadership for Innovation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM30015",
+  "name": "Media and Communications Project",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90059",
+  "name": "Introduction to Programming",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE10001",
+  "name": "Korean 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30019",
+  "name": "Astrophysics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90033",
+  "name": "Integrated Accounting Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90606",
+  "name": "Engagement and the Arts",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90008",
+  "name": "HCI Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP10002",
+  "name": "The Electronic Arts: Vision and Sound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO40002",
+  "name": "Seminars in Languages and Linguistics A",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE10030",
+  "name": "Dance Lab 1: Studio Practices",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90049",
+  "name": "Introduction to Machine Learning",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE20034",
+  "name": "Dance Lab 3: Repertory Studies",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE30026",
+  "name": "Dance Lab 5: Dance and Music",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE20035",
+  "name": "Knowing Dance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90031",
+  "name": "Research Studies in Optometry",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20032",
+  "name": "Vector Calculus: Advanced",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90026",
+  "name": "Independent Study Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90021",
+  "name": "Advanced Clinical Genomics 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM40006",
+  "name": "Public Relations and Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30003",
+  "name": "Public Affairs Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS90007",
+  "name": "Biennales, Triennales and Documentas",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90026",
+  "name": "Journalism Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ZOOL30007",
+  "name": "Experimental Animal Behaviour",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM30016",
+  "name": "Reactivity and Mechanism",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10041",
+  "name": "Baroque Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90309",
+  "name": "Supply Chains in Construction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM40008",
+  "name": "Criminology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90018",
+  "name": "Advanced Topics in Genetics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI10002",
+  "name": "Knowledge Practices 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE10003",
+  "name": "Korean 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30183",
+  "name": "String Ensemble 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM20001",
+  "name": "Econometrics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30249",
+  "name": "Music History 3:Impressionism to Present",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM20013",
+  "name": "Applications of GIS",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB30010",
+  "name": "Food for a Healthy Planet III",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC10001",
+  "name": "The Global Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM20016",
+  "name": "Introduction to Islamic Spirituality",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20035",
+  "name": "Cities: From Local to Global",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN10006",
+  "name": "French 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20013",
+  "name": "The Holocaust & Genocide",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10001",
+  "name": "Chinese 9",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GDES10001",
+  "name": "Graphic Design Studio 1: Image & Text",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL30013",
+  "name": "Gothic Fictions",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20043",
+  "name": "Light in Performance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO10014",
+  "name": "Indonesia in the World",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP10003",
+  "name": "Media Computation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JEWI20007",
+  "name": "Modern Israel: Good Bad and Disputed",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30023",
+  "name": "Space in Performance",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN20002",
+  "name": "Earth Processes for Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN30005",
+  "name": "Introduction to Biomechanics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30030",
+  "name": "Livestock Production Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL30053",
+  "name": "Philosophy of Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20134",
+  "name": "Melbourne Big Band 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10019",
+  "name": "Contemporary Chinese Literature",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10022",
+  "name": "Linear Algebra: Advanced",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG20006",
+  "name": "Brand Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90012",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10057",
+  "name": "Wellbeing, Motivation and Performance",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS20006",
+  "name": "Russian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS10001",
+  "name": "Australian Politics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30007",
+  "name": "Derivative Securities",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA10026",
+  "name": "Critical and Theoretical Studies 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC30004",
+  "name": "Dynamical Meteorology and Oceanography",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN10004",
+  "name": "French 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP20007",
+  "name": "Design of Algorithms",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10159",
+  "name": "Choir 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30030",
+  "name": "The Music Of Spain",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PROP20002",
+  "name": "Design and Property Principles",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING30007",
+  "name": "Semantics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH20001",
+  "name": "Keeping the Body in Mind",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CULS20014",
+  "name": "Television, Lifestyle & Consumer Culture",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC20006",
+  "name": "Energy and the Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30050",
+  "name": "Modern Architecture: MoMo to PoMo",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN20011",
+  "name": "Hollywood and Entertainment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM20006",
+  "name": "Understanding Australian Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20001",
+  "name": "Science, Reason and Reality",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20009",
+  "name": "The Australian Imaginary",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD20003",
+  "name": "Intro to Food Science & Human Nutrition",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30012",
+  "name": "The Unconscious Mind",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CULS30004",
+  "name": "Thinking Sex",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN10005",
+  "name": "Japanese 7",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR20005",
+  "name": "Hebrew 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO30011",
+  "name": "Indonesian 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20009",
+  "name": "Signs and Symbols in Japanese",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30021",
+  "name": "Complex Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM30001",
+  "name": "Basic Econometrics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO10005",
+  "name": "Indonesian 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL30007",
+  "name": "To Hell with Dante",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL20001",
+  "name": "Evolution: Making Sense Of Life",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS20015",
+  "name": "Ancient Greek 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20018",
+  "name": "Japanese Through the Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE10001",
+  "name": "Genetics in the Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30025",
+  "name": "Computational Economics and Business",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB20002",
+  "name": "Biochemistry and Molecular Biology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE30001",
+  "name": "Evolutionary Genetics and Genomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL20002",
+  "name": "Structural and Metamorphic Geology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20001",
+  "name": "French 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS30024",
+  "name": "Ancient Greek 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT40002",
+  "name": "Seminars in Anatomy and Neuroscience",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10007",
+  "name": "Linear Algebra",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHRM30003",
+  "name": "Drug Treatment of Disease",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP30023",
+  "name": "Computer Systems",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "WELF90009",
+  "name": "Genetic Counselling Practice 1",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM10001",
+  "name": "German 3",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10006",
+  "name": "Latin 1",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB20012",
+  "name": "Water for Sustainable Futures",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20013",
+  "name": "Japanese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE30001",
+  "name": "Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC30003",
+  "name": "Environmental Risk Assessment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO20003",
+  "name": "Memory & Memoirs of 20th Century Europe",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10001",
+  "name": "Physics 1: Advanced",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN30014",
+  "name": "French Travel Writing",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM10003",
+  "name": "Islam and Muslim Societies: Introduction",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30020",
+  "name": "Arts Internship: Not for Profit",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20003",
+  "name": "Critical Analytical Skills",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20010",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20149",
+  "name": "Music Psychology",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM10003",
+  "name": "Chemistry 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20173",
+  "name": "The Art of Game Music",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30012",
+  "name": "Variation in Japanese Language",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR20007",
+  "name": "Hebrew 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30010",
+  "name": "Microeconomics",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30006",
+  "name": "Managing Entrepreneurship and Innovation",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20031",
+  "name": "Literature, Adaptation, Media",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30051",
+  "name": "Urban Morphological Mapping",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH30001",
+  "name": "Hydrogeology/Environmental Geochemistry",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW10001",
+  "name": "Ancient Egypt and Mesopotamia",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10017",
+  "name": "Chinese 5",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS20016",
+  "name": "Art and Revolution",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BLAW30003",
+  "name": "Taxation Law II",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS30005",
+  "name": "Contemporary Aboriginal Art",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ZOOL30006",
+  "name": "Animal Behaviour",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST20001",
+  "name": "Human Behaviour and Environment",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR10019",
+  "name": "Clear Speech and Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30007",
+  "name": "Advanced Seminar in Chinese",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN30012",
+  "name": "Signals and Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ZOOL20005",
+  "name": "Animal Structure and Function",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30012",
+  "name": "Chinese Economic Documents",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC90002",
+  "name": "Climate Science for Decision-Making",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90007",
+  "name": "Customer Experience Management",
+  "offered": [
+   "semester_1"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_semester_2.json
+++ b/subject-utils/subject-lists/subjects_2021_semester_2.json
@@ -1,10396 +1,34832 @@
 [
-  {
-    "code": "ABPL10004",
-    "name": "Global Foundations of Design",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL20028",
-    "name": "Architecture Design Studio: Water",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL20033",
-    "name": "Construction Analysis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL20036",
-    "name": "Environmental Building Systems",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL20053",
-    "name": "Construction of Concrete Buildings",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL30037",
-    "name": "Architecture Design Studio: Fire",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL30039",
-    "name": "Construction Contract Administration",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL30040",
-    "name": "Measurement of Building Works",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL30041",
-    "name": "Construction Design",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL30044",
-    "name": "Industry Partner project Studio",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL30048",
-    "name": "Architecture Design Studio: Air",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL30057",
-    "name": "Asia Pacific Modernities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL30061",
-    "name": "Landscape Studio: Designed Ecologies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL30068",
-    "name": "Design Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90011",
-    "name": "Advanced Property Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90022",
-    "name": "Healthy Communities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90027",
-    "name": "Life Cycle Analysis and Sustainability",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90030",
-    "name": "Project Evaluation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90031",
-    "name": "Corporate Real Estate Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90032",
-    "name": "Building Services and Operations",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90036",
-    "name": "Property Investment",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90045",
-    "name": "Statutory Valuation (PG)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90048",
-    "name": "Landscape Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90061",
-    "name": "Urban Design Studio A",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90064",
-    "name": "Urban Sustainability and Climate Change",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90067",
-    "name": "MSD Thesis -Semester Long (25 Points)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90072",
-    "name": "Landscape Studio 5:Sustainable Urbanism",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90074",
-    "name": "Landscape Detail Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90085",
-    "name": "Construction History",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90090",
-    "name": "Public Transport Network Planning",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90117",
-    "name": "Twenty-first Century Architecture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90118",
-    "name": "Applied Architectural Technology",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90131",
-    "name": "Strategic Plan Making",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90132",
-    "name": "Land Use and Urban Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90140",
-    "name": "Architectural Practice",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90146",
-    "name": "Architectural Conservation in East Asia",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90151",
-    "name": "Popular Architecture and Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90152",
-    "name": "Bower Studio - Community Development",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90167",
-    "name": "Design Communications Workshop (P/G)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90170",
-    "name": "Landscape Studio 4 Strategies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90173",
-    "name": "Advanced Planting Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90176",
-    "name": "Landscape Studio 2: Site and Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90208",
-    "name": "Construction Measurement and Estimating",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90222",
-    "name": "Ex_Lab: Timber Furniture",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90241",
-    "name": "Representing and Remembering Place (PG)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90265",
-    "name": "History of Landscape Architecture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90266",
-    "name": "Inclusive Cities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90273",
-    "name": "Urban Design Studio B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90275",
-    "name": "Property Resources and Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90280",
-    "name": "City Lights: Cities, Culture and History",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90281",
-    "name": "Housing Markets, Policy and Planning",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90283",
-    "name": "Ecology for Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90285",
-    "name": "Master of Architecture Studio B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90287",
-    "name": "Architectural Technology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90289",
-    "name": "Architectural Cultures 2:After Modernism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90290",
-    "name": "Fundamentals of Built Environment Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90293",
-    "name": "Commercial Construction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90304",
-    "name": "Flexible Urban Modelling",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90306",
-    "name": "MUP Independent Study",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90307",
-    "name": "MSD Vocational Placement",
-    "offered": ["summer_term", "semester_1", "may", "semester_2"]
-  },
-  {
-    "code": "ABPL90312",
-    "name": "Cost Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90315",
-    "name": "Participatory Planning",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90316",
-    "name": "The Shaping of Urban Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90325",
-    "name": "Prefabrication in Building",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90327",
-    "name": "Procurement Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90331",
-    "name": "ICT in Building",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90335",
-    "name": "Contract Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90358",
-    "name": "Research in Construction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90359",
-    "name": "Research Practicum in Construction",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90360",
-    "name": "MUCH Heritage Industry Internship",
-    "offered": ["january", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90362",
-    "name": "Research Thesis - Property",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90364",
-    "name": "Industry Based Research - Property",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90367",
-    "name": "Critical&Curatorial Practices in Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90375",
-    "name": "Landscape Architecture Design Thesis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90376",
-    "name": "Urban Design Thesis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90382",
-    "name": "Urban and Cultural Heritage Minor Thesis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90384",
-    "name": "MUP Studio",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90389",
-    "name": "Urban Design Studio C",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90390",
-    "name": "Architectural Engineering Thesis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90396",
-    "name": "MSD Minor Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90397",
-    "name": "MSD Minor Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90402",
-    "name": "Design Strategies of Asian Gardens",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90405",
-    "name": "Energy & Carbon in the Built Environment",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90416",
-    "name": "Land and Property Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90418",
-    "name": "Architects in Asia, Practice & Politics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ABPL90422",
-    "name": "SI-Lab: Scanning and Virtual Reality",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ABPL90424",
-    "name": "Introduction to High-Performance Design",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT10001",
-    "name": "Accounting Reports and Analysis",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT10002",
-    "name": "Introductory Financial Accounting",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT10004",
-    "name": "Introduction to Accounting",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACCT20001",
-    "name": "Cost Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT20002",
-    "name": "Intermediate Financial Accounting",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT20007",
-    "name": "Accounting Information: Risks & Controls",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT30001",
-    "name": "Financial Accounting Theory",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT30002",
-    "name": "Enterprise Performance Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT30004",
-    "name": "Auditing and Assurance Services",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT40006",
-    "name": "Honours Research Essay Accounting",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACCT40009",
-    "name": "Honours Research Essay Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACCT90002",
-    "name": "Financial Statement Analysis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT90003",
-    "name": "Accounting Research Report",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACCT90004",
-    "name": "Accounting for Decision Making",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT90009",
-    "name": "Strategic Cost Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT90010",
-    "name": "Strategic Performance Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT90012",
-    "name": "Corporate Reporting",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT90013",
-    "name": "Theory of Financial Accounting",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT90014",
-    "name": "Auditing and Assurance Services",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT90015",
-    "name": "Legal Issues for Business",
-    "offered": ["semester_1", "june", "semester_2"]
-  },
-  {
-    "code": "ACCT90016",
-    "name": "Taxation for Business Decision Making",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT90030",
-    "name": "Information Processes & Control",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT90031",
-    "name": "Sustainability Reporting & Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACCT90033",
-    "name": "Integrated Accounting Studies",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACCT90041",
-    "name": "Fundamentals in Accounting",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACTL10001",
-    "name": "Introduction to Actuarial Studies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL20003",
-    "name": "Stochastic Techniques in Insurance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL20004",
-    "name": "Topics in Actuarial Studies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL30003",
-    "name": "Contingencies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL30004",
-    "name": "Actuarial Statistics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL30006",
-    "name": "Intermediate Financial Mathematics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL40001",
-    "name": "Actuarial Studies Research Essay",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACTL40007",
-    "name": "Actuarial Practice and Control II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL40011",
-    "name": "Actuarial Studies Projects Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL40012",
-    "name": "Actuarial Analytics and Data II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL90002",
-    "name": "Mathematics of Finance II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL90005",
-    "name": "Life Contingencies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL90007",
-    "name": "Life Insurance Models 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL90008",
-    "name": "Statistical Techniques in Insurance",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACTL90011",
-    "name": "Actuarial Practice and Control II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL90013",
-    "name": "Actuarial Studies Projects",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACTL90016",
-    "name": "Actuarial Science Research Report Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACTL90017",
-    "name": "Actuarial Science Research Report Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACTL90019",
-    "name": "Data Analytics in Insurance 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACTL90021",
-    "name": "Topics in Insurance and Finance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACUR90001",
-    "name": "Issues in Art Conservation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACUR90005",
-    "name": "Interpreting Exhibitions",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACUR90006",
-    "name": "Exhibition Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ACUR90009",
-    "name": "Art Curatorship Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ACUR90010",
-    "name": "Art Curatorship Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI10039",
-    "name": "Australia in the Wine World",
-    "offered": ["february", "june", "semester_2"]
-  },
-  {
-    "code": "AGRI10044",
-    "name": "Plant Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI10046",
-    "name": "Foundations of Agricultural Sciences 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI10048",
-    "name": "Plant Production Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI10049",
-    "name": "Animal Production Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI10051",
-    "name": "Genetics for Agriculture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI10052",
-    "name": "Agricultural Genetics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI20035",
-    "name": "Applied Crop Production and Horticulture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI20036",
-    "name": "Ecology and Grazing Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI20037",
-    "name": "Crop Production and Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI20038",
-    "name": "Principles of Soil Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI20040",
-    "name": "Enterprise Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI30003",
-    "name": "Agricultural Systems Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI30006",
-    "name": "Industry Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI30022",
-    "name": "Special Studies",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI30038",
-    "name": "Professional Practice for Agriculture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI30041",
-    "name": "Industry Internship",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "AGRI30046",
-    "name": "Agronomy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI30048",
-    "name": "Plant Breeding and Genetics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI40018",
-    "name": "Agric.Science Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI90012",
-    "name": "Agribusiness Management Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI90014",
-    "name": "Managing Markets",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI90058",
-    "name": "Agronomy & Cropping Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI90070",
-    "name": "Minor Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI90072",
-    "name": "Major Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI90076",
-    "name": "Industry Internship",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "AGRI90078",
-    "name": "Internship for Agricultural Sciences",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI90079",
-    "name": "Minor Research Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI90080",
-    "name": "Major Research Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI90081",
-    "name": "Minor Research Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI90082",
-    "name": "Major Research Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI90083",
-    "name": "Internship for Agricultural Sciences Pt1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI90084",
-    "name": "Internship for Agricultural Sciences Pt2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AGRI90093",
-    "name": "Agricultural Extension",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AGRI90094",
-    "name": "Managing Innovation and Change",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AHIS10003",
-    "name": "The World in Twenty Art Works",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AHIS20002",
-    "name": "Australian Art",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AHIS20018",
-    "name": "Art, Market and Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AHIS20022",
-    "name": "Modern and Contemporary Chinese Art",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AHIS30019",
-    "name": "Theory and Practice of Art History",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AHIS30024",
-    "name": "Virtual Worlds in Japanese Art",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AHIS40002",
-    "name": "Indigenous Australian Art Histories",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AHIS40019",
-    "name": "The Book: Late Antiquity to Renaissance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AHIS40023",
-    "name": "Art History Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AHIS40024",
-    "name": "Art History Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AHIS90004",
-    "name": "The Print Room",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AHIS90008",
-    "name": "Writing About Art and the Moving Image",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AIND10005",
-    "name": "Decolonising the Landscape MultiStudio 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AIND20011",
-    "name": "Indigenous Art and Changing the Nation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AMGT90001",
-    "name": "Principles of Arts Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AMGT90004",
-    "name": "States, Governments and the Arts",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AMGT90006",
-    "name": "Audiences and the Arts",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AMGT90013",
-    "name": "Finance and Budgeting",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AMGT90018",
-    "name": "The Economics of Culture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AMGT90027",
-    "name": "Arts Management Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "AMGT90028",
-    "name": "Arts Management Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANAT20006",
-    "name": "Principles of Human Structure",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANAT30008",
-    "name": "Viscera and Visceral Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANAT40001",
-    "name": "Anatomy & Neurosci Research Proj Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANAT90012",
-    "name": "Project in Anatomy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANAT90013",
-    "name": "Project in Anatomy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANAT90014",
-    "name": "Project in Anatomy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANAT90015",
-    "name": "Project in Anatomy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANCW10002",
-    "name": "Myth, Art and Empire: Greece and Rome",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW10007",
-    "name": "Ancient Egyptian 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW20003",
-    "name": "Egypt Under the Pharaohs",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW20022",
-    "name": "History of Greece: Homer to Alexander",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW20024",
-    "name": "Ancient Egyptian 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW20027",
-    "name": "Archaeology of the Classical Greek World",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW30004",
-    "name": "Beyond Babylon",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW30011",
-    "name": "Underworld and Afterlife",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW30026",
-    "name": "Roman Law in Context",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW40003",
-    "name": "Archaeology of Complex Societies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW40007",
-    "name": "Problems in Greek Prehistory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANCW40016",
-    "name": "Ancient World Studies Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANCW40017",
-    "name": "Ancient World Studies Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANCW40018",
-    "name": "The Roman Countryside",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANSC10001",
-    "name": "Animals in Society 1: Introduction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANSC10002",
-    "name": "Animal Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANSC20002",
-    "name": "Comparative Nutrition and Digestion",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANSC20003",
-    "name": "Topics in Animal Health",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANSC20004",
-    "name": "Animals and Society 2: Humans & Animals",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANSC30002",
-    "name": "Animal Disease Biotechnology 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANSC30008",
-    "name": "Production Animal Physiology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANSC30009",
-    "name": "Animal Systems Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANSC40002",
-    "name": "Animal Sci & Mgt Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANTH10001",
-    "name": "Anthropology: Studying Self and Other",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANTH20008",
-    "name": "Anthropology of Gender and Sexuality",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANTH20012",
-    "name": "Self, Culture and Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANTH20013",
-    "name": "Diplomat, Soldier, Spy: The Deep State",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANTH30013",
-    "name": "The Anthropological Imagination",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ANTH40009",
-    "name": "Anthropology Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANTH40010",
-    "name": "Anthropology Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ANTH40011",
-    "name": "Critical Anthropological Theory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC10002",
-    "name": "Arabic 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC10004",
-    "name": "Arabic 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC10006",
-    "name": "Arabic 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC20003",
-    "name": "Arabic 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC20005",
-    "name": "Arabic 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC20007",
-    "name": "Arabic 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC30001",
-    "name": "Arabic in Context 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC30003",
-    "name": "Arabic 10",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC30005",
-    "name": "Arabic 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC30007",
-    "name": "Arabic 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC40002",
-    "name": "Honours Arabic B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARBC40007",
-    "name": "Arabic Studies Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ARBC40008",
-    "name": "Arabic Studies Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ARBC90002",
-    "name": "Graduate Arabic B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARCH10001",
-    "name": "Foundations of Design: Representation",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ARCH10002",
-    "name": "Construction as Alchemy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ARCH10003",
-    "name": "Design Studio Alpha",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ARCH20001",
-    "name": "Design Studio Beta",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ARCH20002",
-    "name": "Design Studio Gamma",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ARCH30001",
-    "name": "Design Studio Delta",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ARCH30002",
-    "name": "Design Studio Epsilon",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ARCH30005",
-    "name": "Design Visualisation: Digital Techniques",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARTS10001",
-    "name": "Reading the Disciplines",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARTS30001",
-    "name": "Industry Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARTS90003",
-    "name": "Introduction to Action Research",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARTS90004",
-    "name": "The Power of Ideas: Ten Great Books",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARTS90024",
-    "name": "Industry Core and Placement",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ARTS90026",
-    "name": "Interdisciplinary Industry Project 1",
-    "offered": ["semester_1", "winter_term", "semester_2"]
-  },
-  {
-    "code": "ARTS90027",
-    "name": "Interdisciplinary Industry Project 2",
-    "offered": ["semester_1", "winter_term", "semester_2"]
-  },
-  {
-    "code": "ARTS90030",
-    "name": "Melbourne History Workshop Practicum",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ARTS90031",
-    "name": "Climate Change and Ethical Dilemmas",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ASIA10002",
-    "name": "Asian Century: Meaning and Impact",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ASIA30002",
-    "name": "Identity, Ideology & Nationalism in Asia",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ASIA40004",
-    "name": "Asian Studies Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ASIA40005",
-    "name": "Asian Studies Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ASIA90001",
-    "name": "Human Rights in Southeast Asia",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ASIA90008",
-    "name": "Asia and the World",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ASIA90012",
-    "name": "International Relations Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ASIA90013",
-    "name": "International Relations Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ATOC10001",
-    "name": "Wonders Of The Weather",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ATOC30003",
-    "name": "Atmosphere Ocean Interaction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ATOC30006",
-    "name": "Modern and Future Climate",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ATOC90012",
-    "name": "Advanced Dynamical Meteorology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ATOC90016",
-    "name": "Weather and Climate Extremes",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90012",
-    "name": "Electrophysiological Assessment A",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90021",
-    "name": "Clinical Audiology A",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90022",
-    "name": "Paediatric Audiology A",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90028",
-    "name": "Swallowing and Voice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90029",
-    "name": "Clinical Processes B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90030",
-    "name": "Language Disorders Across the Lifespan",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90031",
-    "name": "Speech Disorders Across the Lifespan",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90038",
-    "name": "Professional Issues and Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90041",
-    "name": "Complex Case Models in Speech Pathology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90047",
-    "name": "Audiology in Professional Contexts",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUDI90052",
-    "name": "Practice in Diverse Communities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "AUST10002",
-    "name": "Land Food and Culture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BCMB20002",
-    "name": "Biochemistry and Molecular Biology",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BCMB20005",
-    "name": "Techniques in Molecular Science",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BCMB30001",
-    "name": "Protein Structure and Function",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BCMB30004",
-    "name": "Cell Signalling and Neurochemistry",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BCMB30010",
-    "name": "Advanced Techniques in Molecular Science",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BCMB30012",
-    "name": "Current Advances in Molecular Science",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BCMB40010",
-    "name": "Biochemistry Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BCMB40011",
-    "name": "Biochemistry Research Project Part 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIEN90002",
-    "name": "Biochemical Engineering Design Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIEN90003",
-    "name": "Biochemical Engineering Minor Thesis",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "BINF90004",
-    "name": "Bioinformatics Case Studies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOL10001",
-    "name": "Biology of Australian Flora & Fauna",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOL10010",
-    "name": "Introductory Biology: Life's Complexity",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOL10011",
-    "name": "Biology: Life's Complexity",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOL30001",
-    "name": "Reproductive Physiology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOL30002",
-    "name": "Experimental Reproductive Physiology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOL30003",
-    "name": "Case Studies In Computational Biology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOL40011",
-    "name": "Research Project - RMH Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOL40012",
-    "name": "Research Project - RMH Part 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOM10001",
-    "name": "Discovering Biomedicine",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM10002",
-    "name": "Exploring Biomedicine",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOM20002",
-    "name": "Human Structure and Function",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOM30001",
-    "name": "Frontiers in Biomedicine",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BIOM30003",
-    "name": "Biomedical Science Research Project",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90012",
-    "name": "Research Project (SBS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90013",
-    "name": "Research Project (SBS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90014",
-    "name": "Research Project (SBS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90015",
-    "name": "Research Project (SBS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90016",
-    "name": "Research Project (MMS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90017",
-    "name": "Research Project (MMS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90018",
-    "name": "Research Project (MMS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90019",
-    "name": "Research Project (MMS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90020",
-    "name": "Research Project (MDS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90021",
-    "name": "Research Project (MDS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90022",
-    "name": "Research Project (MDS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BIOM90023",
-    "name": "Research Project (MDS)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BISY90009",
-    "name": "Managing Information Technology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BLAW10001",
-    "name": "Principles of Business Law",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BLAW10002",
-    "name": "Free Speech and Media Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BLAW30002",
-    "name": "Taxation Law I",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BMEN20002",
-    "name": "Anatomy & Physiology for Bioengineering",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BMEN30008",
-    "name": "Biosystems Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BMEN30009",
-    "name": "Introduction to Biomaterials",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BMEN90002",
-    "name": "Neural Information Processing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BMEN90011",
-    "name": "Tissue Engineering & Stem Cells",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BMEN90018",
-    "name": "Biomedical Engineering Capstone Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BMEN90022",
-    "name": "Computational Biomechanics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BMEN90031",
-    "name": "Biomed Eng Capstone Proj Part 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BMEN90035",
-    "name": "Biosignal Processing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BMEN90036",
-    "name": "Biofluid Mechanics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BMSC40008",
-    "name": "Medical Biology Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BOTA20002",
-    "name": "Plant Biodiversity",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BOTA30002",
-    "name": "Plant Evolution",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BOTA30004",
-    "name": "Vegetation Management and Conservation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BOTA30005",
-    "name": "Plant Molecular Biology & Biotechnology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BTCH20002",
-    "name": "Biotechnology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BTCH90005",
-    "name": "Advanced Molecular Biology Techniques",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BUSA20001",
-    "name": "Visualisation and Data Wrangling",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "BUSA30000",
-    "name": "Business Judgement",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "BUSA90525",
-    "name": "Business and Economics Internship",
-    "offered": ["summer_term", "semester_1", "winter_term", "semester_2"]
-  },
-  {
-    "code": "CCDP10002",
-    "name": "The Electronic Arts: Vision and Sound",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CCDP10003",
-    "name": "Video Games: Remaking Reality",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CCDP20001",
-    "name": "Street Art",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CCDP40003",
-    "name": "Research Paper (Social Practice)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CEDB30003",
-    "name": "Developmental Biology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CEDB30004",
-    "name": "Stem Cells in Development & Regeneration",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEM10003",
-    "name": "Chemistry 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CHEM10004",
-    "name": "Chemistry 2",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "CHEM20019",
-    "name": "Practical Chemistry 2",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "CHEM20020",
-    "name": "Chemistry: Structure and Properties",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEM30012",
-    "name": "Analytical & Environmental Chemistry",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEM30013",
-    "name": "Chemical Research Project",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "CHEM30014",
-    "name": "Specialised Topics in Chemistry B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEM90006",
-    "name": "Analytical & Environmental Chemistry",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEN20010",
-    "name": "Material and Energy Balances",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEN20011",
-    "name": "Chemical Process Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEN30005",
-    "name": "Heat and Mass Transport Processes",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEN30015",
-    "name": "Safety and Sustainability Case Studies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEN90010",
-    "name": "Minerals, Materials and Recycling",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEN90011",
-    "name": "Bioenvironmental Engineering",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEN90012",
-    "name": "Process Equipment Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEN90022",
-    "name": "Chemical Engineering Design Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEN90026",
-    "name": "Chemical Engineering Minor Research Proj",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "CHEN90030",
-    "name": "Chemical Engineering Minor Thesis",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "CHEN90032",
-    "name": "Process Dynamics And Control",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHEN90039",
-    "name": "Pharmaceutical & Biochemical Production",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN10002",
-    "name": "Chinese 10",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN10004",
-    "name": "Chinese 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN10006",
-    "name": "Chinese 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN10009",
-    "name": "Chinese Cinema",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN10016",
-    "name": "Chinese 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN10018",
-    "name": "Chinese 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN20002",
-    "name": "Chinese 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN20004",
-    "name": "Chinese 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN20008",
-    "name": "China Since Mao",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN20011",
-    "name": "Chinese in Context 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN20013",
-    "name": "Chinese 10",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN20016",
-    "name": "Chinese Cinema",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN20021",
-    "name": "Analysis of Contemporary Chinese Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN20026",
-    "name": "Advanced Chinese Translation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN20028",
-    "name": "Chinese 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN30001",
-    "name": "Classic Chinese Civilisation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN30003",
-    "name": "Chinese News Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN30005",
-    "name": "Advanced Chinese Translation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN30006",
-    "name": "Analysis of Contemporary Chinese Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN30009",
-    "name": "Chinese 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN30018",
-    "name": "Chinese Cinema",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN30026",
-    "name": "Chinese 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN30028",
-    "name": "Chinese 10",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN40006",
-    "name": "Chinese Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CHIN40007",
-    "name": "Chinese Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CHIN90002",
-    "name": "Honours Chinese B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CHIN90006",
-    "name": "Graduate Chinese B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CICU30012",
-    "name": "Creating Screen and Cultural Worlds",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS10005",
-    "name": "Ancient Greek 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS10007",
-    "name": "Latin 2",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "CLAS10014",
-    "name": "Latin 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS10021",
-    "name": "Ancient Greek 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS20014",
-    "name": "Ancient Greek 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS20016",
-    "name": "Ancient Greek 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS20026",
-    "name": "Latin 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS20031",
-    "name": "Latin 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS30009",
-    "name": "Latin 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS30025",
-    "name": "Ancient Greek 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS40036",
-    "name": "Classics Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CLAS40037",
-    "name": "Classics Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CLAS40039",
-    "name": "Ancient Greek Honours Seminar 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CLAS40041",
-    "name": "Latin Honours Seminar 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP10001",
-    "name": "Foundations of Computing",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP10002",
-    "name": "Foundations of Algorithms",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP20003",
-    "name": "Algorithms and Data Structures",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP20005",
-    "name": "Engineering Computation",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP20008",
-    "name": "Elements of Data Processing",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP30013",
-    "name": "Advanced Studies in Computing",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP30019",
-    "name": "Graphics and Interaction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP30020",
-    "name": "Declarative Programming",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP30022",
-    "name": "IT Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP30026",
-    "name": "Models of Computation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP90005",
-    "name": "Advanced Studies in Computing",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90007",
-    "name": "Internet Technologies",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90014",
-    "name": "Algorithms for Bioinformatics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP90015",
-    "name": "Distributed Systems",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90018",
-    "name": "Mobile Computing Systems Programming",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP90025",
-    "name": "Parallel and Multicore Computing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP90038",
-    "name": "Algorithms and Complexity",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90041",
-    "name": "Programming and Software Development",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90043",
-    "name": "Cryptography and Security",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP90044",
-    "name": "Research Methods",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90045",
-    "name": "Programming Language Implementation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP90049",
-    "name": "Introduction to Machine Learning",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90051",
-    "name": "Statistical Machine Learning",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90054",
-    "name": "AI Planning for Autonomy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90055",
-    "name": "Research Project",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90057",
-    "name": "Advanced Theoretical Computer Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP90059",
-    "name": "Introduction to Programming",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90060",
-    "name": "Computer Science Research Project Pt1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90061",
-    "name": "Computer Science Research Project Pt1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90062",
-    "name": "Computer Science Research Project Pt1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90063",
-    "name": "Computer Science Research Project Pt1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90064",
-    "name": "Computer Science Research Project Pt2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90065",
-    "name": "Computer Science Research Project Pt2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90066",
-    "name": "Computer Science Research Project Pt2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90067",
-    "name": "Computer Science Research Project Pt2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90068",
-    "name": "Computer Science Research Project Pt3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90069",
-    "name": "Computer Science Research Project Pt3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90070",
-    "name": "Computer Science Research Project Pt3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90071",
-    "name": "Computer Science Research Project Pt3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90072",
-    "name": "The Art of Scientific Computation",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90073",
-    "name": "Security Analytics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP90078",
-    "name": "Computer Science Research Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90079",
-    "name": "Computer Science Research Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90080",
-    "name": "Computer Science Research Project Part 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90081",
-    "name": "Computer Science Research Project Part 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90082",
-    "name": "Software Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90083",
-    "name": "Computational Modelling and Simulation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP90084",
-    "name": "Quantum Software Fundamentals",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "COMP90085",
-    "name": "Volunteer Experience in I.T.",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "COMP90086",
-    "name": "Computer Vision",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CONS10001",
-    "name": "Principles of Building",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CONS20002",
-    "name": "Measurement of Building Designs",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CONS30002",
-    "name": "Building Information Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CONS90001",
-    "name": "Management Systems for Construction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CREA10001",
-    "name": "Contemporary Art and Biomedicine",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CREA90007",
-    "name": "Creative Arts Therapies in Education",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CREA90009",
-    "name": "Creative Arts Therapies Research 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CREA90012",
-    "name": "Creative Arts Therapies in Health",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CREA90019",
-    "name": "Creative Arts Therapies Research 3",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM10002",
-    "name": "Law in Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM20004",
-    "name": "Order, Disorder, Crime, Deviance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM20006",
-    "name": "Punishment and Social Control",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM20007",
-    "name": "Cybercrime and Digital Criminology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM20008",
-    "name": "Terrorism: Shifting Paradigms",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM20009",
-    "name": "Race, Ethnicity, Crime and Justice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM30001",
-    "name": "Crime and Public Policy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM30012",
-    "name": "Law in Social Theory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM40008",
-    "name": "Criminology Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CRIM40009",
-    "name": "Criminology Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CRIM90015",
-    "name": "Terror, Law and War",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM90019",
-    "name": "Advances in Criminological Research",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CRIM90028",
-    "name": "Criminology Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CRIM90029",
-    "name": "Criminology Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CRIM90030",
-    "name": "Criminology & Sociology Internship Pt 1",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "CRIM90031",
-    "name": "Criminology & Sociology Internship Pt 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CULS10005",
-    "name": "Media, Identity and Everyday Life",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CULS20017",
-    "name": "Gender and Contemporary Culture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CULS30005",
-    "name": "City Cultures, Urban Ecologies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CULS40011",
-    "name": "Cultural Studies Now",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CULS90004",
-    "name": "Cultural Complexity and Intelligence",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CUMC90006",
-    "name": "Conservation Internship and Projects",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CUMC90035",
-    "name": "Conservation Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CUMC90036",
-    "name": "Conservation Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CVEN30008",
-    "name": "Engineering Risk Analysis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CVEN30009",
-    "name": "Structural Theory and Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN30010",
-    "name": "Systems Modelling and Design",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CVEN30011",
-    "name": "Smart Transportation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90016",
-    "name": "Concrete Design and Technology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90018",
-    "name": "Structural Dynamics and Modelling",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90027",
-    "name": "Geotechnical Applications",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90035",
-    "name": "Steel and Composite Structures Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90045",
-    "name": "Engineering Project Implementation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90047",
-    "name": "IE Research Project 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CVEN90048",
-    "name": "Transport Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90051",
-    "name": "Civil Hydraulics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90056",
-    "name": "IE Research Project 3",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90058",
-    "name": "Construction Engineering",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90060",
-    "name": "Integrated Design - Civil",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90061",
-    "name": "Freight Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90062",
-    "name": "Building Information Modeling",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CVEN90071",
-    "name": "Offshore Geotechnical Engineering",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CWRI20002",
-    "name": "Short Fiction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CWRI30001",
-    "name": "Novels",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CWRI30004",
-    "name": "Encounters with Writing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CWRI30013",
-    "name": "Life Writing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CWRI40009",
-    "name": "Genealogies of Place",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CWRI40010",
-    "name": "Contemporary Eco-Fictions",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CWRI40012",
-    "name": "Reading Dialogue",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CWRI40013",
-    "name": "New Script",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "CWRI40015",
-    "name": "Creative Writing Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CWRI40016",
-    "name": "Creative Writing Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CWRI90015",
-    "name": "Creative Writing Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CWRI90016",
-    "name": "Creative Writing Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CWRI90018",
-    "name": "Advanced Writing Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "CWRI90019",
-    "name": "Advanced Creative Writing Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DENT40003",
-    "name": "Advances in Oral Health Research",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT40010",
-    "name": "Oral Health Sci Research Proj Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT40011",
-    "name": "Oral Health Sci Research Proj Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT90012",
-    "name": "Research Design 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DENT90014",
-    "name": "Research Proposal 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT90016",
-    "name": "Principles of Specialty 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT90018",
-    "name": "Clinical Practice in Specialty 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT90020",
-    "name": "Minor Thesis 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DENT90022",
-    "name": "Advanced Seminars in Specialty 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DENT90024",
-    "name": "Adv Clinical Practice in Specialty 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT90026",
-    "name": "Minor Thesis 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT90028",
-    "name": "Advanced Seminars in Specialty 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DENT90030",
-    "name": "Adv Clinical Practice in Specialty 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT90032",
-    "name": "Research Design 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT90034",
-    "name": "Research Project 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DENT90036",
-    "name": "Advanced Clinical Practice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DENT90038",
-    "name": "Advanced Clinical Practice 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DENT90040",
-    "name": "Forensic Odontology 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DENT90042",
-    "name": "Casework/Research Report 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DENT90046",
-    "name": "Research Project 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DENT90048",
-    "name": "OMS Clinical Practice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DEVT20001",
-    "name": "Development in the 21st Century",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DEVT90002",
-    "name": "Internship in Development",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DEVT90008",
-    "name": "International Internship in Development",
-    "offered": ["january", "semester_1", "semester_2"]
-  },
-  {
-    "code": "DEVT90045",
-    "name": "Political Economy of Development",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DEVT90047",
-    "name": "Rural and Urban Development Strategies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DEVT90054",
-    "name": "Development Studies Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DEVT90055",
-    "name": "Development Studies Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DEVT90060",
-    "name": "Internship in Development",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DEVT90077",
-    "name": "Poverty, Microfinance and Development",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DNCE10027",
-    "name": "Dancing the Dance 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DPSS10005",
-    "name": "Artefact and Performance 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DPSS10007",
-    "name": "The History of Cool: Fashion & Attitude",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DPSS10010",
-    "name": "Production Studio 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DPSS20012",
-    "name": "Production Practice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DPSS20013",
-    "name": "Production Studio 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DPSS30008",
-    "name": "Production Practice 3 - Part A",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DPSS30009",
-    "name": "Production Practice 3 - Part B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "DPSS90003",
-    "name": "Design Projects 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM10026",
-    "name": "Up Close and Personal with MTC",
-    "offered": ["semester_1", "june", "semester_2"]
-  },
-  {
-    "code": "DRAM10034",
-    "name": "Contextual Studies 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM10035",
-    "name": "Performance Preparation 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM20030",
-    "name": "Performance Practice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM20031",
-    "name": "Performance Skills 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM20034",
-    "name": "Theatre Practice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM20035",
-    "name": "Theatre Skills 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM30030",
-    "name": "Performance Practice 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM30031",
-    "name": "Performance Skills 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM30032",
-    "name": "Professional Practice Acting 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM30036",
-    "name": "Theatre Practice 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM30037",
-    "name": "Theatre Skills 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM30038",
-    "name": "Professional Practice Theatre 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM40002",
-    "name": "Research Paper (Theatre Practice)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM90012",
-    "name": "Collaborative Dramaturgies Project 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM90017",
-    "name": "Independent Directing Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM90021",
-    "name": "Director, Actor and Text",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "DRAM90024",
-    "name": "New Writing Dramaturgy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOL20003",
-    "name": "Ecology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOL30005",
-    "name": "Applied Ecology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM20001",
-    "name": "Econometrics 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECOM30002",
-    "name": "Econometrics 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECOM30003",
-    "name": "Applied Microeconometric Modelling",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM30004",
-    "name": "Time Series Analysis and Forecasting",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM40001",
-    "name": "Microeconometrics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM40004",
-    "name": "Financial Econometrics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM40005",
-    "name": "Modelling the Australian Macroeconomy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM40007",
-    "name": "Econometrics of Markets and Competition",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM90002",
-    "name": "Econometrics 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECOM90003",
-    "name": "Applied Microeconometric Modelling",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM90004",
-    "name": "Time Series Analysis and Forecasting",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM90008",
-    "name": "Microeconometrics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM90009",
-    "name": "Quantitative Methods for Business",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECOM90011",
-    "name": "Financial Econometrics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM90012",
-    "name": "Modelling the Australian Macroeconomy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM90014",
-    "name": "Advanced Econometric Techniques 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM90017",
-    "name": "Econometrics of Markets and Competition",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM90019",
-    "name": "Advanced Studies in Econometrics 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECOM90021",
-    "name": "Research Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON10002",
-    "name": "Seminar in Economics and Commerce A",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON10003",
-    "name": "Introductory Macroeconomics",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ECON10004",
-    "name": "Introductory Microeconomics",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECON10005",
-    "name": "Quantitative Methods 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECON10006",
-    "name": "Introductory Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON20001",
-    "name": "Intermediate Macroeconomics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON20003",
-    "name": "Quantitative Methods 2",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ECON20005",
-    "name": "Competition and Strategy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON20007",
-    "name": "Globalisation and the World Economy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECON30002",
-    "name": "Economic Development",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON30003",
-    "name": "Industrial Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON30009",
-    "name": "Macroeconomics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON30011",
-    "name": "Environmental Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON30019",
-    "name": "Behavioural Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON30022",
-    "name": "Experimental Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON30029",
-    "name": "International Macroeconomics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON30030",
-    "name": "Topics in Asian Economic History",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON40003",
-    "name": "International Trade",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON40004",
-    "name": "Long-Run Economic Change",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON40008",
-    "name": "Labour Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON40009",
-    "name": "Positive Political Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON40010",
-    "name": "Game Theory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON40012",
-    "name": "Development Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON40013",
-    "name": "Monetary Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON40017",
-    "name": "Mathematics for Economists",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON40019",
-    "name": "Economics Research Essay Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON40020",
-    "name": "Topics in Experimental Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90010",
-    "name": "Quantitative Analysis of Finance II",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECON90011",
-    "name": "Monetary Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90012",
-    "name": "Microeconomics II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90013",
-    "name": "Labour Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90014",
-    "name": "Macroeconomics II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90015",
-    "name": "Managerial Economics",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECON90019",
-    "name": "International Trade",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90022",
-    "name": "Game Theory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90023",
-    "name": "Development Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90033",
-    "name": "Quantitative Analysis of Finance I",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECON90034",
-    "name": "Economics of Finance",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECON90037",
-    "name": "Positive Political Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90045",
-    "name": "Microeconomics 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90053",
-    "name": "Mathematics for Economists",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ECON90056",
-    "name": "World Economic History",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90062",
-    "name": "Behavioural Economics:Accounting&Finance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90072",
-    "name": "Economics Research Report Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ECON90074",
-    "name": "Economics Thesis Workshop Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC10048",
-    "name": "Creativity, Play and the Arts",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC10049",
-    "name": "Creative Projects-Digital Technologies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC10050",
-    "name": "Understanding Knowing and Learning",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC10051",
-    "name": "Sports Coaching: Theory and Practice",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC10053",
-    "name": "Spontaneous Drama:Improv and Communities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC10054",
-    "name": "Drawing, Painting and Sensory Knowing",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC10059",
-    "name": "Performance, Potential and Development",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC20068",
-    "name": "Sport, Education and the Media",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC20070",
-    "name": "Learning via Sport and Outdoor Education",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC20074",
-    "name": "Positive Communities and Organisations",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC20080",
-    "name": "School Experience as Breadth",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC20083",
-    "name": "Story, Children and the Arts",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC30067",
-    "name": "Youth and Popular Culture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC30070",
-    "name": "Applying Coaching Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90057",
-    "name": "Education Capstone Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC90334",
-    "name": "Minor Project in Education 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC90335",
-    "name": "Minor Project in Education",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC90408",
-    "name": "Professional Practice & Seminar Sec 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90558",
-    "name": "Education Research Design",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC90640",
-    "name": "Diversity, Inclusion and Transitions",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90641",
-    "name": "Identity, Equity and Change",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90741",
-    "name": "Effective Clinical Teaching",
-    "offered": ["february", "semester_2"]
-  },
-  {
-    "code": "EDUC90742",
-    "name": "Effective Clinical Supervision",
-    "offered": ["february", "semester_2"]
-  },
-  {
-    "code": "EDUC90788",
-    "name": "Applications of Positive Psychology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90838",
-    "name": "Project in Clinical Education",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC90869",
-    "name": "Doctor of Education Thesis Proposal",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC90890",
-    "name": "3-8 Year-Olds Learning and Development",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90891",
-    "name": "Becoming a Clinical Practitioner (EC)",
-    "offered": ["february", "semester_2"]
-  },
-  {
-    "code": "EDUC90899",
-    "name": "Numeracy in Early Childhood",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90902",
-    "name": "Diverse and Inclusive Classrooms (Sec)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90916",
-    "name": "Place Based Elective (Alternative)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90922",
-    "name": "Place Based Elective (International)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90923",
-    "name": "Place Based Elective (Rural / Remote)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90929",
-    "name": "Understanding Education in Context",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC90930",
-    "name": "Local Literacies in Global Contexts",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC90931",
-    "name": "Education Research Design Part 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90937",
-    "name": "International Issues in Arts Education",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC90989",
-    "name": "Capstone Professional Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC91029",
-    "name": "Understanding the Student as Learner",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC91030",
-    "name": "Research in Educational Relationships",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EDUC91035",
-    "name": "Teaching Measurement and Geometry (7-10)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC91036",
-    "name": "Teaching Probability & Statistics (7-10)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC91039",
-    "name": "Social Issues in Science Education",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EDUC91040",
-    "name": "Beyond Siloed Approaches to Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ELEN20005",
-    "name": "Foundations of Electrical Networks",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN30009",
-    "name": "Electrical Network Analysis and Design",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN30011",
-    "name": "Electrical Device Modelling",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ELEN30012",
-    "name": "Signals and Systems",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN30013",
-    "name": "Electronic System Implementation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ELEN90011",
-    "name": "Directed Studies",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN90053",
-    "name": "Electronic System Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ELEN90054",
-    "name": "Probability and Random Models",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN90055",
-    "name": "Control Systems",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN90056",
-    "name": "Electronic Circuit Design",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN90057",
-    "name": "Communication Systems",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN90058",
-    "name": "Signal Processing",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN90060",
-    "name": "Power System Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ELEN90061",
-    "name": "Communication Networks",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ELEN90062",
-    "name": "High Speed Electronics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ELEN90064",
-    "name": "Advanced Control Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ELEN90066",
-    "name": "Embedded System Design",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN90075",
-    "name": "Power Electronics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ELEN90083",
-    "name": "Electrical Engineering Research Project",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ELEN90091",
-    "name": "Semiconductor Devices",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ELEN90092",
-    "name": "Low-carbon Grids: Operation & Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENEN20002",
-    "name": "Earth Processes for Engineering",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENEN30001",
-    "name": "Environmental Eng Systems Capstone",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENEN30003",
-    "name": "Environmental Systems Modelling & Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENEN90011",
-    "name": "Energy Efficiency Technology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENEN90028",
-    "name": "Monitoring Environmental Impacts",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENEN90029",
-    "name": "Water and Waste Water Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENEN90032",
-    "name": "Environmental Analysis Tools",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL10001",
-    "name": "Modern and Contemporary Literature",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL20020",
-    "name": "Romanticism, Feminism, Revolution",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL20022",
-    "name": "Modernism and Avant Garde",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL20023",
-    "name": "American Classics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL20025",
-    "name": "The House of Fiction: Literary Realism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL20032",
-    "name": "Poetry, Love, and Death",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL20034",
-    "name": "The Theatre Experience",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL30002",
-    "name": "Critical Debates",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL30007",
-    "name": "Popular Fiction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL30047",
-    "name": "Literature, Environment, Crisis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL30049",
-    "name": "Exploring Irish Literature",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL40003",
-    "name": "Medieval Passions",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL40020",
-    "name": "Australian Theatre and Performance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL40025",
-    "name": "Global Crime Narratives",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGL40026",
-    "name": "English & Theatre Studies Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGL40027",
-    "name": "English & Theatre Studies Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGM90006",
-    "name": "Engineering Contracts and Procurement",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGM90012",
-    "name": "Marketing Management for Engineers",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGM90013",
-    "name": "Strategy Execution for Engineers",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGM90014",
-    "name": "The World of Engineering Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGM90016",
-    "name": "Engineering Management Capstone",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR10005",
-    "name": "Statics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGR10006",
-    "name": "Engineering Modelling and Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGR20003",
-    "name": "Engineering Materials",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGR20004",
-    "name": "Engineering Mechanics",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR20005",
-    "name": "Numerical Methods in Engineering",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR30002",
-    "name": "Fluid Mechanics",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR30004",
-    "name": "Numerical Algorithms in Engineering",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGR90021",
-    "name": "Critical Communication for Engineers",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR90030",
-    "name": "Non-Renewable Energy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENGR90031",
-    "name": "Energy Systems Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR90033",
-    "name": "Internship",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR90034",
-    "name": "Creating Innovative Engineering",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR90035",
-    "name": "Graduate Research Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR90036",
-    "name": "Leadership for Innovation",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR90037",
-    "name": "Engineering Capstone Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR90038",
-    "name": "Engineering Capstone Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR90039",
-    "name": "Creating Innovative Professionals",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR90041",
-    "name": "Engineering Research Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENGR90042",
-    "name": "Engineering Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENST10005",
-    "name": "Exploring Science and Environment",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENST20004",
-    "name": "Economic Tools for the Environment",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENST30002",
-    "name": "Land And Environment Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENST30003",
-    "name": "Green Infrastructure Technologies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENST30004",
-    "name": "Nature, Conservation and Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENST90002",
-    "name": "Social Impact Assessment and Evaluation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENST90004",
-    "name": "Climate Change Politics and Policy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENST90005",
-    "name": "Environmental Policy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENST90006",
-    "name": "Environmental Research Review (12.5)",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ENST90007",
-    "name": "Environmental Research Project (25)",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ENST90016",
-    "name": "Environmental Research Project (50)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENST90017",
-    "name": "Environmental Policy Instruments",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENST90019",
-    "name": "Consumerism and the Growth Economy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ENST90020",
-    "name": "Environmental Industry Research (50)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENST90025",
-    "name": "Environmental Industry Research (25)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENST90032",
-    "name": "Sustainability and Behaviour Change",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ENST90046",
-    "name": "Landscape Governance and Policy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ERTH10002",
-    "name": "Understanding Planet Earth",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ERTH10003",
-    "name": "Geology For Engineers",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ERTH20001",
-    "name": "Dangerous Earth",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ERTH20002",
-    "name": "Environmental Geosciences",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ERTH20003",
-    "name": "Past Climates: Icehouse to Greenhouse",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ERTH90026",
-    "name": "Climate Modelling and Climate Change",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ERTH90028",
-    "name": "Urban Soils, Substrates and Water",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ESLA10003",
-    "name": "Academic English 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ESLA90002",
-    "name": "Advanced Self-Editing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ESLA90004",
-    "name": "Intercultural Professional Communication",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EURO10002",
-    "name": "Eurovisions",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EURO20002",
-    "name": "European Modernism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EURO30003",
-    "name": "European Modernism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EURO40001",
-    "name": "Introduction to European Critical Theory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EURO40002",
-    "name": "Seminars in Languages and Linguistics A",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EURO40003",
-    "name": "Seminars in Languages and Linguistics B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "EVSC20007",
-    "name": "Modelling the Real World",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EVSC30002",
-    "name": "Problem Solving in Environmental Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EVSC30007",
-    "name": "Landscape Ecosystem Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EVSC90019",
-    "name": "Graduate Seminar: Environmental Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "EVSC90026",
-    "name": "Modelling Species Distributions & Niches",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA10032",
-    "name": "Critical and Theoretical Studies 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA10034",
-    "name": "Studio Studies 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA10035",
-    "name": "Still Life: Nature Morte",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FINA20026",
-    "name": "Painting Techniques",
-    "offered": [
-      "summer_term",
-      "february",
-      "semester_1",
-      "winter_term",
-      "june",
-      "semester_2"
-    ]
-  },
-  {
-    "code": "FINA20030",
-    "name": "Studio Studies 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA20032",
-    "name": "Critical and Theoretical Studies 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA20041",
-    "name": "The Figure in Performance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA20044",
-    "name": "Art and the Botanical",
-    "offered": [
-      "summer_term",
-      "february",
-      "semester_1",
-      "winter_term",
-      "june",
-      "semester_2"
-    ]
-  },
-  {
-    "code": "FINA30002",
-    "name": "Studio Studies 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA30018",
-    "name": "Critical and Theoretical Studies 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA30024",
-    "name": "Performance Design Studio",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA40005",
-    "name": "Research Paper (Visual Art)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA60010",
-    "name": "Studio Materials and Methods B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA60012",
-    "name": "Contemporary Art Practice B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA60014",
-    "name": "Critical Issues in Contemporary Art B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA70009",
-    "name": "Studio Practice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA90007",
-    "name": "Perspectives in Art & Cultural Theory 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FINA90009",
-    "name": "Perspectives in Art & Cultural Theory 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV10008",
-    "name": "Screen Practice 1B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV10009",
-    "name": "Screen Culture 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV10010",
-    "name": "Making Movies 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FLTV10015",
-    "name": "Screenwriting Practices 1B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV10019",
-    "name": "Animation Studio 1B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV10020",
-    "name": "Animation Lab 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV10021",
-    "name": "Interactive Art Media 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FLTV10023",
-    "name": "Introduction to Screenwriting Practices",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FLTV20008",
-    "name": "Screenwriting 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV20009",
-    "name": "Screen Practice 2B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV20011",
-    "name": "Gaming and the Writer",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV20013",
-    "name": "Animation Lab 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV20016",
-    "name": "Animation Studio 2B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV20017",
-    "name": "Screenwriting Practices 2B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV40006",
-    "name": "Research Paper (Animation)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV40009",
-    "name": "Research Paper (Film and Television)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV40012",
-    "name": "Research Paper (Screenwriting)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV70022",
-    "name": "Documentary Projects 1B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV70023",
-    "name": "Narrative Projects 1B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV70046",
-    "name": "Script Development Hothouse",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV70047",
-    "name": "Major Screenwriting Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90007",
-    "name": "Design Processes and Principles B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90008",
-    "name": "Design Realisation and Collaboration B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90009",
-    "name": "Design Documentation and Communication B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90010",
-    "name": "Roles and Processes in Art Department",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90012",
-    "name": "Industry Investigation Project B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90013",
-    "name": "Professional Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90016",
-    "name": "Screen Design Projects B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90018",
-    "name": "Film Craft",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90019",
-    "name": "Screenwriting and Creative Development",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90020",
-    "name": "Business of Producing 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90021",
-    "name": "Producing and the Creative Process",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90024",
-    "name": "Production Collaboration",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FLTV90027",
-    "name": "Screen Language 1B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE10002",
-    "name": "Principles of Finance",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE20003",
-    "name": "Introductory Personal Finance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE20005",
-    "name": "Corporate Financial Decision Making",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE30001",
-    "name": "Investments",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE30003",
-    "name": "International Finance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE30007",
-    "name": "Derivative Securities",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE30010",
-    "name": "Algorithmic Trading",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE30012",
-    "name": "Foundations of FinTech",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE40006",
-    "name": "Finance Research Essay",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE40009",
-    "name": "Advanced Derivative Securities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE90002",
-    "name": "Foundations of Finance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE90005",
-    "name": "Advanced Derivative Securities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE90011",
-    "name": "Derivative Securities",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90012",
-    "name": "Corporate Restructuring and Valuation",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90013",
-    "name": "Case Studies in Finance",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90016",
-    "name": "International Financial Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90018",
-    "name": "Corporate Financial Policy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90045",
-    "name": "Financial Spreadsheeting",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE90046",
-    "name": "Treasury Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90047",
-    "name": "Financial Markets and Instruments",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90048",
-    "name": "Project Finance",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90056",
-    "name": "Investment Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90060",
-    "name": "Financial Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90062",
-    "name": "Capstone Studies in Finance",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90064",
-    "name": "Emerging Markets Finance",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90065",
-    "name": "Fundamentals of Finance",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90070",
-    "name": "Experimental Methods in Decision Studies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE90071",
-    "name": "DRFS Research Report Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90072",
-    "name": "DRFS Research Report Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90073",
-    "name": "Laboratory Rotation 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE90078",
-    "name": "Algorithmic Trading",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE90080",
-    "name": "Applied Investment Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90081",
-    "name": "Applied Research Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE90082",
-    "name": "Applied Risk Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90084",
-    "name": "Fintech: Foundations and Applications",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FNCE90085",
-    "name": "Communicating Current Issues in Finance",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FNCE90087",
-    "name": "Sustainable Investment",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD20006",
-    "name": "Food Microbiology and Safety",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD30009",
-    "name": "Food Research & Development",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD30010",
-    "name": "Functional Foods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD40002",
-    "name": "Food Science Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD90007",
-    "name": "Food Processing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD90008",
-    "name": "Food Safety and Quality",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD90028",
-    "name": "Sensory Evaluation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD90033",
-    "name": "Sustainable Food: Policy and Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD90034",
-    "name": "Sustainable Food Production",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD90035",
-    "name": "Plant Food Products",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD90036",
-    "name": "MFPI Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FOOD90037",
-    "name": "MFPI Internship Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FOOD90038",
-    "name": "MFPI Internship Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FOOD90040",
-    "name": "Nutrition Politics and Policy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FOOD90042",
-    "name": "Special Studies in Food",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "FREN10003",
-    "name": "French 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN10005",
-    "name": "French 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN10007",
-    "name": "French 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN20002",
-    "name": "French 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN20003",
-    "name": "Romanticism to Decadence: French Novels",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN20004",
-    "name": "French Translation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN20016",
-    "name": "French and Francophone Cultural Studies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN20017",
-    "name": "French 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN30004",
-    "name": "French 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN30005",
-    "name": "Romanticism to Decadence: French Novels",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN30006",
-    "name": "French Translation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FREN40010",
-    "name": "French Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FREN40011",
-    "name": "French Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FREN90004",
-    "name": "Graduate French B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FRST20015",
-    "name": "Fire in the Australian Landscape",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FRST90032",
-    "name": "Forests, Carbon and Climate Change",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FRST90033",
-    "name": "Farm Trees & Agroforestry",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "FRST90076",
-    "name": "Short Research Project B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "FRST90077",
-    "name": "Long Research Project B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GDES10001",
-    "name": "Graphic Design Studio 1: Image & Text",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GDES20002",
-    "name": "Colour Studio",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GDES30003",
-    "name": "Graphic Design Studio 3",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEND10001",
-    "name": "Sex, Gender and Culture: An Introduction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEND30003",
-    "name": "Gender at Work in The World",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEND30005",
-    "name": "Gender Diversity in the Workplace",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEND30007",
-    "name": "Transgender Studies Terms and Debates",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEND40006",
-    "name": "Gender Studies Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEND40007",
-    "name": "Gender Studies Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEND40009",
-    "name": "Feminist & Queer Perspectives on Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEND90007",
-    "name": "Rethinking Rights and Global Development",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEND90011",
-    "name": "Gender and Development Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEND90012",
-    "name": "Gender and Development Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GENE20004",
-    "name": "Applications of Genetics and Genomics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GENE30004",
-    "name": "Genetic Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GENE30005",
-    "name": "Human and Medical Genetics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GENE90002",
-    "name": "Clinical Genomics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GENE90005",
-    "name": "Genomics in Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GENE90022",
-    "name": "Advanced Clinical Genomics 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GENE90024",
-    "name": "Frontiers in Genomics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GENE90025",
-    "name": "Clinical Genome Variant Analysis 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GENP40001",
-    "name": "Primary Care Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GENP60002",
-    "name": "Preventive Health Care",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GENP90017",
-    "name": "Immunisation and Travel Health",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG10002",
-    "name": "Landscape Information Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG10003",
-    "name": "Global Youth",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG20008",
-    "name": "Inside the City of Diversity",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG20011",
-    "name": "Global Inequalities In The Anthropocene",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG20013",
-    "name": "Health Geography",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG20015",
-    "name": "Environmental Change & the Human Journey",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG20017",
-    "name": "Spatial Analysis in Geography",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG20018",
-    "name": "India: Economic, Politics, and Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG30021",
-    "name": "The Disaster Resilient City",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG30024",
-    "name": "Africa: Environment, Development, People",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG30027",
-    "name": "Local Sites, Global Connections",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG90010",
-    "name": "Geography Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG90011",
-    "name": "Geography Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG90012",
-    "name": "Geography Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG90013",
-    "name": "Geography Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG90015",
-    "name": "Geography Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG90022",
-    "name": "International Internship in Environment",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG90025",
-    "name": "East Timor Field Class",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG90026",
-    "name": "Global Climate Change In Context",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOG90028",
-    "name": "Geography Practical",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG90030",
-    "name": "Geography Minor Research Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG90031",
-    "name": "Geography Minor Research Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG90032",
-    "name": "Geography Minor Research Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOG90033",
-    "name": "Geography Minor Research Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOL30003",
-    "name": "Sedimentary Geology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOL30005",
-    "name": "Applied Geophysics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOL30006",
-    "name": "Economic Geology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOL90022",
-    "name": "Practical Earth Science A",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOL90023",
-    "name": "Practical Earth Science B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOL90024",
-    "name": "Project In Geoscience",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOL90025",
-    "name": "Research Project In Geoscience",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOL90031",
-    "name": "Ore Reserve Estimation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOL90033",
-    "name": "Mine Safety and Engineering",
-    "offered": ["june", "semester_2"]
-  },
-  {
-    "code": "GEOM20015",
-    "name": "Surveying and Mapping",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOM30012",
-    "name": "Integrated Spatial Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOM30013",
-    "name": "Land Administration Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOM90005",
-    "name": "Remote Sensing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOM90006",
-    "name": "Spatial Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOM90007",
-    "name": "Information Visualisation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOM90008",
-    "name": "Foundations of Spatial Information",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOM90010",
-    "name": "Spatial Information Research Project A",
-    "offered": ["summer_term", "semester_1", "winter_term", "semester_2"]
-  },
-  {
-    "code": "GEOM90013",
-    "name": "Spatial Information Research Project C",
-    "offered": ["summer_term", "semester_1", "winter_term", "semester_2"]
-  },
-  {
-    "code": "GEOM90020",
-    "name": "Spatial Information Research Project",
-    "offered": ["summer_term", "semester_1", "winter_term", "semester_2"]
-  },
-  {
-    "code": "GEOM90023",
-    "name": "Spatial Information Research Project B",
-    "offered": ["summer_term", "semester_1", "winter_term", "semester_2"]
-  },
-  {
-    "code": "GEOM90031",
-    "name": "Spatial Information Research Project D",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "GEOM90033",
-    "name": "Satellite Positioning Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOM90040",
-    "name": "Mathematics of Spatial Information",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOM90041",
-    "name": "Cadastral Surveying",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GEOM90043",
-    "name": "Spatial IT Project",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "GERM10002",
-    "name": "German 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM10005",
-    "name": "German 2",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "GERM10007",
-    "name": "German 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM10009",
-    "name": "German 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM20002",
-    "name": "German 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM20003",
-    "name": "German Cultural Studies B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GERM20005",
-    "name": "German 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM20006",
-    "name": "German Cultural Studies A",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM20008",
-    "name": "German 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM20010",
-    "name": "German 10",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM30001",
-    "name": "German Cultural Studies B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GERM30004",
-    "name": "German 10",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM30006",
-    "name": "German 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM30022",
-    "name": "German 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM30023",
-    "name": "German Cultural Studies D",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "GERM40016",
-    "name": "German Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GERM40017",
-    "name": "German Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "GERM90004",
-    "name": "Graduate German B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HEBR10002",
-    "name": "Hebrew 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HEBR10006",
-    "name": "Hebrew 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HEBR10012",
-    "name": "Hebrew 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HEBR20006",
-    "name": "Hebrew 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HEBR20008",
-    "name": "Hebrew 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HEBR30004",
-    "name": "Hebrew 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST10015",
-    "name": "Dictators & Democrats: The Modern World",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST10017",
-    "name": "Gender, Rights, & Leadership in History",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST20010",
-    "name": "The First Centuries of Islam",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST20060",
-    "name": "Total War: World War II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST20071",
-    "name": "American History: 1945 to Now",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST20080",
-    "name": "Witch-Hunting in European Societies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST20084",
-    "name": "Red Empire: The Soviet Union and After",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST20088",
-    "name": "Introduction to Indigenous History",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST30004",
-    "name": "A History of Sexualities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST30010",
-    "name": "Hitler's Germany and Fascism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST30059",
-    "name": "Race in the Americas",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST30060",
-    "name": "Making History",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST30064",
-    "name": "Controversies in Australian History",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST30066",
-    "name": "Cold War Cultures in Asia",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST40037",
-    "name": "The Long History of Globalisation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST40040",
-    "name": "History Thesis Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST90026",
-    "name": "History, Memory and Violence in Asia",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HIST90034",
-    "name": "International Relations Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "HIST90035",
-    "name": "International Relations Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "HIST90037",
-    "name": "Russia and the World",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HLTH90006",
-    "name": "Basics of Digital Health for Clinicians",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "HLTH90011",
-    "name": "Research Project in Human Genomics 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HLTH90020",
-    "name": "Digital Health Information Services",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HLTH90021",
-    "name": "Introduction to Biomedical Enterprise",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HORT20017",
-    "name": "Landscape Design 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HORT20027",
-    "name": "Greening Landscapes",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HORT90004",
-    "name": "Plant Production and Establishment",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HORT90035",
-    "name": "Landscape Construction and Graphics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HPSC10001",
-    "name": "From Plato to Einstein",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HPSC10003",
-    "name": "Debating Science in Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HPSC20023",
-    "name": "Sex and Gender in the Sciences",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HPSC30035",
-    "name": "The Dynamics of Scientific Change",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "HPSC40018",
-    "name": "HPS Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "HPSC40019",
-    "name": "HPS Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "HPSC90012",
-    "name": "Trust, Communication and Expertise",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "IBUS90001",
-    "name": "Global Strategy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "IBUS90002",
-    "name": "Managing in Asia",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "IBUS90003",
-    "name": "The Multinational",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "IBUS90008",
-    "name": "Global Value Chains",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDG20002",
-    "name": "Indigenous Environmental Heritage",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDG20003",
-    "name": "Aboriginal Women and Coloniality",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDG30001",
-    "name": "Being Indigenous in the 21st Century",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDG40001",
-    "name": "Indigenous First Principles",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDG40003",
-    "name": "Indigenous Studies Thesis Pt1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "INDG40004",
-    "name": "Indigenous Studies Thesis Pt2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "INDO10002",
-    "name": "Indonesian 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO10004",
-    "name": "Indonesian 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO10006",
-    "name": "Indonesian 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO10011",
-    "name": "Diversity: Identities in Indonesia",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO10013",
-    "name": "Translation: Intercultural Indonesian",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO20007",
-    "name": "Indonesian 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO20009",
-    "name": "Indonesian 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO20014",
-    "name": "Diversity: Identities in Indonesia",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO20016",
-    "name": "Translation: Intercultural Indonesian",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO20018",
-    "name": "Indonesian Politics and Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO30002",
-    "name": "Creative Industries in Indonesia",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO30007",
-    "name": "Indonesian 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO30018",
-    "name": "Diversity: Identities in Indonesia",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO30019",
-    "name": "Translation: Intercultural Indonesian",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO40002",
-    "name": "Honours Indonesian B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INDO40003",
-    "name": "Topics in Indonesian Studies",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "INDO40008",
-    "name": "Indonesian Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "INDO40009",
-    "name": "Indonesian Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "INDO90003",
-    "name": "Graduate Indonesian B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INFO10003",
-    "name": "Fundamentals of Interaction Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INFO20003",
-    "name": "Database Systems",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "INFO20004",
-    "name": "Usability Evaluation Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INFO30006",
-    "name": "Information Security and Privacy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INFO30008",
-    "name": "Interactive Technology Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INFO90001",
-    "name": "Health Informatics Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INFO90002",
-    "name": "Database Systems & Information Modelling",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "INFO90005",
-    "name": "Information Architecture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INFO90006",
-    "name": "Fieldwork for Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INFO90007",
-    "name": "Social Computing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "INFO90008",
-    "name": "HCI Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "INFO90009",
-    "name": "HCI Project (Advanced)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "INFO90010",
-    "name": "Technology Innovation Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "INTS10001",
-    "name": "International Politics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ISLM10002",
-    "name": "Islam and Modernity",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ISLM20015",
-    "name": "Politics in the Middle East & South Asia",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ISLM30003",
-    "name": "Islam and Ethics: Doctrines and Debates",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ISLM30017",
-    "name": "Contemporary Challenges and Islam",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ISLM30020",
-    "name": "Islam and Democracy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ISLM40001",
-    "name": "Topics in Arabic & Islamic Studies",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISLM40011",
-    "name": "Islamic Studies Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISLM40012",
-    "name": "Islamic Studies Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS10001",
-    "name": "Foundations of Information Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ISYS90026",
-    "name": "Fundamentals of Information Systems",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90032",
-    "name": "Emerging Technologies and Issues",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90034",
-    "name": "B2B Electronic Commerce",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ISYS90038",
-    "name": "IS Strategy and Governance",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90040",
-    "name": "Managing Change for IS Professionals",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ISYS90043",
-    "name": "Enterprise Applications & Architectures",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90045",
-    "name": "Professional IS Consulting",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90048",
-    "name": "Managing ICT Infrastructure",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90049",
-    "name": "Digital Business Analysis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90050",
-    "name": "IT Project and Change Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90051",
-    "name": "Impact of Digitisation",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90078",
-    "name": "Structuring and Managing Patient Data",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ISYS90079",
-    "name": "Health IT Project",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90081",
-    "name": "Business Process Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90100",
-    "name": "Information Systems Maj Res Project Pt 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90101",
-    "name": "Information Systems Maj Res Project Pt 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90102",
-    "name": "Information Systems Maj Res Project Pt 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90103",
-    "name": "Information Systems Maj Res Project Pt 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90104",
-    "name": "Information Systems Maj Res Project Pt 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90105",
-    "name": "Information Systems Maj Res Project Pt 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90106",
-    "name": "Information Systems Maj Res Project Pt 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90107",
-    "name": "Information Systems Maj Res Project Pt 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90108",
-    "name": "Information Systems Maj Res Project Pt 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90109",
-    "name": "Information Systems Min Res Project Pt 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ISYS90110",
-    "name": "Information Systems Min Res Project Pt 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ITAL10002",
-    "name": "Italian 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL10005",
-    "name": "Italian 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL10007",
-    "name": "Italian 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL10010",
-    "name": "Italian 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL20001",
-    "name": "Italian Cultural Studies B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL20003",
-    "name": "Italian 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL20008",
-    "name": "Italian 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL20009",
-    "name": "Italian Cultural Studies A",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL20010",
-    "name": "Italian 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL30010",
-    "name": "Imaging Italy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL30014",
-    "name": "Italian 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL30016",
-    "name": "Italian 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ITAL40015",
-    "name": "Italian Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ITAL40016",
-    "name": "Italian Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ITAL90004",
-    "name": "Graduate Italian B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN10002",
-    "name": "Japanese 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN10004",
-    "name": "Japanese 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN10006",
-    "name": "Japanese 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN10008",
-    "name": "Japanese 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN10009",
-    "name": "Reading Japanese Literature",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN20002",
-    "name": "Introduction to Japanese Communication",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN20004",
-    "name": "Japanese 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN20008",
-    "name": "Japanese 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN20010",
-    "name": "Japanese Grammar in Action",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN20011",
-    "name": "Reading Japanese Literature",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN20014",
-    "name": "Japanese 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN20016",
-    "name": "Japanese Through Translation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN30002",
-    "name": "Social Problems in Japan",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN30003",
-    "name": "Japanese Through Translation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN30006",
-    "name": "Japanese 8",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN30008",
-    "name": "Japanese 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN30011",
-    "name": "Reading Japanese Literature",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN30013",
-    "name": "Japanese Grammar in Action",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN40002",
-    "name": "Honours Japanese B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JAPN40008",
-    "name": "Japanese Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "JAPN40009",
-    "name": "Japanese Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "JAPN90003",
-    "name": "Graduate Japanese B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JEWI20006",
-    "name": "Israelis & Palestinians: Conflict, Peace",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JEWI30005",
-    "name": "Research in Contemporary Jewish Studies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JOUR90001",
-    "name": "Researching/Writing Stories",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "JOUR90003",
-    "name": "Journalism Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "JOUR90004",
-    "name": "New Media: Harnessing Digital Disruption",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JOUR90008",
-    "name": "Video Journalism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JOUR90009",
-    "name": "Advanced Non Fiction Writing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JOUR90013",
-    "name": "Investigative Journalism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JOUR90015",
-    "name": "Journalism Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "JOUR90016",
-    "name": "Journalism Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "JOUR90017",
-    "name": "Journalism Project (Extended) Part 1",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "JOUR90019",
-    "name": "Journalism Project (Extended) Part 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "JOUR90020",
-    "name": "International Journalism - Key Skills",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "JOUR90022",
-    "name": "Photojournalism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JOUR90023",
-    "name": "International Business Journalism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JOUR90024",
-    "name": "Advanced Audio: Podcasting",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "JOUR90025",
-    "name": "Journalism Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "JOUR90026",
-    "name": "Journalism Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "KORE10002",
-    "name": "Korean 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "KORE10004",
-    "name": "Korean 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "KORE20002",
-    "name": "Contemporary Korea",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "KORE20004",
-    "name": "Korean 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LANG30001",
-    "name": "Languages at Work",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LANG40003",
-    "name": "Seminar in Languages 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LANG40004",
-    "name": "Seminar in Languages 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LARC10001",
-    "name": "Natural History",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LARC20001",
-    "name": "Designing Living Systems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LARC30002",
-    "name": "Interpreting Australian Landscape Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS10009",
-    "name": "AI, Ethics and the Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS20012",
-    "name": "Global Human Rights Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS20013",
-    "name": "Health Law, Ethics and Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS30024",
-    "name": "Public Trials",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50028",
-    "name": "Constitutional Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50029",
-    "name": "Contracts",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50031",
-    "name": "Legal Theory",
-    "offered": ["semester_2", "november"]
-  },
-  {
-    "code": "LAWS50033",
-    "name": "Equity and Trusts",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50034",
-    "name": "Criminal Law and Procedure",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50035",
-    "name": "Corporations Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50039",
-    "name": "Legal Research",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LAWS50047",
-    "name": "Family Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50049",
-    "name": "Human Rights Law and Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50050",
-    "name": "Cross-Border Litigation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50055",
-    "name": "Advocacy",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "LAWS50058",
-    "name": "Melbourne University Law Review",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "LAWS50059",
-    "name": "Legal Internship",
-    "offered": ["january", "semester_1", "june", "semester_2", "november"]
-  },
-  {
-    "code": "LAWS50060",
-    "name": "Melbourne Journal of International Law",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "LAWS50084",
-    "name": "Construction Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50093",
-    "name": "Insolvency Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50096",
-    "name": "Media Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50114",
-    "name": "New Ideas in Legal Scholarship",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS50126",
-    "name": "Sustainability Business Clinic",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS70003",
-    "name": "Minor Thesis (LLM) # P/T",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LAWS70015",
-    "name": "Minor Thesis F/T LLM",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LAWS70024",
-    "name": "Corporate Tax A",
-    "offered": ["april", "semester_2"]
-  },
-  {
-    "code": "LAWS70067",
-    "name": "International Legal Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LAWS70121",
-    "name": "International Commercial Arbitration",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS70333",
-    "name": "Taxation of Trusts",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90003",
-    "name": "Regulation of Biotechnology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90033",
-    "name": "Law Apps",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LAWS90036",
-    "name": "Legal Drafting",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90059",
-    "name": "Commercial Law in Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90075",
-    "name": "Patents and Trade Secrets",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90077",
-    "name": "Not for Profits and the Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90136",
-    "name": "Criminal Institutions",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90140",
-    "name": "Disputes and Ethics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90164",
-    "name": "MLS Tax Clinic",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LAWS90186",
-    "name": "Advanced Trusts Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90189",
-    "name": "NDIS and Disability Benefits Clinic",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90191",
-    "name": "Treaty: Indigenous-settler Agreements",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90197",
-    "name": "Consumer Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90203",
-    "name": "Digital Ethics for Scientists",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90213",
-    "name": "Commercial Data Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LAWS90217",
-    "name": "Hot Topics in Public Law",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING10001",
-    "name": "The Secret Life of Language",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING20003",
-    "name": "Second Language Learning and Teaching",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING20006",
-    "name": "Syntax",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING20010",
-    "name": "Language, Society and Culture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING30001",
-    "name": "Exploring Linguistic Diversity",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING30002",
-    "name": "Phonology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING40006",
-    "name": "Linguistic Field Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING40015",
-    "name": "LAL Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LING40016",
-    "name": "LAL Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LING90002",
-    "name": "Presenting Academic Discourse",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LING90008",
-    "name": "Language Program Evaluation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING90010",
-    "name": "Applied Linguistics Thesis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LING90012",
-    "name": "Second Language Acquisition",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LING90015",
-    "name": "English Phonetics and Phonology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING90021",
-    "name": "Bilingualism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING90026",
-    "name": "Transcultural Communication at Work",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING90028",
-    "name": "Discourse and Interaction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "LING90031",
-    "name": "Advanced Linguistics Analysis A",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LING90032",
-    "name": "Advanced Linguistics Analysis B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "LING90039",
-    "name": "Concepts in Applied Linguistics",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST10005",
-    "name": "Calculus 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST10006",
-    "name": "Calculus 2",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST10007",
-    "name": "Linear Algebra",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST10009",
-    "name": "Accelerated Mathematics 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST10010",
-    "name": "Data Analysis 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST10011",
-    "name": "Experimental Design and Data Analysis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST10015",
-    "name": "Foundation Mathematics 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST10016",
-    "name": "Mathematics for Biomedicine",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST10017",
-    "name": "Fundamentals of Mathematics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST10021",
-    "name": "Calculus 2: Advanced",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST10023",
-    "name": "Exploring Numbers and Reasoning",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST20004",
-    "name": "Probability",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST20005",
-    "name": "Statistics",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "MAST20009",
-    "name": "Vector Calculus",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST20018",
-    "name": "Discrete Maths and Operations Research",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST20022",
-    "name": "Group Theory and Linear Algebra",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST20026",
-    "name": "Real Analysis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST20029",
-    "name": "Engineering Mathematics",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST20030",
-    "name": "Differential Equations",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST30001",
-    "name": "Stochastic Modelling",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST30012",
-    "name": "Discrete Mathematics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST30021",
-    "name": "Complex Analysis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST30022",
-    "name": "Decision Making",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST30024",
-    "name": "Geometry",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST30026",
-    "name": "Metric and Hilbert Spaces",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST30027",
-    "name": "Modern Applied Statistics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST30028",
-    "name": "Numerical Methods & Scientific Computing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST30031",
-    "name": "Methods of Mathematical Physics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST30033",
-    "name": "Statistical Genomics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST30034",
-    "name": "Applied Data Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90013",
-    "name": "Network Optimisation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90017",
-    "name": "Representation Theory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90030",
-    "name": "Advanced Discrete Mathematics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90042",
-    "name": "Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90046",
-    "name": "Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90047",
-    "name": "Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90048",
-    "name": "Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90050",
-    "name": "Scheduling and Optimisation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90056",
-    "name": "Riemann Surfaces and Complex Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90058",
-    "name": "Elements of Statistics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90065",
-    "name": "Exactly Solvable Models",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90073",
-    "name": "Minor Research Project Part A",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90074",
-    "name": "Minor Research Project Part B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90075",
-    "name": "Research Project Part A",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90076",
-    "name": "Research Project Part B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90077",
-    "name": "Research Project Part C",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90081",
-    "name": "Advanced Probability",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90083",
-    "name": "Computational Statistics & Data Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90098",
-    "name": "Approximation, Algorithms and Heuristics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90099",
-    "name": "Categorical Data: Models and Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90102",
-    "name": "Linear Regression",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90104",
-    "name": "A First Course In Statistical Learning",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90107",
-    "name": "Data Science Project Pt2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90108",
-    "name": "Data Science Research Project Pt1",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90109",
-    "name": "Data Science Research Project Pt2",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MAST90113",
-    "name": "Continuum Mechanics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90125",
-    "name": "Bayesian Statistical Learning",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90126",
-    "name": "Advanced Statistical Genomics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90128",
-    "name": "Advanced Environmental Computation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90129",
-    "name": "Infectious Disease Dynamics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90133",
-    "name": "Partial Differential Equations",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90138",
-    "name": "Multivariate Statistics for Data Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90140",
-    "name": "Causal Inference",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MAST90141",
-    "name": "Machine Learning for Biostatistics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN30017",
-    "name": "Mechanics & Materials",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MCEN30018",
-    "name": "Thermodynamics and Fluid Mechanics",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MCEN30020",
-    "name": "Systems Modelling and Analysis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MCEN30021",
-    "name": "Mechanical Systems Design",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MCEN90008",
-    "name": "Fluid Dynamics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90019",
-    "name": "Advanced Thermodynamics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90020",
-    "name": "Additive Manufacturing of Metals",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90026",
-    "name": "Solid Mechanics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90031",
-    "name": "Applied High Performance Computing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90036",
-    "name": "Capstone Project A",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MCEN90041",
-    "name": "Advanced Dynamics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90046",
-    "name": "Vibrations and Aeroelasticity",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90047",
-    "name": "Aerospace Propulsion",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90050",
-    "name": "Human Centred Mechanical Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90052",
-    "name": "Advanced Materials",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90053",
-    "name": "Industrial Systems and Simulation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90057",
-    "name": "Manufacturing Automation and IT",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90059",
-    "name": "Probability, Reliability and Quality",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90061",
-    "name": "Mechatronics Systems Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MCEN90062",
-    "name": "Materials Modelling and Characterisation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM10005",
-    "name": "Academic Writing and Communication",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM10006",
-    "name": "Introduction to Media Writing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM20003",
-    "name": "Internet Communication",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM20011",
-    "name": "Approaches to Media Research",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM20014",
-    "name": "Visual Communication and Digital Media",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM30002",
-    "name": "Perspectives in Global Media Cultures",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM30004",
-    "name": "Media Futures and New Technologies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM30013",
-    "name": "Marketing Communications",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM30017",
-    "name": "Digital and Mobile Journalism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM40006",
-    "name": "Public Relations and Communications",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM40007",
-    "name": "Change in Journalism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM40018",
-    "name": "Media & Communications Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM40019",
-    "name": "Media & Communications Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM90003",
-    "name": "Mobility, Culture and Communication",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM90009",
-    "name": "Global Crisis Reporting",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM90016",
-    "name": "Digital Politics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM90017",
-    "name": "Media Writing: Rhetoric and Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM90020",
-    "name": "Global Media: Theory and Research",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM90024",
-    "name": "Strategic Content Creation",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM90025",
-    "name": "Advanced Industry Practice – PR",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MECM90029",
-    "name": "Media and Communications Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM90030",
-    "name": "Media and Communications Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM90031",
-    "name": "Audiovisual Communication",
-    "offered": ["semester_1", "winter_term", "semester_2"]
-  },
-  {
-    "code": "MECM90032",
-    "name": "Marketing Communications Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM90033",
-    "name": "Marketing Communications Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM90034",
-    "name": "Marketing & Media in a Global Context",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM90035",
-    "name": "Integrated Marketing Communications",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM90036",
-    "name": "Foundations of Marketing & Communication",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM90038",
-    "name": "Researching Media & Communications",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MECM90039",
-    "name": "Understanding Media & Communications",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI40013",
-    "name": "Research Project - SVHM Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MEDI40015",
-    "name": "Biomedicine Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MEDI40019",
-    "name": "Research Project – WH Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MEDI90046",
-    "name": "3-D Echocardiography & New Technologies",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90047",
-    "name": "Congenital,Obsetric& Medical Conditions",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90048",
-    "name": "Advanced Case Studies Practicum",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90049",
-    "name": "Principles of Ultrasound Heart Scan",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90050",
-    "name": "Doppler Echocardiography",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90051",
-    "name": "Ventricular Function",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90054",
-    "name": "Ultrasound Guided Procedures",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90056",
-    "name": "Advanced Anatomy and Doppler Analysis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90057",
-    "name": "Advanced Valve and Aortic Pathology",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90058",
-    "name": "Applications of Echocardiography",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90059",
-    "name": "Advanced Echocardiography Interpretation",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90083",
-    "name": "Research Methods & Ultrasound Literature",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90088",
-    "name": "Graduate Research Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90100",
-    "name": "Abdominal and Peri-Arrest Ultrasound",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90101",
-    "name": "Obstetrics Gynaecology and Practicum",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90102",
-    "name": "Vessels Nerves Lungs and Musculoskeletal",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MEDI90105",
-    "name": "Perioperative Complications",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MEDI90106",
-    "name": "Post-op Quality of Recovery Practicum",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT10002",
-    "name": "Principles of Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT20001",
-    "name": "Organisational Behaviour",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT20004",
-    "name": "Managing People at Work",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT20005",
-    "name": "Business Decision Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT30004",
-    "name": "Managing Globally",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT30008",
-    "name": "Managing Sustainably",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT30011",
-    "name": "Managing Supply Chain Networks",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT30012",
-    "name": "Management Consulting",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90010",
-    "name": "Strategic Human Resources",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90012",
-    "name": "Managing Diversity",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90014",
-    "name": "Human Resource Management in Context",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90015",
-    "name": "Human Resource Fundamentals",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90017",
-    "name": "HR Consulting",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90018",
-    "name": "Managing Behaviour in Organisations",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90025",
-    "name": "People and Change",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90027",
-    "name": "International Human Resources",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90030",
-    "name": "Managing Innovation",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90031",
-    "name": "Project Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90032",
-    "name": "Operations and Process Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90038",
-    "name": "Global Corporate Governance",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90129",
-    "name": "Group Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90130",
-    "name": "Internship I",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90131",
-    "name": "Internship II",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90140",
-    "name": "Management Competencies",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90141",
-    "name": "Business Analysis & Decision Making",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90146",
-    "name": "Strategic Management",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90148",
-    "name": "Consulting Fundamentals",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90164",
-    "name": "EMA Special Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90165",
-    "name": "Social Entrepreneurship",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90176",
-    "name": "People and Capability",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90195",
-    "name": "Advanced Management Theory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90202",
-    "name": "Foundations in Qualitative Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90203",
-    "name": "Foundations in Quantitative Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90204",
-    "name": "Leading for Strategic Advantage",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90206",
-    "name": "Management & Marketing Special Topics 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90207",
-    "name": "Management & Marketing Special Topics 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90209",
-    "name": "EMA Career Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90228",
-    "name": "Managing Growth and Pathways to Market",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90235",
-    "name": "EMA Special Project (Year Long) Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90236",
-    "name": "EMA Special Project (Year Long) Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90237",
-    "name": "Research Report Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90238",
-    "name": "Research Report Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MGMT90249",
-    "name": "Research Foundations",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MGMT90280",
-    "name": "Managerial Decision Analytics",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MIIM20002",
-    "name": "Microbes, Infections and Responses",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MIIM30003",
-    "name": "Medical and Applied Immunology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MIIM30014",
-    "name": "Medical Microbiology: Virology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MIIM30015",
-    "name": "Techniques in Immunology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MIIM30017",
-    "name": "Medical Microbiology: Parasitology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MIIM40006",
-    "name": "Micro & Immuno Research Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MKTG10001",
-    "name": "Principles of Marketing",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MKTG20004",
-    "name": "Market and Business Research",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG20007",
-    "name": "Entrepreneurship and Product Innovation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG30009",
-    "name": "Digital Marketing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG30010",
-    "name": "Advertising and Promotions",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG30013",
-    "name": "Strategic Marketing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG90003",
-    "name": "Public Relations",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG90004",
-    "name": "Marketing Management",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MKTG90005",
-    "name": "Marketing Strategy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MKTG90008",
-    "name": "Consumers and Consumption",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MKTG90009",
-    "name": "Advertising and Communications Strategy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG90011",
-    "name": "Marketing Research",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MKTG90017",
-    "name": "Digital Business and Marketing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG90022",
-    "name": "Commercialisation of Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG90023",
-    "name": "Advanced Consumer Behaviour",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG90026",
-    "name": "Marketing Metrics",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MKTG90032",
-    "name": "Applied Syndicate Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MKTG90037",
-    "name": "Managing for Value Creation",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MKTG90042",
-    "name": "Social Media and Viral Marketing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG90048",
-    "name": "B2B Marketing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MKTG90049",
-    "name": "Marketing, Society and Sustainability",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MREN90004",
-    "name": "Ceramics and Brittle Materials",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MREN90005",
-    "name": "Materials Engineering Research Project",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT10001",
-    "name": "First Peoples in a Global Context",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MULT10017",
-    "name": "Representation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MULT20010",
-    "name": "Arts Internship",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT20011",
-    "name": "Science Communication and Employability",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MULT20012",
-    "name": "Arts Internship: Not for Profit",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT20015",
-    "name": "Elements of Quantum Computing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MULT30015",
-    "name": "Independent Research Project",
-    "offered": ["summer_term", "semester_1", "winter_term", "semester_2"]
-  },
-  {
-    "code": "MULT30017",
-    "name": "Australian Indigenous Public Policy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MULT30018",
-    "name": "Applied Research Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MULT30019",
-    "name": "Arts Internship",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT30020",
-    "name": "Arts Internship: Not for Profit",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT30022",
-    "name": "Indigenous Engineering and Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MULT40007",
-    "name": "Special Research Topics",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT90002",
-    "name": "Supervised Reading (Asia Institute)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT90005",
-    "name": "Interdisciplinarity and the Environment",
-    "offered": ["march", "semester_2"]
-  },
-  {
-    "code": "MULT90018",
-    "name": "Internship I (Placement Only)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT90019",
-    "name": "Internship II (Semester Long)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT90054",
-    "name": "Quantitative Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MULT90059",
-    "name": "Social Enterprise Incubator",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT90061",
-    "name": "Internship II (Year Long) Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT90062",
-    "name": "Internship II (Year Long) Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MULT90064",
-    "name": "Industry Core and Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI10004",
-    "name": "Computing for Musicians",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10023",
-    "name": "Music Language 1: the Diatonic World",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "MUSI10042",
-    "name": "Baroque Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10053",
-    "name": "Brass Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10057",
-    "name": "Early Voices 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10059",
-    "name": "Conservatorium Choir 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10061",
-    "name": "Symphonic Ensembles 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10067",
-    "name": "Guitar Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10069",
-    "name": "String Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10093",
-    "name": "Vocal Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10162",
-    "name": "Choir 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10174",
-    "name": "Guitar Group 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10179",
-    "name": "Making Music For Film And Animation 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10184",
-    "name": "Pop Song Writing 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI10192",
-    "name": "Ensemble Studies 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI10193",
-    "name": "Contextual Studies 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10194",
-    "name": "Interactive Composition 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10196",
-    "name": "Music Making Laboratory 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10197",
-    "name": "Individual Performance Studies 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI10206",
-    "name": "Medieval and Renaissance Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10220",
-    "name": "Practical Music 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI10221",
-    "name": "Practical Music 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI10222",
-    "name": "The Wellbeing Orchestra",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10223",
-    "name": "Sound in Performance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10226",
-    "name": "Chamber Choir 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10227",
-    "name": "Musics of the World",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI10228",
-    "name": "Sound Studies 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20013",
-    "name": "Chamber Music 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20014",
-    "name": "Chamber Music 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20025",
-    "name": "Minor Music Performance 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20026",
-    "name": "Minor Music Performance 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20055",
-    "name": "Composition 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20056",
-    "name": "Composition 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20061",
-    "name": "Music Language 2: Chromaticism & Beyond",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "MUSI20070",
-    "name": "Baroque Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20072",
-    "name": "Big Band 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20074",
-    "name": "Brass Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20081",
-    "name": "Early Voices 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20083",
-    "name": "Conservatorium Choir 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20087",
-    "name": "MCM Indonesian Gamelan Ensemble 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20088",
-    "name": "MCM Indonesian Gamelan Ensemble 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20090",
-    "name": "Guitar Ensemble 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20092",
-    "name": "String Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20094",
-    "name": "Symphonic Ensembles 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20104",
-    "name": "Shakuhachi 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20105",
-    "name": "Shakuhachi 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20108",
-    "name": "MCM Chinese Music Ensemble",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20113",
-    "name": "Vocal Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20123",
-    "name": "University Symphonic Ensembles 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20132",
-    "name": "Melbourne Big Band 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20135",
-    "name": "Chinese Music Ensemble 1",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20138",
-    "name": "Indonesian Gamelan Ensemble",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20143",
-    "name": "World Music Choir",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20150",
-    "name": "Music and Health",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20163",
-    "name": "Samba Band",
-    "offered": ["february", "semester_1", "june", "semester_2"]
-  },
-  {
-    "code": "MUSI20164",
-    "name": "Free Play New Music Improvisation Ensem",
-    "offered": ["february", "semester_1", "june", "semester_2"]
-  },
-  {
-    "code": "MUSI20174",
-    "name": "The Laptop Recording Studio",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20175",
-    "name": "Individual Performance Studies 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20176",
-    "name": "Ensemble Studies 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20178",
-    "name": "Individual Performance Studies 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20179",
-    "name": "Ensemble Studies 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20180",
-    "name": "Contextual Studies 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20183",
-    "name": "Interactive Composition 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20184",
-    "name": "Music Making Laboratory 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20190",
-    "name": "Advanced Recording Studio Techniques",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20196",
-    "name": "Riffs: Guitar Cultures & Practice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20199",
-    "name": "Practical Music 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20200",
-    "name": "Practical Music 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20201",
-    "name": "Performance 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20202",
-    "name": "Performance 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20203",
-    "name": "Peak Performance Under Pressure",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20206",
-    "name": "The Business of Music",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20207",
-    "name": "Applied Aural Musicianship 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20208",
-    "name": "Electronic Dance Music Technique",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20209",
-    "name": "Chinese Music Ensemble 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20210",
-    "name": "Saxophone Ensemble",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI20212",
-    "name": "Practical Anatomy for Classical Voice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20214",
-    "name": "Chamber Choir 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20216",
-    "name": "Medieval and Renaissance Ensemble 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20221",
-    "name": "Sound Studies 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20222",
-    "name": "Creativity, Genius, Expertise and Talent",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20224",
-    "name": "Music and Gender",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI20225",
-    "name": "Music, Mind & Wellbeing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30019",
-    "name": "Chamber Music 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30020",
-    "name": "Chamber Music 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30046",
-    "name": "Music Language 3: Modern Directions",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "MUSI30050",
-    "name": "Minor Music Performance 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30051",
-    "name": "Minor Music Performance 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30116",
-    "name": "Historical Performance Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30139",
-    "name": "Shakuhachi Ensemble 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30160",
-    "name": "Acting for Singers 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30164",
-    "name": "Baroque Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30166",
-    "name": "Big Band 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30168",
-    "name": "Brass Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30173",
-    "name": "Early Voices 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30175",
-    "name": "Conservatorium Choir 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30182",
-    "name": "Guitar Ensemble 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30184",
-    "name": "String Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30186",
-    "name": "Symphonic Ensembles 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30207",
-    "name": "Vocal Ensemble 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30213",
-    "name": "Composition 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30214",
-    "name": "Composition 4",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30224",
-    "name": "Contextual Studies 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30225",
-    "name": "Ensemble Studies 5",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30226",
-    "name": "Ensemble Studies 6",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30227",
-    "name": "Individual Performance Studies 5",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30228",
-    "name": "Individual Performance Studies 6",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30230",
-    "name": "Interactive Composition 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30232",
-    "name": "Music Making Laboratory 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30250",
-    "name": "Practical Music 5",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30251",
-    "name": "Practical Music 6",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30252",
-    "name": "Performance 5",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30253",
-    "name": "Performance 6",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI30255",
-    "name": "Applied Aural Musicianship 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30258",
-    "name": "Chamber Choir 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30261",
-    "name": "Medieval and Renaissance Ensemble 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30262",
-    "name": "French Lyric Diction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30263",
-    "name": "Jazz & Improv Composition Workshop",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30268",
-    "name": "Interpretation Italian Lyric Repertoire",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI30270",
-    "name": "Topics in Musicology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI40012",
-    "name": "GradDip Composition 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40013",
-    "name": "GradDip Composition 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40016",
-    "name": "Practical Study 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40017",
-    "name": "Practical Study 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40028",
-    "name": "Music and Gender",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI40032",
-    "name": "Historical Performance Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI40056",
-    "name": "Special Study",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40060",
-    "name": "Concerto",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40061",
-    "name": "Recital",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40062",
-    "name": "Honours Chamber Music 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40063",
-    "name": "Honours Ensemble 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40064",
-    "name": "The Research Process for Musicians",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40067",
-    "name": "Honours Composition 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40068",
-    "name": "Honours Composition 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40074",
-    "name": "Music and Health",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI40076",
-    "name": "Musics of the World",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI40080",
-    "name": "Honours Ensemble 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40081",
-    "name": "Honours Chamber Music 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40084",
-    "name": "Research Paper",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI40088",
-    "name": "Integrated Musical Practice 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40089",
-    "name": "Integrated Musical Practice 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40091",
-    "name": "Music Internship",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI40101",
-    "name": "Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40102",
-    "name": "Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40104",
-    "name": "Dissertation Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40105",
-    "name": "Dissertation Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40106",
-    "name": "Research Paper (Jazz & Improvisation)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI40107",
-    "name": "Capstone Music Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40108",
-    "name": "Capstone Music Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40110",
-    "name": "Honours Music Studies 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI40111",
-    "name": "Honours Music Studies 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90033",
-    "name": "Music Therapy Methods 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90035",
-    "name": "Music Therapy Methods 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90037",
-    "name": "Research in Music Therapy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90039",
-    "name": "Clinical Training in Music Therapy 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90042",
-    "name": "Applications of Music in Therapy B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90045",
-    "name": "Interpretivist Research in Music Therapy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90093",
-    "name": "Ensemble A",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90094",
-    "name": "Ensemble B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90100",
-    "name": "Recital 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90144",
-    "name": "The Teacher as Conductor",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90147",
-    "name": "Performing to Teach 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90148",
-    "name": "Ensemble",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90149",
-    "name": "Applied Instrumental and Vocal Teaching",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90150",
-    "name": "Music Learning, Teaching and Research",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90151",
-    "name": "Music Performance Curriculum& Assessment",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90152",
-    "name": "Second Instrument / Vocal Study 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90153",
-    "name": "Professional Practice 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90154",
-    "name": "Professional Practice 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90155",
-    "name": "Second Instrument / Vocal Study 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90156",
-    "name": "Performing to Teach 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90157",
-    "name": "Pedagogue Recital",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90183",
-    "name": "Acting for Opera Performance 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90187",
-    "name": "Clinical Training in Music Therapy 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90188",
-    "name": "Music and Health Research",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90191",
-    "name": "The Research Process For Musicians (RHD)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90192",
-    "name": "Studio Teaching 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90193",
-    "name": "Studio Teaching 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90194",
-    "name": "Instrumental Pedagogy",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90195",
-    "name": "Professional Practice 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90197",
-    "name": "Professional Research Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90198",
-    "name": "Professional Research Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90199",
-    "name": "Suzuki Practicum Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90200",
-    "name": "Suzuki Practicum Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90226",
-    "name": "Orchestral Experience 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90227",
-    "name": "Orchestral Performance Practicum 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90228",
-    "name": "Advanced Orchestra Audition Prep",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90229",
-    "name": "Orchestral Performance Practicum 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUSI90233",
-    "name": "Core Skills in Opera 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90235",
-    "name": "Practice-Led Music Research Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90238",
-    "name": "Music, Learning & Technology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUSI90241",
-    "name": "Theories of Inclusive Music Teaching",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUST10015",
-    "name": "Music Theatre Contextual Studies 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUST10016",
-    "name": "Music Theatre Studio 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUST10017",
-    "name": "The Art of Working Online",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUST20010",
-    "name": "Singing and the Power of Pop Music",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "MUST20014",
-    "name": "Music Theatre Combination Skills 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUST20015",
-    "name": "Music Theatre Studio 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUST30016",
-    "name": "Music Theatre Industry Skills",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUST30017",
-    "name": "Music Theatre Studio 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "MUST30018",
-    "name": "Production Studio 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NEUR30004",
-    "name": "Complex Functions in Neuroscience",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NEUR30005",
-    "name": "Developmental Neurobiology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NEUR30006",
-    "name": "Real and Artificial Neural Networks",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NEUR30007",
-    "name": "Auditory Neuroscience",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NEUR90015",
-    "name": "Project in Neuroscience",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "NEUR90016",
-    "name": "Project in Neuroscience",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "NEUR90017",
-    "name": "Project in Neuroscience",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "NEUR90018",
-    "name": "Project in Neuroscience",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "NRMT90002",
-    "name": "Biosecurity: Managing Invasive Species",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NRMT90007",
-    "name": "Communities and Ecosystem Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90002",
-    "name": "Independent Study",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "NURS90026",
-    "name": "Independent Study Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "NURS90055",
-    "name": "Nursing as Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90057",
-    "name": "Contemporary Nursing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90071",
-    "name": "Quality Use of Medicines",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90072",
-    "name": "Advanced Nursing Practice in Context",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90075",
-    "name": "Applications of Clinical Pharmacology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90087",
-    "name": "Paediatric Intensive Care Nursing 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90088",
-    "name": "Paediatric Nursing 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90089",
-    "name": "Rural Critical Care Nursing 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90090",
-    "name": "Cancer and Palliative Care Nursing 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90094",
-    "name": "Neonatal Intensive Care Nursing 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90104",
-    "name": "Chronic Disease Management: Foundations",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "NURS90105",
-    "name": "Chronic Disease Management: In Practice",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "NURS90106",
-    "name": "Advanced Nursing Practice: Primary Care",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "NURS90125",
-    "name": "Nursing Science 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90131",
-    "name": "Clients with Acute and Chronic Illness",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NURS90132",
-    "name": "Transitioning to Advanced Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NUTR20001",
-    "name": "Food Nutrition and Health",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NUTR30003",
-    "name": "Lifestage Nutrition",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NUTR30004",
-    "name": "Advanced Topics in Nutrition",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "NUTR40002",
-    "name": "Human Nutrition Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "OPTO30007",
-    "name": "Visual Neuroscience",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "OPTO40013",
-    "name": "Vision Science Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "OPTO90006",
-    "name": "Anterior Eye Disease and Dry Eye",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "OPTO90015",
-    "name": "Management of Neuro-ophthalmic Disorders",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "OPTO90017",
-    "name": "Graduate Seminar in Vision Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "OPTO90019",
-    "name": "Project in Vision Science",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "OPTO90020",
-    "name": "Project in Vision Science",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "OPTO90021",
-    "name": "Project in Vision Science",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "OPTO90022",
-    "name": "Project in Vision Science",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "OPTO90031",
-    "name": "Research Studies in Optometry",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ORAL10002",
-    "name": "Society and Health 1B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ORAL10004",
-    "name": "Oral Health Sciences 1B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ORAL20002",
-    "name": "Health Promotion 2B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ORAL20004",
-    "name": "Oral Health Sciences 2B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ORAL40001",
-    "name": "Oral Health Research Project 4A",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "ORAL40002",
-    "name": "Oral Health Research Project 4B",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "OTOL40003",
-    "name": "Otolaryngology Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PADM90004",
-    "name": "Public Administration Thesis",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PAED40005",
-    "name": "Paediatrics Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PAED90026",
-    "name": "Cancer Care in Young People",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PATH20003",
-    "name": "Experimental Pathology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PATH30003",
-    "name": "Frontiers in Human Disease",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PATH30004",
-    "name": "Advanced Investigation of Human Disease",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PATH40001",
-    "name": "Pathology Research Project Part 1",
-    "offered": ["semester_1", "june", "semester_2"]
-  },
-  {
-    "code": "PATH40006",
-    "name": "Clinical Path Research Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHIL10003",
-    "name": "Philosophy: The Great Thinkers",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL10004",
-    "name": "Knowledge Practices 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL20008",
-    "name": "Ethical Theory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL20030",
-    "name": "Logical Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL20040",
-    "name": "Greek Philosophy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL20041",
-    "name": "Phenomenology and Existentialism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL20044",
-    "name": "The Ethics of Capitalism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL30007",
-    "name": "The Philosophy of Philosophy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL30016",
-    "name": "Knowledge and Reality",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL30052",
-    "name": "Race and Gender: Philosophical Issues",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL30054",
-    "name": "The Metaphysics of Ethics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL40005",
-    "name": "Topics in Metaphysics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL40013",
-    "name": "Topics in the Philosophy of Language",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL40018",
-    "name": "Topics in Contemporary Epistemology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHIL40021",
-    "name": "Philosophy Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHIL40022",
-    "name": "Philosophy Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHIL90042",
-    "name": "Time",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHRM20001",
-    "name": "Pharmacology: How Drugs Work",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHRM30002",
-    "name": "Drugs Affecting the Nervous System",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHRM30008",
-    "name": "Drugs: From Discovery to Market",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHRM30009",
-    "name": "Drugs in Biomedical Experiments",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHRM40006",
-    "name": "Pharmacology Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHTY90040",
-    "name": "Physiotherapy Professional Portfolio",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYC10002",
-    "name": "Physics 2: Advanced",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC10003",
-    "name": "Physics 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYC10004",
-    "name": "Physics 2: Physical Science & Technology",
-    "offered": ["summer_term", "semester_2"]
-  },
-  {
-    "code": "PHYC10006",
-    "name": "Physics 2: Life Sciences & Environment",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC10007",
-    "name": "Physics for Biomedicine",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYC10008",
-    "name": "From the Solar System to the Cosmos",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC20013",
-    "name": "Laboratory and Computational Physics 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYC20014",
-    "name": "Theoretical Physics 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC20015",
-    "name": "Special Relativity and Electromagnetism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC30011",
-    "name": "Sub-atomic Physics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC30017",
-    "name": "Statistical Physics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC30021",
-    "name": "Laboratory and Computational Physics 3",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYC30022",
-    "name": "Theoretical Physics 3",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC30024",
-    "name": "Condensed Matter Physics 3",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC90011",
-    "name": "Particle Physics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC90012",
-    "name": "General Relativity",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC90013",
-    "name": "Condensed Matter Physics 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYC90021",
-    "name": "Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYC90022",
-    "name": "Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYC90023",
-    "name": "Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYC90024",
-    "name": "Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYS20008",
-    "name": "Human Physiology",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYS20009",
-    "name": "Research-Based Physiology",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PHYS30011",
-    "name": "Clinical and Translational Physiology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYS30012",
-    "name": "Physiology: Adapting to Challenges",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PHYS40006",
-    "name": "Physiology Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PLAN10002",
-    "name": "Introduction to Urban Planning",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PLAN20002",
-    "name": "Urban Design for People and Places",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PLAN30005",
-    "name": "Urban Precinct Studio",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PLAN90001",
-    "name": "Urban Demography and Statistics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS10003",
-    "name": "Introduction to Political Ideas",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS20006",
-    "name": "Contemporary Political Theory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS20008",
-    "name": "Public Policy Making",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS20025",
-    "name": "International Relations: Key Questions",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS20026",
-    "name": "Politics and the Media",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS30003",
-    "name": "Public Affairs Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POLS30018",
-    "name": "European Integration: Politics of the EU",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS30022",
-    "name": "Global Environmental Politics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS30030",
-    "name": "American Politics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS40022",
-    "name": "Politics & International Thesis Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS40025",
-    "name": "Key Debates in Political Science 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS90009",
-    "name": "International Relations Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POLS90012",
-    "name": "Trade Policy Politics & Governance",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS90016",
-    "name": "The United Nations: Review and Reform",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS90028",
-    "name": "International Relations Theory",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS90034",
-    "name": "International Policymaking in Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS90035",
-    "name": "Great Power Politics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POLS90054",
-    "name": "International Relations Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POLS90055",
-    "name": "International Relations Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POLS90063",
-    "name": "Indigenous Peoples in Global Context",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH40006",
-    "name": "Population Health Research Project 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90068",
-    "name": "Prevention and Control of STIs and HIV",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90069",
-    "name": "Sexual and Reproductive Health",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90090",
-    "name": "Health Program Evaluation 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90093",
-    "name": "Economic Evaluation 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90111",
-    "name": "Genetic Epidemiology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90119",
-    "name": "Design of Randomised Controlled Trials",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90124",
-    "name": "Statistical Genomics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90148",
-    "name": "Probability and Distribution Theory",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90149",
-    "name": "Biostatistics Research Project - S",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90151",
-    "name": "Biostatistics Research Project - D",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90170",
-    "name": "Adolescent Health Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90171",
-    "name": "Drug Issues",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90172",
-    "name": "SocioEnvironmentalContext of Adolescents",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90173",
-    "name": "Health Promotion and Young People",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90205",
-    "name": "Health Inequalities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90229",
-    "name": "Health Economics 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90231",
-    "name": "Qualitative Research in Public Health",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90239",
-    "name": "Professional Practice - S",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90255",
-    "name": "Research Project in Public Health - S",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90271",
-    "name": "Infectious Diseases Modelling",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90275",
-    "name": "Population & Global Mental Health",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90276",
-    "name": "M.Epidemiology Research Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90277",
-    "name": "M.Epidemiology Research Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90284",
-    "name": "Research Project in Public Health Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90285",
-    "name": "Research Project in Public Health Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90286",
-    "name": "Professional Practice - Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90287",
-    "name": "Professional Practice - Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90288",
-    "name": "Biostatistics Research Project Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90289",
-    "name": "Biostatistics Research Project Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90291",
-    "name": "Indigenous Health in a Global Context",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90292",
-    "name": "M.Epidemiology Research Project - S",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "POPH90294",
-    "name": "Consumer Participatory Health Technology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "POPH90296",
-    "name": "Indigenous Health & History Insights",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PPMN20003",
-    "name": "Political Leadership",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PPMN40006",
-    "name": "Public Policy & Management Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PPMN40007",
-    "name": "Public Policy & Management Thesis Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PPMN90030",
-    "name": "Public Policy in the Asian Century",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PPMN90033",
-    "name": "Public Budgets and Financial Management",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PPMN90039",
-    "name": "Executive Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PPMN90049",
-    "name": "Public /Social Policy Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PPMN90050",
-    "name": "Public /Social Policy Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PROP10001",
-    "name": "Economics and Cities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PROP20003",
-    "name": "Design and Property Industry Studies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PROP30002",
-    "name": "Sustainable Management of Design Assets",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PROP30003",
-    "name": "Design and Property Studio",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC10004",
-    "name": "Mind, Brain and Behaviour 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC20007",
-    "name": "Cognitive Psychology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC20009",
-    "name": "Personality and Social Psychology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC30016",
-    "name": "Lifespan Social & Emotional Development",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC30019",
-    "name": "Development of the Thinking Child",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC30020",
-    "name": "The Integrated Brain",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC30021",
-    "name": "Psychological Science: Theory & Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC30022",
-    "name": "Trends in Personality& Social Psychology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC30023",
-    "name": "Computational Behavioural Science",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC30024",
-    "name": "Behaviour Change and Well-being",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC40001",
-    "name": "Current Topics in Developmental Psych.",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC40012",
-    "name": "Models of Psychological Processes",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC40013",
-    "name": "Advanced Psychological Theory & Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90005",
-    "name": "Thesis (Masters/coursework)",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PSYC90009",
-    "name": "Individual and Cultural Diversity",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90015",
-    "name": "Advanced Psychopathology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90016",
-    "name": "Biological Psychology & Pharmacotherapy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90017",
-    "name": "Advanced Psychological Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90029",
-    "name": "Graduate Research Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90033",
-    "name": "Neuropsychological Rehabilitation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90042",
-    "name": "Child Neuropsychological Disorders",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90062",
-    "name": "Mental Health and Young People",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90082",
-    "name": "Clinical Skills in Neuropsychology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90083",
-    "name": "Cognitive Neuroscience and Disorders",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90096",
-    "name": "Thesis (Masters/coursework) Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90100",
-    "name": "Applied Research Methods",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90102",
-    "name": "Attitude and Behaviour Change",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYC90106",
-    "name": "Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PSYC90107",
-    "name": "Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PSYC90113",
-    "name": "Professional Psychology Skills 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYT90039",
-    "name": "Foundations of Parent and Liaison Work",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYT90041",
-    "name": "Clinical Practicum: Parent&Liaison Work",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYT90087",
-    "name": "Mental Health Science Research Project 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYT90107",
-    "name": "Reflective Youth Mental Health Practice",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PSYT90109",
-    "name": "Youth Mental Health Research Project 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PUBL90001",
-    "name": "Structural Editing",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PUBL90002",
-    "name": "Editorial English",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PUBL90005",
-    "name": "Technical Writing and Editing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PUBL90006",
-    "name": "Writing and Editing for Digital Media",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PUBL90015",
-    "name": "Grattan Street Press",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PUBL90019",
-    "name": "Book Markets: Structures and Strategies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PUBL90020",
-    "name": "Advanced Book Publishing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PUBL90021",
-    "name": "Editing Masterclass",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "PUBL90022",
-    "name": "Publishing and Communications Thesis Pt1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "PUBL90023",
-    "name": "Publishing and Communications Thesis Pt2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "RADI90012",
-    "name": "Radiology Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RADI90016",
-    "name": "Minor Thesis (Radiology) Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RADI90018",
-    "name": "Diagnostic Radiology 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RADI90020",
-    "name": "Diagnostic Radiology 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RADI90023",
-    "name": "Diagnostic Radiology Minor Thesis 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RURA90009",
-    "name": "Health Projects in Aboriginal Settings",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RUSS10002",
-    "name": "Russian 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RUSS20005",
-    "name": "Russian 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RUSS20007",
-    "name": "Russian 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RUSS30002",
-    "name": "Russian 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RUSS30005",
-    "name": "Russian Culture Through Film",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RUSS40007",
-    "name": "Russian Language & Culture 4B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "RUSS40009",
-    "name": "Russian Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "RUSS40010",
-    "name": "Russian Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SCIE10002",
-    "name": "Science: Systems, Technology and Design",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCIE10004",
-    "name": "Human Sciences: From Cells to Societies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCIE20001",
-    "name": "Thinking Scientifically",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCIE30001",
-    "name": "Science Research Project",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "SCIE30002",
-    "name": "Science and Technology Internship",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "SCIE30003",
-    "name": "Science Research Project Abroad",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "SCIE90002",
-    "name": "Metabolomics and Proteomics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCIE90006",
-    "name": "Scientists,Communication & the Workplace",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCIE90012",
-    "name": "Science Communication",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCIE90013",
-    "name": "Communication for Research Scientists",
-    "offered": ["semester_1", "winter_term", "semester_2"]
-  },
-  {
-    "code": "SCIE90014",
-    "name": "Renewable Energy",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCIE90017",
-    "name": "Science and Technology Internship",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "SCIE90018",
-    "name": "Science Research Internship",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "SCIE90026",
-    "name": "Biomolecular Structure Determination",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCIE90027",
-    "name": "Ecosystem Internship",
-    "offered": ["summer_term", "semester_1", "semester_2"]
-  },
-  {
-    "code": "SCRN20013",
-    "name": "Australian Film and Television",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCRN20014",
-    "name": "Ensemble Filmmaking, Art and Industry",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCRN30001",
-    "name": "Art Cinema and the Love Story",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCRN30004",
-    "name": "Film Noir: History and Sexuality",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCRN40009",
-    "name": "Screen Media and Political Aesthetics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCRN40013",
-    "name": "Censorship: Film, Art and Media",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SCRN40017",
-    "name": "Screen & Cultural Studies Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SCRN40018",
-    "name": "Screen & Cultural Studies Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SCRN90002",
-    "name": "Film Production: From Script to Screen",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SKIL10007",
-    "name": "Foundation Communication Skills",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOCI10003",
-    "name": "Inequalities: Challenges for the Future",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOCI20014",
-    "name": "Sociology of Youth",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOCI20016",
-    "name": "Sociology of Culture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOCI20018",
-    "name": "Families, Relationships and Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOCI20019",
-    "name": "Talking with People: Doing Interviews",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOCI30005",
-    "name": "Sociology Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SOCI30014",
-    "name": "Sociology of 'Race' and Ethnicities",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOCI40003",
-    "name": "Understanding The Life Course",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOCI40006",
-    "name": "Sociology Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SOCI40007",
-    "name": "Sociology Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SOCI90005",
-    "name": "Social Research Design and Evaluation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOCI90013",
-    "name": "Social Policy Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SOCI90018",
-    "name": "Indigenous Policy Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOCI90023",
-    "name": "Project-based Policy Analysis",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SOLS40002",
-    "name": "Socio-Legal Studies Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SOLS40003",
-    "name": "Socio-Legal Studies Thesis Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SPAN10002",
-    "name": "Spanish 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SPAN10004",
-    "name": "Spanish 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SPAN10008",
-    "name": "Spanish 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SPAN20001",
-    "name": "Hispanic Cultural Studies",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SPAN20003",
-    "name": "Spanish 4",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SPAN20019",
-    "name": "Spanish 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SPAN30001",
-    "name": "Gender in Hispanic Cultures",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SPAN30015",
-    "name": "Spanish 6",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SPAN40002",
-    "name": "Spanish Honours Language Seminar 1",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SPAN40007",
-    "name": "Spanish & Latin American Thesis Part 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SPAN40008",
-    "name": "Spanish & Latin American Thesis Part 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SPAN90004",
-    "name": "Graduate Spanish B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SURG40001",
-    "name": "Surgery Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SURG90024",
-    "name": "Fundamentals of Surgery II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SURG90027",
-    "name": "Surgical Research II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SURG90028",
-    "name": "Basic Surgical Skills I",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SURG90029",
-    "name": "Basic Surgical Skills II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SURG90030",
-    "name": "Surgery, Society and Professionalism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SWEN20003",
-    "name": "Object Oriented Software Development",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SWEN30006",
-    "name": "Software Modelling and Design",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "SWEN90006",
-    "name": "Security & Software Testing",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SWEN90007",
-    "name": "Software Design and Architecture",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SWEN90014",
-    "name": "Masters Software Engineering Project",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "SWEN90016",
-    "name": "Software Processes and Management",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "THTR10019",
-    "name": "Clear Speech and Communication",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "THTR40007",
-    "name": "Research Paper (Music Theatre)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "THTR40010",
-    "name": "Research Paper (Production)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "THTR70010",
-    "name": "Writing for Performance 3 (Portfolio)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "THTR90007",
-    "name": "Applied Project B (Design)",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "THTR90009",
-    "name": "Performance and Community Engagement",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "TRAN90003",
-    "name": "Specialised Translation",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "TRAN90007",
-    "name": "Translating From English to Chinese",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "TRAN90009",
-    "name": "Translating from Chinese to English",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "TRAN90010",
-    "name": "Translation Internship",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "TRAN90011",
-    "name": "Translation and Interpreting as Process",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "TRAN90012",
-    "name": "Translation and Interpreting Thesis 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "TRAN90013",
-    "name": "Translation and Interpreting Thesis 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "TRAN90021",
-    "name": "Translation, Interpreting, Communication",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "TRAN90022",
-    "name": "Translation Industry Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "UNIB10005",
-    "name": "Being Online: Internet Meets Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB10007",
-    "name": "Introduction to Climate Change",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB10010",
-    "name": "Generating the Wealth of Nations",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB10011",
-    "name": "The Secret Life of the Body 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "UNIB10013",
-    "name": "Catastrophes as Turning Points",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB10014",
-    "name": "Philosophy, Politics and Economics",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB10017",
-    "name": "Our Planet, Our Health",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB10018",
-    "name": "Insects Shaping Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB10019",
-    "name": "Thinking Tools for Wicked Problems",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB10020",
-    "name": "Refugees, Borders, Nationalism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB10022",
-    "name": "Entrepreneurship Principles and Tools",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "UNIB10023",
-    "name": "The Making of Melbourne",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "UNIB20008",
-    "name": "Drugs That Shape Society",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB20014",
-    "name": "Food For a Healthy Planet II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB20018",
-    "name": "Going Places - Travelling Smarter",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "UNIB20020",
-    "name": "Our Planet, Our Health II",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB20021",
-    "name": "Inequalities: Causes and Consequences",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "UNIB20022",
-    "name": "Indigenous Cultures and Knowledges",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS30014",
-    "name": "Veterinary Bioscience: Cardiovasc System",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS30017",
-    "name": "Veterinary Bioscience: Metabolism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS30018",
-    "name": "Veterinary Bioscience:Respiratory System",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS30032",
-    "name": "Animal Production Systems 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS30033",
-    "name": "Health & Disease in Wildlife Populations",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS40017",
-    "name": "Veterinary Clinical Skills",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS40021",
-    "name": "Vet Bioscience Research Project Part 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS70001",
-    "name": "MVSc (Clinical) Practicum # FT",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS70002",
-    "name": "MVSc (Clinical) Practicum # PT",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90029",
-    "name": "Vet Public Health Research Project",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90036",
-    "name": "Cardiovascular & Respiratory Emergencies",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90037",
-    "name": "Abdominal & Urogenital Emergencies",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90038",
-    "name": "Haemato, Neurologic & Global Conditions",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90039",
-    "name": "CPR, Eye Emergencies & Practical ECC",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90040",
-    "name": "General Principles and FAST Techniques",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90041",
-    "name": "Urinary Reproductive Tracts Lymph Nodes",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90042",
-    "name": "Liver, Spleen and Sampling",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90043",
-    "name": "Gastrointestinal Tract Pancreas Adrenals",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90044",
-    "name": "Vet Public Health Research Project Pt 1",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90045",
-    "name": "Vet Public Health Research Project Pt 2",
-    "offered": ["semester_1", "semester_2"]
-  },
-  {
-    "code": "VETS90059",
-    "name": "Veterinary Bioscience 1B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90061",
-    "name": "Applications in Animal Health B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90065",
-    "name": "Veterinary Bioscience 2 Part B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90067",
-    "name": "Infections Population & Pub. Health PtB",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90069",
-    "name": "Applications in Animal Health 2 Part B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90098",
-    "name": "Production, Herd and Public Health B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90100",
-    "name": "Infections and Immunity B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90101",
-    "name": "Veterinary Bioscience 2B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90116",
-    "name": "Veterinary Bioscience 1B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90118",
-    "name": "Applications in Animal Health B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90124",
-    "name": "Vet Bioscience: Cardiovascular System",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90125",
-    "name": "Vet Bioscience: Metabolism",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90126",
-    "name": "Vet Bioscience: Respiratory System",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90127",
-    "name": "Animal Production Systems: Intensive",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90134",
-    "name": "Vet Bioscience: Nervous System",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90135",
-    "name": "Vet Bioscience: Reproduction",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90136",
-    "name": "Veterinary Public Health",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90137",
-    "name": "Veterinary Bacteriology and Mycology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90138",
-    "name": "Veterinary Parasitology B",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90139",
-    "name": "Veterinary Professional Practice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VETS90140",
-    "name": "Animal Production Systems: Applications",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "VISM40009",
-    "name": "Visual Media: Experimental Projects",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "WELF90005",
-    "name": "Principles of Counselling 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "WELF90007",
-    "name": "Fitness to Practice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "WELF90008",
-    "name": "Genetic Counselling Practice 2",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ZOOL20006",
-    "name": "Comparative Animal Physiology",
-    "offered": ["semester_2"]
-  },
-  {
-    "code": "ZOOL30009",
-    "name": "Tropical Field Ecology",
-    "offered": ["semester_2"]
-  }
+ {
+  "code": "MUSI30224",
+  "name": "Contextual Studies 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90148",
+  "name": "Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90024",
+  "name": "Industry Core and Placement",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90067",
+  "name": "Infections Population & Pub. Health PtB",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10220",
+  "name": "Practical Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90273",
+  "name": "Urban Design Studio B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90033",
+  "name": "Geography Minor Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90020",
+  "name": "Spatial Information Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90063",
+  "name": "Indigenous Peoples in Global Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90022",
+  "name": "Chemical Engineering Design Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40061",
+  "name": "Recital",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "WELF90007",
+  "name": "Fitness to Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NUTR40002",
+  "name": "Human Nutrition Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20180",
+  "name": "Contextual Studies 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90186",
+  "name": "Advanced Trusts Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90015",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC40008",
+  "name": "Arabic Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90106",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90069",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90289",
+  "name": "Biostatistics Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "IBUS90001",
+  "name": "Global Strategy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYT90107",
+  "name": "Reflective Youth Mental Health Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90010",
+  "name": "Minerals, Materials and Recycling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50039",
+  "name": "Legal Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACUR90006",
+  "name": "Exhibition Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30116",
+  "name": "Historical Performance Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90047",
+  "name": "Audiology in Professional Contexts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90058",
+  "name": "Signal Processing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "THTR70010",
+  "name": "Writing for Performance 3 (Portfolio)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90009",
+  "name": "Individual and Cultural Diversity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90025",
+  "name": "East Timor Field Class",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90152",
+  "name": "Bower Studio - Community Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30186",
+  "name": "Symphonic Ensembles 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90002",
+  "name": "Editorial English",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30250",
+  "name": "Practical Music 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90031",
+  "name": "Advanced Linguistics Analysis A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90030",
+  "name": "Criminology & Sociology Internship Pt 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90038",
+  "name": "IS Strategy and Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL10002",
+  "name": "Society and Health 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90197",
+  "name": "Professional Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20183",
+  "name": "Interactive Composition 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE10002",
+  "name": "Science: Systems, Technology and Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90146",
+  "name": "Strategic Management",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90902",
+  "name": "Diverse and Inclusive Classrooms (Sec)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90007",
+  "name": "Environmental Research Project (25)",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90026",
+  "name": "Marketing Metrics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10020",
+  "name": "Animation Lab 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10015",
+  "name": "Screenwriting Practices 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30048",
+  "name": "Architecture Design Studio: Air",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40074",
+  "name": "Music and Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90062",
+  "name": "Behavioural Economics:Accounting&Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ERTH90026",
+  "name": "Climate Modelling and Climate Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40064",
+  "name": "The Research Process for Musicians",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90375",
+  "name": "Landscape Architecture Design Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90012",
+  "name": "Research Design 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90082",
+  "name": "Major Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90195",
+  "name": "Advanced Management Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90187",
+  "name": "Clinical Training in Music Therapy 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PAED90026",
+  "name": "Cancer Care in Young People",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90012",
+  "name": "Agribusiness Management Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND90007",
+  "name": "Rethinking Rights and Global Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90136",
+  "name": "Criminal Institutions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90296",
+  "name": "Indigenous Health & History Insights",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90002",
+  "name": "Social Impact Assessment and Evaluation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90050",
+  "name": "Public /Social Policy Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70024",
+  "name": "Corporate Tax A",
+  "offered": [
+   "april",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90027",
+  "name": "Life Cycle Analysis and Sustainability",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90023",
+  "name": "Practical Earth Science B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90105",
+  "name": "Chronic Disease Management: In Practice",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90002",
+  "name": "Mathematics of Finance II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90101",
+  "name": "Obstetrics Gynaecology and Practicum",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI90018",
+  "name": "Advanced Writing Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE90026",
+  "name": "Biomolecular Structure Determination",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90001",
+  "name": "Principles of Arts Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40067",
+  "name": "Honours Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90014",
+  "name": "Advanced Econometric Techniques 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90100",
+  "name": "Abdominal and Peri-Arrest Ultrasound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST10005",
+  "name": "Exploring Science and Environment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30068",
+  "name": "Design Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM10006",
+  "name": "Introduction to Media Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90006",
+  "name": "Conservation Internship and Projects",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90071",
+  "name": "Quality Use of Medicines",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90022",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10059",
+  "name": "Conservatorium Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90019",
+  "name": "Book Markets: Structures and Strategies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90015",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90009",
+  "name": "Global Crisis Reporting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90045",
+  "name": "Interpretivist Research in Music Therapy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90049",
+  "name": "Marketing, Society and Sustainability",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20030",
+  "name": "Studio Studies 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM20030",
+  "name": "Performance Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO40003",
+  "name": "Seminars in Languages and Linguistics B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90064",
+  "name": "Emerging Markets Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI20035",
+  "name": "Applied Crop Production and Horticulture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90287",
+  "name": "Professional Practice - Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10008",
+  "name": "Screen Practice 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90064",
+  "name": "Urban Sustainability and Climate Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40018",
+  "name": "Media & Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90005",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM40016",
+  "name": "German Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90005",
+  "name": "Interdisciplinarity and the Environment",
+  "offered": [
+   "march",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN40017",
+  "name": "Screen & Cultural Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40027",
+  "name": "English & Theatre Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90015",
+  "name": "Grattan Street Press",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90239",
+  "name": "Professional Practice - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90325",
+  "name": "Prefabrication in Building",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90046",
+  "name": "Treasury Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90012",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90026",
+  "name": "Interdisciplinary Industry Project 1",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90249",
+  "name": "Research Foundations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90183",
+  "name": "Acting for Opera Performance 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RADI90020",
+  "name": "Diagnostic Radiology 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90030",
+  "name": "Media and Communications Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90284",
+  "name": "Research Project in Public Health Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30225",
+  "name": "Ensemble Studies 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RADI90023",
+  "name": "Diagnostic Radiology Minor Thesis 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90070",
+  "name": "Minor Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90113",
+  "name": "Continuum Mechanics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90098",
+  "name": "Production, Herd and Public Health B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90367",
+  "name": "Critical&Curatorial Practices in Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90031",
+  "name": "Spatial Information Research Project D",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM40001",
+  "name": "Microeconometrics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST30016",
+  "name": "Music Theatre Industry Skills",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90131",
+  "name": "Strategic Plan Making",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90132",
+  "name": "Land Use and Urban Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG40001",
+  "name": "Indigenous First Principles",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40012",
+  "name": "GradDip Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90071",
+  "name": "DRFS Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40013",
+  "name": "GradDip Composition 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL90002",
+  "name": "Writing as Women: Critical Readings",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90031",
+  "name": "Speech Disorders Across the Lifespan",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90003",
+  "name": "Introduction to Action Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30018",
+  "name": "Critical and Theoretical Studies 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90118",
+  "name": "Applied Architectural Technology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC90012",
+  "name": "Trust, Communication and Expertise",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90040",
+  "name": "Nutrition Politics and Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20026",
+  "name": "Minor Music Performance 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90017",
+  "name": "Environmental Policy Instruments",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10019",
+  "name": "Animation Studio 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91030",
+  "name": "Research in Educational Relationships",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90012",
+  "name": "Modelling the Australian Macroeconomy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90037",
+  "name": "MFPI Internship Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90039",
+  "name": "Executive Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN90003",
+  "name": "Graduate Japanese B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90043",
+  "name": "Gastrointestinal Tract Pancreas Adrenals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40017",
+  "name": "Practical Study 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50034",
+  "name": "Criminal Law and Procedure",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT40007",
+  "name": "Special Research Topics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90009",
+  "name": "Translating from Chinese to English",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90015",
+  "name": "Journalism Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90048",
+  "name": "Project Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST30018",
+  "name": "Production Studio 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90078",
+  "name": "Algorithmic Trading",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90012",
+  "name": "Collaborative Dramaturgies Project 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90005",
+  "name": "Environmental Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90079",
+  "name": "Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90003",
+  "name": "Accounting Research Report",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90016",
+  "name": "Engineering Management Capstone",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90036",
+  "name": "Property Investment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90043",
+  "name": "Enterprise Applications & Architectures",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LARC20001",
+  "name": "Designing Living Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIEN90003",
+  "name": "Biochemical Engineering Minor Thesis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30253",
+  "name": "Performance 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI40018",
+  "name": "Agric.Science Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90022",
+  "name": "Game Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10023",
+  "name": "Exploring Numbers and Reasoning",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENP90017",
+  "name": "Immunisation and Travel Health",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND40009",
+  "name": "Feminist & Queer Perspectives on Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90061",
+  "name": "Applications in Animal Health B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90125",
+  "name": "Nursing Science 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM10005",
+  "name": "Academic Writing and Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90013",
+  "name": "Spatial Information Research Project C",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20074",
+  "name": "Brass Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90083",
+  "name": "Research Methods & Ultrasound Literature",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90171",
+  "name": "Drug Issues",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA40004",
+  "name": "Asian Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS90008",
+  "name": "Writing About Art and the Moving Image",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90043",
+  "name": "Spatial IT Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90290",
+  "name": "Fundamentals of Built Environment Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10009",
+  "name": "Screen Culture 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10019",
+  "name": "Animation Studio 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91030",
+  "name": "Research in Educational Relationships",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90018",
+  "name": "Film Craft",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90064",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90018",
+  "name": "The Economics of Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90020",
+  "name": "Minor Thesis 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV70022",
+  "name": "Documentary Projects 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40007",
+  "name": "Change in Journalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90039",
+  "name": "Executive Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90065",
+  "name": "Exactly Solvable Models",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90197",
+  "name": "Consumer Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90004",
+  "name": "Accounting for Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90031",
+  "name": "Biomed Eng Capstone Proj Part 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SURG40001",
+  "name": "Surgery Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS40021",
+  "name": "Vet Bioscience Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90203",
+  "name": "Digital Ethics for Scientists",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20013",
+  "name": "Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90031",
+  "name": "Energy Systems Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90037",
+  "name": "MFPI Internship Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90016",
+  "name": "Principles of Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST30017",
+  "name": "Music Theatre Studio 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40025",
+  "name": "Global Crime Narratives",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90017",
+  "name": "Advanced Psychological Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30054",
+  "name": "The Metaphysics of Ethics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90012",
+  "name": "Translation and Interpreting Thesis 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30228",
+  "name": "Individual Performance Studies 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90018",
+  "name": "Managing Behaviour in Organisations",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90047",
+  "name": "Aerospace Propulsion",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90034",
+  "name": "Sustainable Food Production",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOLS40003",
+  "name": "Socio-Legal Studies Thesis Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90899",
+  "name": "Numeracy in Early Childhood",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90131",
+  "name": "Internship II",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90058",
+  "name": "Agronomy & Cropping Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40016",
+  "name": "Creative Writing Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90021",
+  "name": "Research Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN40018",
+  "name": "Screen & Cultural Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40021",
+  "name": "Philosophy Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90011",
+  "name": "Directed Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90172",
+  "name": "SocioEnvironmentalContext of Adolescents",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING40015",
+  "name": "LAL Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90047",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90923",
+  "name": "Place Based Elective (Rural / Remote)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90742",
+  "name": "Effective Clinical Supervision",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90103",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90004",
+  "name": "Accounting for Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90031",
+  "name": "Biomed Eng Capstone Proj Part 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SURG40001",
+  "name": "Surgery Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90003",
+  "name": "Journalism Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90929",
+  "name": "Understanding Education in Context",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90116",
+  "name": "Veterinary Bioscience 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV40012",
+  "name": "Research Paper (Screenwriting)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90019",
+  "name": "Advanced Studies in Econometrics 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90018",
+  "name": "Internship I (Placement Only)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE40009",
+  "name": "Advanced Derivative Securities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20224",
+  "name": "Music and Gender",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS40021",
+  "name": "Vet Bioscience Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90203",
+  "name": "Digital Ethics for Scientists",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90059",
+  "name": "Commercial Law in Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90048",
+  "name": "Landscape Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90083",
+  "name": "Internship for Agricultural Sciences Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90016",
+  "name": "International Financial Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENP60002",
+  "name": "Preventive Health Care",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30019",
+  "name": "Chamber Music 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90049",
+  "name": "Principles of Ultrasound Heart Scan",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90031",
+  "name": "Energy Systems Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20013",
+  "name": "Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG40004",
+  "name": "Indigenous Studies Thesis Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE90013",
+  "name": "Communication for Research Scientists",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM30038",
+  "name": "Professional Practice Theatre 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90048",
+  "name": "Managing ICT Infrastructure",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN90007",
+  "name": "Software Design and Architecture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90026",
+  "name": "Fundamentals of Information Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90072",
+  "name": "Engineering Project Implementation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90282",
+  "name": "Strategic Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90039",
+  "name": "Creating Innovative Professionals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90021",
+  "name": "Critical Communication for Engineers",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90041",
+  "name": "Engineering Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN30020",
+  "name": "Systems Modelling and Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM30001",
+  "name": "Frontiers in Biomedicine",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90937",
+  "name": "International Issues in Arts Education",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30034",
+  "name": "Applied Data Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL20003",
+  "name": "Stochastic Techniques in Insurance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM30020",
+  "name": "Islam and Democracy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20108",
+  "name": "MCM Chinese Music Ensemble",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90033",
+  "name": "Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN30021",
+  "name": "Mechanical Systems Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS10003",
+  "name": "The World in Twenty Art Works",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN90004",
+  "name": "Graduate Spanish B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90062",
+  "name": "Capstone Studies in Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90039",
+  "name": "Pharmaceutical & Biochemical Production",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS30018",
+  "name": "Veterinary Bioscience:Respiratory System",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST10017",
+  "name": "The Art of Working Online",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH40007",
+  "name": "Clinical Path Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90038",
+  "name": "Algorithms and Complexity",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM10006",
+  "name": "Chemistry for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM20035",
+  "name": "Theatre Skills 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90007",
+  "name": "Information Visualisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL30006",
+  "name": "Intermediate Financial Mathematics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV70022",
+  "name": "Documentary Projects 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LARC30002",
+  "name": "Interpreting Australian Landscape Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90200",
+  "name": "Suzuki Practicum Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90001",
+  "name": "Health Informatics Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90045",
+  "name": "Professional IS Consulting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90125",
+  "name": "Vet Bioscience: Metabolism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90020",
+  "name": "Engineering Management Capstone",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90153",
+  "name": "Professional Practice 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20088",
+  "name": "MCM Indonesian Gamelan Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG30001",
+  "name": "Being Indigenous in the 21st Century",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND30003",
+  "name": "Gender at Work in The World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30002",
+  "name": "Critical Debates",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST30002",
+  "name": "Land And Environment Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC20013",
+  "name": "Laboratory and Computational Physics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA30002",
+  "name": "Identity, Ideology & Nationalism in Asia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI40007",
+  "name": "Sociology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90013",
+  "name": "Strategy Execution for Engineers",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90038",
+  "name": "Engineering Capstone Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL20004",
+  "name": "Topics in Actuarial Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM30017",
+  "name": "Digital and Mobile Journalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT90004",
+  "name": "Plant Production and Establishment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CCDP10003",
+  "name": "Video Games: Remaking Reality",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL20034",
+  "name": "The Theatre Experience",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS20006",
+  "name": "Contemporary Political Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL20041",
+  "name": "Phenomenology and Existentialism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN10002",
+  "name": "Japanese 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GDES30003",
+  "name": "Graphic Design Studio 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10017",
+  "name": "Our Planet, Our Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HEBR10002",
+  "name": "Hebrew 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN20019",
+  "name": "Spanish 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10005",
+  "name": "Quantitative Methods 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20190",
+  "name": "Advanced Recording Studio Techniques",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30057",
+  "name": "Asia Pacific Modernities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CONS20002",
+  "name": "Measurement of Building Designs",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10023",
+  "name": "The Making of Melbourne",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10222",
+  "name": "The Wellbeing Orchestra",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10023",
+  "name": "Music Language 1: the Diatonic World",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL20028",
+  "name": "Architecture Design Studio: Water",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS10009",
+  "name": "AI, Ethics and the Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20004",
+  "name": "French Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30003",
+  "name": "Japanese Through Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PROP10001",
+  "name": "Economics and Cities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20018",
+  "name": "Going Places - Travelling Smarter",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI30001",
+  "name": "Novels",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20163",
+  "name": "Samba Band",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NUTR20001",
+  "name": "Food Nutrition and Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN30009",
+  "name": "Structural Theory and Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30008",
+  "name": "Japanese 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GDES30003",
+  "name": "Graphic Design Studio 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10003",
+  "name": "Physics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30017",
+  "name": "Australian Indigenous Public Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30003",
+  "name": "Japanese Through Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PROP10001",
+  "name": "Economics and Cities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS20017",
+  "name": "Gender and Contemporary Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10005",
+  "name": "Quantitative Methods 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10010",
+  "name": "Making Movies 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL20034",
+  "name": "The Theatre Experience",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS20006",
+  "name": "Contemporary Political Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CONS20002",
+  "name": "Measurement of Building Designs",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10023",
+  "name": "The Making of Melbourne",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10222",
+  "name": "The Wellbeing Orchestra",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10023",
+  "name": "Music Language 1: the Diatonic World",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR20004",
+  "name": "Engineering Mechanics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AIND20011",
+  "name": "Indigenous Art and Changing the Nation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL30003",
+  "name": "Sedimentary Geology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG20002",
+  "name": "Indigenous Environmental Heritage",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS30024",
+  "name": "Public Trials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM20008",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20041",
+  "name": "The Figure in Performance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD30009",
+  "name": "Food Research & Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM20006",
+  "name": "Punishment and Social Control",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BLAW30002",
+  "name": "Taxation Law I",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW30004",
+  "name": "Beyond Babylon",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BOTA30002",
+  "name": "Plant Evolution",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HEBR10006",
+  "name": "Hebrew 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30003",
+  "name": "Agricultural Systems Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL20010",
+  "name": "Italian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30052",
+  "name": "Race and Gender: Philosophical Issues",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA30000",
+  "name": "Business Judgement",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20005",
+  "name": "Statistics",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH30001",
+  "name": "Design Studio Delta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MIIM30003",
+  "name": "Medical and Applied Immunology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP30026",
+  "name": "Models of Computation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT30008",
+  "name": "Viscera and Visceral Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30028",
+  "name": "Chinese 10",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90010",
+  "name": "Quantitative Analysis of Finance II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CEDB30003",
+  "name": "Developmental Biology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN20002",
+  "name": "Anatomy & Physiology for Bioengineering",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS30001",
+  "name": "Industry Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS30024",
+  "name": "Public Trials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM20008",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20041",
+  "name": "The Figure in Performance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD30009",
+  "name": "Food Research & Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM20006",
+  "name": "Punishment and Social Control",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BLAW30002",
+  "name": "Taxation Law I",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW30004",
+  "name": "Beyond Babylon",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BOTA30002",
+  "name": "Plant Evolution",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI30001",
+  "name": "Novels",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30052",
+  "name": "Race and Gender: Philosophical Issues",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA30000",
+  "name": "Business Judgement",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH30001",
+  "name": "Design Studio Delta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN30009",
+  "name": "Structural Theory and Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC10002",
+  "name": "Arabic 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP20005",
+  "name": "Engineering Computation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30003",
+  "name": "Chinese News Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30033",
+  "name": "Statistical Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL10010",
+  "name": "Italian 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10005",
+  "name": "Calculus 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10010",
+  "name": "Data Analysis 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10021",
+  "name": "Calculus 2: Advanced",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT30001",
+  "name": "Financial Accounting Theory",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM30012",
+  "name": "Integrated Spatial Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN10003",
+  "name": "French 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20004",
+  "name": "Probability",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20026",
+  "name": "Advanced Chinese Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR90017",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP30026",
+  "name": "Models of Computation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT30008",
+  "name": "Viscera and Visceral Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30028",
+  "name": "Chinese 10",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN10002",
+  "name": "Spanish 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10004",
+  "name": "Chinese 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20026",
+  "name": "Real Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM30012",
+  "name": "Integrated Spatial Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN10003",
+  "name": "French 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20026",
+  "name": "Advanced Chinese Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10018",
+  "name": "Chinese 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20026",
+  "name": "Real Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO30019",
+  "name": "Translation: Intercultural Indonesian",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HLTH90011",
+  "name": "Research Project in Human Genomics 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "WELF90008",
+  "name": "Genetic Counselling Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB40010",
+  "name": "Biochemistry Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90019",
+  "name": "International Trade",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90052",
+  "name": "Practice in Diverse Communities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90191",
+  "name": "The Research Process For Musicians (RHD)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90102",
+  "name": "Linear Regression",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90138",
+  "name": "Veterinary Parasitology B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90013",
+  "name": "Finance and Budgeting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90114",
+  "name": "Information Systems Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90228",
+  "name": "Managing Growth and Pathways to Market",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90235",
+  "name": "EMA Special Project (Year Long) Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90073",
+  "name": "Laboratory Rotation 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90213",
+  "name": "Commercial Data Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN40007",
+  "name": "Spanish & Latin American Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90107",
+  "name": "Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90072",
+  "name": "Major Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90105",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN40008",
+  "name": "Spanish & Latin American Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL40007",
+  "name": "Actuarial Practice and Control II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90045",
+  "name": "Engineering Project Implementation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM20014",
+  "name": "Visual Communication and Digital Media",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW40003",
+  "name": "Archaeology of Complex Societies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90021",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90078",
+  "name": "Structuring and Managing Patient Data",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40003",
+  "name": "Medieval Passions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90069",
+  "name": "Applications in Animal Health 2 Part B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90019",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90021",
+  "name": "Translation, Interpreting, Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40091",
+  "name": "Music Internship",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT10004",
+  "name": "Introduction to Accounting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90170",
+  "name": "Landscape Studio 4 Strategies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90011",
+  "name": "Advanced Property Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI10044",
+  "name": "Plant Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20017",
+  "name": "French 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP30019",
+  "name": "Graphics and Interaction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN30006",
+  "name": "Software Modelling and Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20203",
+  "name": "Peak Performance Under Pressure",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10009",
+  "name": "German 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC10006",
+  "name": "Arabic 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO10004",
+  "name": "Indonesian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20014",
+  "name": "Diversity: Identities in Indonesia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB20005",
+  "name": "Techniques in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR30007",
+  "name": "Auditory Neuroscience",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB30004",
+  "name": "Cell Signalling and Neurochemistry",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT90015",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS20031",
+  "name": "Latin 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH20003",
+  "name": "Experimental Pathology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "WELF90005",
+  "name": "Principles of Counselling 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90015",
+  "name": "Terror, Law and War",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90012",
+  "name": "Electrophysiological Assessment A",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90062",
+  "name": "Materials Modelling and Characterisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90002",
+  "name": "Foundations of Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90026",
+  "name": "Minor Thesis 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90141",
+  "name": "Business Analysis & Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV70046",
+  "name": "Script Development Hothouse",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN90014",
+  "name": "Masters Software Engineering Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV40009",
+  "name": "Research Paper (Film and Television)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50049",
+  "name": "Human Rights Law and Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90001",
+  "name": "Researching/Writing Stories",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI20040",
+  "name": "Enterprise Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90265",
+  "name": "History of Landscape Architecture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACUR90005",
+  "name": "Interpreting Exhibitions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90193",
+  "name": "Studio Teaching 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90028",
+  "name": "International Relations Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE40006",
+  "name": "Finance Research Essay",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40013",
+  "name": "Topics in the Philosophy of Language",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90030",
+  "name": "Public Policy in the Asian Century",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC90002",
+  "name": "Graduate Arabic B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90025",
+  "name": "Research Project In Geoscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40003",
+  "name": "International Trade",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40101",
+  "name": "Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90013",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90137",
+  "name": "Veterinary Bacteriology and Mycology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90022",
+  "name": "Photojournalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90040",
+  "name": "Mathematics of Spatial Information",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20113",
+  "name": "Vocal Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20202",
+  "name": "Performance 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90035",
+  "name": "Music Therapy Methods 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90125",
+  "name": "Bayesian Statistical Learning",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90051",
+  "name": "Impact of Digitisation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90059",
+  "name": "Veterinary Bioscience 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90135",
+  "name": "Vet Bioscience: Reproduction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA90007",
+  "name": "Perspectives in Art & Cultural Theory 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "THTR90009",
+  "name": "Performance and Community Engagement",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90019",
+  "name": "Research Project (MMS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90079",
+  "name": "Computer Science Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90087",
+  "name": "Sustainable Investment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40076",
+  "name": "Musics of the World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90035",
+  "name": "Biosignal Processing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90060",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR10005",
+  "name": "Statics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40025",
+  "name": "Global Crime Narratives",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90005",
+  "name": "Information Architecture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST30017",
+  "name": "Music Theatre Studio 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30054",
+  "name": "The Metaphysics of Ethics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90012",
+  "name": "Translation and Interpreting Thesis 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30228",
+  "name": "Individual Performance Studies 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90017",
+  "name": "Advanced Psychological Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30224",
+  "name": "Contextual Studies 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90148",
+  "name": "Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90024",
+  "name": "Industry Core and Placement",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90273",
+  "name": "Urban Design Studio B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90033",
+  "name": "Geography Minor Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10220",
+  "name": "Practical Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90067",
+  "name": "Infections Population & Pub. Health PtB",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90020",
+  "name": "Spatial Information Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90063",
+  "name": "Indigenous Peoples in Global Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "WELF90007",
+  "name": "Fitness to Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90022",
+  "name": "Chemical Engineering Design Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40061",
+  "name": "Recital",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NUTR40002",
+  "name": "Human Nutrition Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20180",
+  "name": "Contextual Studies 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90015",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO40003",
+  "name": "Seminars in Languages and Linguistics B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40017",
+  "name": "Practical Study 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90064",
+  "name": "Emerging Markets Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI20035",
+  "name": "Applied Crop Production and Horticulture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90064",
+  "name": "Urban Sustainability and Climate Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90287",
+  "name": "Professional Practice - Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40018",
+  "name": "Media & Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90005",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90079",
+  "name": "Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90003",
+  "name": "Accounting Research Report",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90005",
+  "name": "Interdisciplinarity and the Environment",
+  "offered": [
+   "march",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90016",
+  "name": "Engineering Management Capstone",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20183",
+  "name": "Interactive Composition 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90013",
+  "name": "Investigative Journalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90869",
+  "name": "Doctor of Education Thesis Proposal",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10020",
+  "name": "Animation Lab 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90062",
+  "name": "Behavioural Economics:Accounting&Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90187",
+  "name": "Clinical Training in Music Therapy 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90195",
+  "name": "Advanced Management Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90012",
+  "name": "Agribusiness Management Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90081",
+  "name": "Minor Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90140",
+  "name": "Causal Inference",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40012",
+  "name": "Reading Dialogue",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL40012",
+  "name": "Research Project - RMH Part 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CONS30002",
+  "name": "Building Information Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90011",
+  "name": "Monetary Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PLAN90001",
+  "name": "Urban Demography and Statistics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90074",
+  "name": "Landscape Detail Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90021",
+  "name": "Bilingualism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90229",
+  "name": "Orchestral Performance Practicum 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90930",
+  "name": "Local Literacies in Global Contexts",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV20009",
+  "name": "Screen Practice 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90013",
+  "name": "Case Studies in Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MIIM40006",
+  "name": "Micro & Immuno Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90006",
+  "name": "Conservation Internship and Projects",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40060",
+  "name": "Concerto",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90019",
+  "name": "Book Markets: Structures and Strategies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90015",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20030",
+  "name": "Studio Studies 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90043",
+  "name": "Gastrointestinal Tract Pancreas Adrenals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT40007",
+  "name": "Special Research Topics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50034",
+  "name": "Criminal Law and Procedure",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10008",
+  "name": "Screen Practice 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90009",
+  "name": "Translating from Chinese to English",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90015",
+  "name": "Journalism Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90012",
+  "name": "Collaborative Dramaturgies Project 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST30018",
+  "name": "Production Studio 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90078",
+  "name": "Algorithmic Trading",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90048",
+  "name": "Project Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN40017",
+  "name": "Screen & Cultural Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM40016",
+  "name": "German Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90005",
+  "name": "Environmental Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40027",
+  "name": "English & Theatre Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90239",
+  "name": "Professional Practice - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90015",
+  "name": "Grattan Street Press",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90036",
+  "name": "Property Investment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90325",
+  "name": "Prefabrication in Building",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90046",
+  "name": "Treasury Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIEN90003",
+  "name": "Biochemical Engineering Minor Thesis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30253",
+  "name": "Performance 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90014",
+  "name": "Advanced Econometric Techniques 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90100",
+  "name": "Abdominal and Peri-Arrest Ultrasound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN90004",
+  "name": "Graduate French B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM10006",
+  "name": "Introduction to Media Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40067",
+  "name": "Honours Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST10005",
+  "name": "Exploring Science and Environment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30164",
+  "name": "Baroque Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM20034",
+  "name": "Theatre Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90011",
+  "name": "Financial Econometrics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90237",
+  "name": "Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20094",
+  "name": "Symphonic Ensembles 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90028",
+  "name": "Geography Practical",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90241",
+  "name": "Theories of Inclusive Music Teaching",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90020",
+  "name": "Environmental Industry Research (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90022",
+  "name": "Practical Earth Science A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40062",
+  "name": "Honours Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90037",
+  "name": "Research in Music Therapy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT20017",
+  "name": "Landscape Design 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL40016",
+  "name": "Italian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN90002",
+  "name": "Film Production: From Script to Screen",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90019",
+  "name": "Research Project (MMS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA90007",
+  "name": "Perspectives in Art & Cultural Theory 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90079",
+  "name": "Computer Science Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90087",
+  "name": "Sustainable Investment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90035",
+  "name": "Biosignal Processing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90060",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR10005",
+  "name": "Statics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40076",
+  "name": "Musics of the World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90005",
+  "name": "Information Architecture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST30017",
+  "name": "Music Theatre Studio 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40025",
+  "name": "Global Crime Narratives",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90017",
+  "name": "Advanced Psychological Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30054",
+  "name": "The Metaphysics of Ethics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90012",
+  "name": "Translation and Interpreting Thesis 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30228",
+  "name": "Individual Performance Studies 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90018",
+  "name": "Managing Behaviour in Organisations",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90047",
+  "name": "Aerospace Propulsion",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90034",
+  "name": "Sustainable Food Production",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOLS40003",
+  "name": "Socio-Legal Studies Thesis Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90899",
+  "name": "Numeracy in Early Childhood",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90290",
+  "name": "Fundamentals of Built Environment Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10009",
+  "name": "Screen Culture 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90031",
+  "name": "Speech Disorders Across the Lifespan",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30018",
+  "name": "Critical and Theoretical Studies 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90003",
+  "name": "Introduction to Action Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "IBUS90002",
+  "name": "Managing in Asia",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90118",
+  "name": "Applied Architectural Technology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC90012",
+  "name": "Trust, Communication and Expertise",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90066",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90040",
+  "name": "Nutrition Politics and Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20026",
+  "name": "Minor Music Performance 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90020",
+  "name": "Global Media: Theory and Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90017",
+  "name": "Environmental Policy Instruments",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90042",
+  "name": "Liver, Spleen and Sampling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90389",
+  "name": "Urban Design Studio C",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10019",
+  "name": "Animation Studio 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91030",
+  "name": "Research in Educational Relationships",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90018",
+  "name": "Film Craft",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90064",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90018",
+  "name": "The Economics of Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS40025",
+  "name": "Key Debates in Political Science 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90045",
+  "name": "Political Economy of Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90640",
+  "name": "Diversity, Inclusion and Transitions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL90004",
+  "name": "Graduate Italian B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90035",
+  "name": "Plant Food Products",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90003",
+  "name": "Public Relations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90015",
+  "name": "English Phonetics and Phonology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM30031",
+  "name": "Performance Skills 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90008",
+  "name": "Microeconometrics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90021",
+  "name": "Director, Actor and Text",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH40011",
+  "name": "Critical Anthropological Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90056",
+  "name": "IE Research Project 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90016",
+  "name": "Journalism Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV20011",
+  "name": "Gaming and the Writer",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10006",
+  "name": "Introductory Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90019",
+  "name": "Consumerism and the Growth Economy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90141",
+  "name": "Machine Learning for Biostatistics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90200",
+  "name": "Suzuki Practicum Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40016",
+  "name": "Creative Writing Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI10048",
+  "name": "Plant Production Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90094",
+  "name": "Managing Innovation and Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90011",
+  "name": "Bioenvironmental Engineering",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90019",
+  "name": "Advanced Studies in Econometrics 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90116",
+  "name": "Veterinary Bioscience 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90003",
+  "name": "Journalism Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90929",
+  "name": "Understanding Education in Context",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV40012",
+  "name": "Research Paper (Screenwriting)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30019",
+  "name": "Chamber Music 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90083",
+  "name": "Internship for Agricultural Sciences Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90049",
+  "name": "Principles of Ultrasound Heart Scan",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90026",
+  "name": "Fundamentals of Information Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90081",
+  "name": "Business Process Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90093",
+  "name": "Economic Evaluation 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90010",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90024",
+  "name": "New Writing Dramaturgy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90331",
+  "name": "ICT in Building",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90057",
+  "name": "Advanced Theoretical Computer Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90742",
+  "name": "Effective Clinical Supervision",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90103",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90047",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20088",
+  "name": "MCM Indonesian Gamelan Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90013",
+  "name": "Strategy Execution for Engineers",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90038",
+  "name": "Engineering Capstone Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG30001",
+  "name": "Being Indigenous in the 21st Century",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND30003",
+  "name": "Gender at Work in The World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL20004",
+  "name": "Topics in Actuarial Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC20013",
+  "name": "Laboratory and Computational Physics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM30017",
+  "name": "Digital and Mobile Journalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA30002",
+  "name": "Identity, Ideology & Nationalism in Asia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30002",
+  "name": "Critical Debates",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT90004",
+  "name": "Plant Production and Establishment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST30002",
+  "name": "Land And Environment Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90058",
+  "name": "Agronomy & Cropping Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90172",
+  "name": "SocioEnvironmentalContext of Adolescents",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "THTR90007",
+  "name": "Applied Project B (Design)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20221",
+  "name": "Sound Studies 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90222",
+  "name": "Ex_Lab: Timber Furniture",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90101",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90036",
+  "name": "Advanced Clinical Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI40015",
+  "name": "Biomedicine Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10221",
+  "name": "Practical Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90358",
+  "name": "Research in Construction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST10015",
+  "name": "Music Theatre Contextual Studies 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI10051",
+  "name": "Genetics for Agriculture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90018",
+  "name": "Internship I (Placement Only)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90059",
+  "name": "Commercial Law in Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90048",
+  "name": "Landscape Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG40004",
+  "name": "Indigenous Studies Thesis Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE90013",
+  "name": "Communication for Research Scientists",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM30038",
+  "name": "Professional Practice Theatre 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM30020",
+  "name": "Islam and Democracy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20108",
+  "name": "MCM Chinese Music Ensemble",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90937",
+  "name": "International Issues in Arts Education",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90039",
+  "name": "Creating Innovative Professionals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90021",
+  "name": "Critical Communication for Engineers",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90041",
+  "name": "Engineering Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90033",
+  "name": "Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN30021",
+  "name": "Mechanical Systems Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN30020",
+  "name": "Systems Modelling and Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS10003",
+  "name": "The World in Twenty Art Works",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50055",
+  "name": "Advocacy",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE20037",
+  "name": "Digital Dance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30046",
+  "name": "Agronomy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ZOOL30009",
+  "name": "Tropical Field Ecology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90061",
+  "name": "Communication Networks",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN30009",
+  "name": "Introduction to Biomaterials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90008",
+  "name": "Video Journalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90004",
+  "name": "New Media: Harnessing Digital Disruption",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE90024",
+  "name": "Frontiers in Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90018",
+  "name": "Corporate Financial Policy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO30007",
+  "name": "Visual Neuroscience",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90107",
+  "name": "Data Science Project Pt2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20092",
+  "name": "String Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ERTH10003",
+  "name": "Geology For Engineers",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN30001",
+  "name": "Environmental Eng Systems Capstone",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20070",
+  "name": "Baroque Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BTCH90005",
+  "name": "Advanced Molecular Biology Techniques",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30040",
+  "name": "Measurement of Building Works",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30009",
+  "name": "Macroeconomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BLAW10002",
+  "name": "Free Speech and Media Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30003",
+  "name": "Industrial Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10228",
+  "name": "Sound Studies 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20021",
+  "name": "Inequalities: Causes and Consequences",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT20001",
+  "name": "Cost Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30018",
+  "name": "European Integration: Politics of the EU",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30041",
+  "name": "Construction Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM10004",
+  "name": "Chemistry 2",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10013",
+  "name": "Catastrophes as Turning Points",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP30020",
+  "name": "Declarative Programming",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN30008",
+  "name": "Engineering Risk Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HEBR10012",
+  "name": "Hebrew 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM20010",
+  "name": "German 10",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HEBR20008",
+  "name": "Hebrew 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT20027",
+  "name": "Greening Landscapes",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10007",
+  "name": "Introduction to Climate Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MIIM30014",
+  "name": "Medical Microbiology: Virology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20008",
+  "name": "China Since Mao",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30046",
+  "name": "Music Language 3: Modern Directions",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR30002",
+  "name": "Fluid Mechanics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10006",
+  "name": "Calculus 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10017",
+  "name": "Our Planet, Our Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HEBR10002",
+  "name": "Hebrew 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN20019",
+  "name": "Spanish 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10005",
+  "name": "Quantitative Methods 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20190",
+  "name": "Advanced Recording Studio Techniques",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30057",
+  "name": "Asia Pacific Modernities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CONS20002",
+  "name": "Measurement of Building Designs",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10023",
+  "name": "The Making of Melbourne",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10222",
+  "name": "The Wellbeing Orchestra",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10023",
+  "name": "Music Language 1: the Diatonic World",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL20028",
+  "name": "Architecture Design Studio: Water",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS10009",
+  "name": "AI, Ethics and the Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20004",
+  "name": "French Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30003",
+  "name": "Japanese Through Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PROP10001",
+  "name": "Economics and Cities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS20017",
+  "name": "Gender and Contemporary Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV10010",
+  "name": "Making Movies 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL20044",
+  "name": "The Ethics of Capitalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT10002",
+  "name": "Principles of Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL30005",
+  "name": "Applied Geophysics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD20006",
+  "name": "Food Microbiology and Safety",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT30008",
+  "name": "Managing Sustainably",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO10006",
+  "name": "Indonesian 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL20023",
+  "name": "American Classics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN30001",
+  "name": "Gender in Hispanic Cultures",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM30004",
+  "name": "Media Futures and New Technologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10014",
+  "name": "Philosophy, Politics and Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL20008",
+  "name": "Ethical Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL30006",
+  "name": "Economic Geology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT20005",
+  "name": "Business Decision Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EVSC30002",
+  "name": "Problem Solving in Environmental Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL20022",
+  "name": "Modernism and Avant Garde",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP20003",
+  "name": "Algorithms and Data Structures",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ERTH20003",
+  "name": "Past Climates: Icehouse to Greenhouse",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30013",
+  "name": "Japanese Grammar in Action",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN20003",
+  "name": "Political Leadership",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10179",
+  "name": "Making Music For Film And Animation 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST30064",
+  "name": "Controversies in Australian History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD30010",
+  "name": "Functional Foods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL20025",
+  "name": "The House of Fiction: Literary Realism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10050",
+  "name": "Understanding Knowing and Learning",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NUTR20001",
+  "name": "Food Nutrition and Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20012",
+  "name": "Arts Internship: Not for Profit",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30008",
+  "name": "Japanese 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10003",
+  "name": "Introductory Macroeconomics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING20003",
+  "name": "Second Language Learning and Teaching",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND10001",
+  "name": "Sex, Gender and Culture: An Introduction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30022",
+  "name": "Indigenous Engineering and Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20150",
+  "name": "Music and Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL10010",
+  "name": "Italian 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20004",
+  "name": "Probability",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10021",
+  "name": "Calculus 2: Advanced",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR90017",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN10002",
+  "name": "Spanish 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10004",
+  "name": "Chinese 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP30026",
+  "name": "Models of Computation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT30008",
+  "name": "Viscera and Visceral Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30028",
+  "name": "Chinese 10",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90010",
+  "name": "Quantitative Analysis of Finance II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CEDB30003",
+  "name": "Developmental Biology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN20002",
+  "name": "Anatomy & Physiology for Bioengineering",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS30001",
+  "name": "Industry Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS30024",
+  "name": "Public Trials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM20008",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20041",
+  "name": "The Figure in Performance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD30009",
+  "name": "Food Research & Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM20006",
+  "name": "Punishment and Social Control",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BLAW30002",
+  "name": "Taxation Law I",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW30004",
+  "name": "Beyond Babylon",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BOTA30002",
+  "name": "Plant Evolution",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI30001",
+  "name": "Novels",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30052",
+  "name": "Race and Gender: Philosophical Issues",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA30000",
+  "name": "Business Judgement",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH30001",
+  "name": "Design Studio Delta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN30009",
+  "name": "Structural Theory and Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ATOC10001",
+  "name": "Wonders Of The Weather",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING20006",
+  "name": "Syntax",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30030",
+  "name": "American Politics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30026",
+  "name": "East Timor Field Class",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ZOOL20006",
+  "name": "Comparative Animal Physiology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM20002",
+  "name": "German 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30022",
+  "name": "Global Environmental Politics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30019",
+  "name": "Behavioural Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN30015",
+  "name": "Spanish 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO30003",
+  "name": "European Modernism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20003",
+  "name": "Quantitative Methods 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST30059",
+  "name": "Race in the Americas",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE20005",
+  "name": "Corporate Financial Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC10002",
+  "name": "Arabic 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP20005",
+  "name": "Engineering Computation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10005",
+  "name": "Calculus 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10010",
+  "name": "Data Analysis 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30003",
+  "name": "Chinese News Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT30001",
+  "name": "Financial Accounting Theory",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30033",
+  "name": "Statistical Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM30012",
+  "name": "Integrated Spatial Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN10003",
+  "name": "French 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20026",
+  "name": "Advanced Chinese Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10018",
+  "name": "Chinese 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20026",
+  "name": "Real Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT90015",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS20031",
+  "name": "Latin 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH20003",
+  "name": "Experimental Pathology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "WELF90005",
+  "name": "Principles of Counselling 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90113",
+  "name": "Information Systems Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90042",
+  "name": "Casework/Research Report 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90018",
+  "name": "Clinical Practice in Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90010",
+  "name": "Applied Linguistics Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90016",
+  "name": "Biological Psychology & Pharmacotherapy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90364",
+  "name": "Industry Based Research - Property",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS40036",
+  "name": "Classics Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST20014",
+  "name": "Music Theatre Combination Skills 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL10004",
+  "name": "Oral Health Sciences 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90011",
+  "name": "Energy Efficiency Technology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90027",
+  "name": "Screen Language 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EVSC90019",
+  "name": "Graduate Seminar: Environmental Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90916",
+  "name": "Place Based Elective (Alternative)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90028",
+  "name": "Advanced Seminars in Specialty 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90015",
+  "name": "Advanced Psychopathology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO20004",
+  "name": "Usability Evaluation Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90017",
+  "name": "Research Project (MMS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM20031",
+  "name": "Performance Skills 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90173",
+  "name": "Advanced Planting Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90130",
+  "name": "Internship I",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90035",
+  "name": "Conservation Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90359",
+  "name": "Research Practicum in Construction",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM40007",
+  "name": "Econometrics of Markets and Competition",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL40011",
+  "name": "Research Project - RMH Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90020",
+  "name": "Advanced Book Publishing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90019",
+  "name": "Journalism Project (Extended) Part 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90016",
+  "name": "Actuarial Science Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30182",
+  "name": "Guitar Ensemble 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10017",
+  "name": "Fundamentals of Mathematics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40088",
+  "name": "Integrated Musical Practice 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI90016",
+  "name": "Creative Writing Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90030",
+  "name": "Project Evaluation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS20012",
+  "name": "Production Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90017",
+  "name": "Journalism Project (Extended) Part 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN40007",
+  "name": "Chinese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90008",
+  "name": "Consumers and Consumption",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90087",
+  "name": "Paediatric Intensive Care Nursing 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90071",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10067",
+  "name": "Guitar Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30268",
+  "name": "Interpretation Italian Lyric Repertoire",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90038",
+  "name": "Global Corporate Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM30032",
+  "name": "Professional Practice Acting 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA60010",
+  "name": "Studio Materials and Methods B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90005",
+  "name": "Social Research Design and Evaluation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90891",
+  "name": "Becoming a Clinical Practitioner (EC)",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90144",
+  "name": "The Teacher as Conductor",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90017",
+  "name": "Econometrics of Markets and Competition",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90047",
+  "name": "Rural and Urban Development Strategies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI40006",
+  "name": "Sociology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90023",
+  "name": "Advanced Consumer Behaviour",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90062",
+  "name": "Internship II (Year Long) Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90041",
+  "name": "Complex Case Models in Speech Pathology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90081",
+  "name": "Advanced Probability",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90316",
+  "name": "The Shaping of Urban Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90011",
+  "name": "Marketing Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90023",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50028",
+  "name": "Constitutional Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CREA90012",
+  "name": "Creative Arts Therapies in Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI40019",
+  "name": "Research Project – WH Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90035",
+  "name": "Integrated Marketing Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MREN90004",
+  "name": "Ceramics and Brittle Materials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90053",
+  "name": "Industrial Systems and Simulation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90327",
+  "name": "Procurement Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30263",
+  "name": "Jazz & Improv Composition Workshop",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS40002",
+  "name": "Indigenous Australian Art Histories",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40028",
+  "name": "Music and Gender",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90010",
+  "name": "Spatial Information Research Project A",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90029",
+  "name": "Clinical Processes B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL40012",
+  "name": "Actuarial Analytics and Data II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90033",
+  "name": "Marketing Communications Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90034",
+  "name": "Research Project 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90084",
+  "name": "Quantum Software Fundamentals",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90023",
+  "name": "Spatial Information Research Project B",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90013",
+  "name": "Condensed Matter Physics 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHTY90040",
+  "name": "Physiotherapy Professional Portfolio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90292",
+  "name": "M.Epidemiology Research Project - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90015",
+  "name": "Managerial Economics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90136",
+  "name": "Veterinary Public Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE90018",
+  "name": "Science Research Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30258",
+  "name": "Chamber Choir 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS30024",
+  "name": "Virtual Worlds in Japanese Art",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90390",
+  "name": "Architectural Engineering Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90061",
+  "name": "Freight Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM90017",
+  "name": "Independent Directing Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL40015",
+  "name": "Italian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SKIL10007",
+  "name": "Foundation Communication Skills",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90155",
+  "name": "Second Instrument / Vocal Study 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10053",
+  "name": "Brass Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90016",
+  "name": "Environmental Research Project (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS70002",
+  "name": "MVSc (Clinical) Practicum # PT",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW40016",
+  "name": "Ancient World Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90040",
+  "name": "Forensic Odontology 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90149",
+  "name": "Biostatistics Research Project - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS10001",
+  "name": "Reading the Disciplines",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90139",
+  "name": "Veterinary Professional Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90057",
+  "name": "Contemporary Nursing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST90032",
+  "name": "Forests, Carbon and Climate Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20207",
+  "name": "Applied Aural Musicianship 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90061",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90017",
+  "name": "Digital Business and Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40018",
+  "name": "Topics in Contemporary Epistemology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90062",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90093",
+  "name": "Agricultural Extension",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND90012",
+  "name": "Gender and Development Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90192",
+  "name": "Studio Teaching 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20056",
+  "name": "Composition 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90042",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PAED40005",
+  "name": "Paediatrics Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90042",
+  "name": "Social Media and Viral Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RURA90009",
+  "name": "Health Projects in Aboriginal Settings",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10196",
+  "name": "Music Making Laboratory 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90078",
+  "name": "Internship for Agricultural Sciences",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90111",
+  "name": "Genetic Epidemiology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50096",
+  "name": "Media Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA60012",
+  "name": "Contemporary Art Practice B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM40017",
+  "name": "German Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST10016",
+  "name": "Music Theatre Studio 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90040",
+  "name": "Managing Change for IS Professionals",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90002",
+  "name": "Financial Statement Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90039",
+  "name": "Understanding Media & Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO40002",
+  "name": "Honours Indonesian B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50058",
+  "name": "Melbourne University Law Review",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30251",
+  "name": "Practical Music 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90007",
+  "name": "Social Computing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90030",
+  "name": "Adv Clinical Practice in Specialty 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90286",
+  "name": "Professional Practice - Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90039",
+  "name": "CPR, Eye Emergencies & Practical ECC",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90011",
+  "name": "Translation and Interpreting as Process",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG40003",
+  "name": "Indigenous Studies Thesis Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90022",
+  "name": "Translation Industry Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90008",
+  "name": "Design Realisation and Collaboration B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90042",
+  "name": "Engineering Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20025",
+  "name": "Minor Music Performance 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90029",
+  "name": "Criminology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10206",
+  "name": "Medieval and Renaissance Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90031",
+  "name": "Criminology & Sociology Internship Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90018",
+  "name": "Mobile Computing Systems Programming",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV20013",
+  "name": "Animation Lab 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90133",
+  "name": "Partial Differential Equations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIEN90002",
+  "name": "Biochemical Engineering Design Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90080",
+  "name": "Major Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90068",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST90037",
+  "name": "Russia and the World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90108",
+  "name": "Data Science Research Project Pt1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90098",
+  "name": "Approximation, Algorithms and Heuristics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90012",
+  "name": "Industry Investigation Project B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90023",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90057",
+  "name": "Manufacturing Automation and IT",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE30003",
+  "name": "Science Research Project Abroad",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90052",
+  "name": "Advanced Materials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC40002",
+  "name": "Animal Sci & Mgt Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90140",
+  "name": "Management Competencies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20179",
+  "name": "Ensemble Studies 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90022",
+  "name": "International Internship in Environment",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90019",
+  "name": "Advances in Criminological Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90104",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA10034",
+  "name": "Studio Studies 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM40012",
+  "name": "Islamic Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90036",
+  "name": "MFPI Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM90004",
+  "name": "Graduate German B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN40009",
+  "name": "Japanese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS40007",
+  "name": "Russian Language & Culture 4B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40026",
+  "name": "English & Theatre Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90074",
+  "name": "Minor Research Project Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RADI90016",
+  "name": "Minor Thesis (Radiology) Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90051",
+  "name": "Civil Hydraulics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90020",
+  "name": "Additive Manufacturing of Metals",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10015",
+  "name": "Foundation Mathematics 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20083",
+  "name": "Conservatorium Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS40017",
+  "name": "Veterinary Clinical Skills",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10192",
+  "name": "Ensemble Studies 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90015",
+  "name": "Management of Neuro-ophthalmic Disorders",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO40008",
+  "name": "Indonesian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90129",
+  "name": "Group Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90083",
+  "name": "Electrical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90164",
+  "name": "MLS Tax Clinic",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90024",
+  "name": "Project In Geoscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90217",
+  "name": "Hot Topics in Public Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90157",
+  "name": "Pedagogue Recital",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90072",
+  "name": "DRFS Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90335",
+  "name": "Contract Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90012",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40063",
+  "name": "Honours Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90030",
+  "name": "Non-Renewable Energy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90165",
+  "name": "Social Entrepreneurship",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW40007",
+  "name": "Problems in Greek Prehistory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90009",
+  "name": "Quantitative Methods for Business",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90031",
+  "name": "Audiovisual Communication",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70003",
+  "name": "Minor Thesis (LLM) # P/T",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90038",
+  "name": "MFPI Internship Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90525",
+  "name": "Business and Economics Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40084",
+  "name": "Research Paper",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50060",
+  "name": "Melbourne Journal of International Law",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90189",
+  "name": "NDIS and Disability Benefits Clinic",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CREA90007",
+  "name": "Creative Arts Therapies in Education",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90099",
+  "name": "Categorical Data: Models and Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90002",
+  "name": "Presenting Academic Discourse",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90030",
+  "name": "Language Disorders Across the Lifespan",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90008",
+  "name": "Food Safety and Quality",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40032",
+  "name": "Historical Performance Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90005",
+  "name": "Thesis (Masters/coursework)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90176",
+  "name": "People and Capability",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20055",
+  "name": "Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90010",
+  "name": "Roles and Processes in Art Department",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO40003",
+  "name": "Topics in Indonesian Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70121",
+  "name": "International Commercial Arbitration",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90131",
+  "name": "Clients with Acute and Chronic Illness",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90241",
+  "name": "Representing and Remembering Place (PG)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90015",
+  "name": "Legal Issues for Business",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90285",
+  "name": "Master of Architecture Studio B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS90004",
+  "name": "Cultural Complexity and Intelligence",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10016",
+  "name": "Mathematics for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90033",
+  "name": "Neuropsychological Rehabilitation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90012",
+  "name": "Corporate Reporting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90002",
+  "name": "Supervised Reading (Asia Institute)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90008",
+  "name": "Foundations of Spatial Information",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90024",
+  "name": "Advanced Audio: Podcasting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30006",
+  "name": "Industry Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90072",
+  "name": "Landscape Studio 5:Sustainable Urbanism",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PLAN30005",
+  "name": "Urban Precinct Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ESLA90004",
+  "name": "Intercultural Professional Communication",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90294",
+  "name": "Consumer Participatory Health Technology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA40005",
+  "name": "Research Paper (Visual Art)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90091",
+  "name": "Semiconductor Devices",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90003",
+  "name": "Specialised Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN40013",
+  "name": "Censorship: Film, Art and Media",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40009",
+  "name": "Positive Political Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM10035",
+  "name": "Performance Preparation 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40010",
+  "name": "Game Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90014",
+  "name": "Managing Markets",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90019",
+  "name": "Screenwriting and Creative Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30252",
+  "name": "Performance 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40013",
+  "name": "Monetary Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90048",
+  "name": "Transport Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS20013",
+  "name": "Production Studio 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90034",
+  "name": "Marketing & Media in a Global Context",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90045",
+  "name": "Statutory Valuation (PG)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10093",
+  "name": "Vocal Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90033",
+  "name": "Mine Safety and Engineering",
+  "offered": [
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90061",
+  "name": "Mechatronics Systems Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30020",
+  "name": "Chamber Music 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90024",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI10052",
+  "name": "Agricultural Genetics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40104",
+  "name": "Dissertation Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90006",
+  "name": "Spatial Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS40023",
+  "name": "Art History Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90288",
+  "name": "Biostatistics Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT40006",
+  "name": "Honours Research Essay Accounting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90146",
+  "name": "Architectural Conservation in East Asia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90048",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM10002",
+  "name": "Exploring Biomedicine",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL20002",
+  "name": "Health Promotion 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90102",
+  "name": "Attitude and Behaviour Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90117",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90120",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90010",
+  "name": "Technology Innovation Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS40009",
+  "name": "Russian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST90033",
+  "name": "Farm Trees & Agroforestry",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN40006",
+  "name": "Chinese Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90119",
+  "name": "Design of Randomised Controlled Trials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90007",
+  "name": "Translating From English to Chinese",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL10004",
+  "name": "Knowledge Practices 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90038",
+  "name": "Advanced Clinical Practice 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUST10002",
+  "name": "Land Food and Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90042",
+  "name": "Applications of Music in Therapy B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90149",
+  "name": "Applied Instrumental and Vocal Teaching",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90062",
+  "name": "High Speed Electronics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90109",
+  "name": "Information Systems Min Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90030",
+  "name": "Advanced Discrete Mathematics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50059",
+  "name": "Legal Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "june",
+   "semester_2",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO40001",
+  "name": "Introduction to European Critical Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90060",
+  "name": "Financial Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90075",
+  "name": "Applications of Clinical Pharmacology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC30024",
+  "name": "Behaviour Change and Well-being",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90281",
+  "name": "Management Competencies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90057",
+  "name": "Communication Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90012",
+  "name": "Second Language Acquisition",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90154",
+  "name": "Professional Practice 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90034",
+  "name": "Creating Innovative Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MIIM30017",
+  "name": "Medical Microbiology: Parasitology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHRM40006",
+  "name": "Pharmacology Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CICU30012",
+  "name": "Creating Screen and Cultural Worlds",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC30021",
+  "name": "Laboratory and Computational Physics 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH30004",
+  "name": "Advanced Investigation of Human Disease",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN30015",
+  "name": "Safety and Sustainability Case Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING30001",
+  "name": "Exploring Linguistic Diversity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90008",
+  "name": "International Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90046",
+  "name": "Landscape Governance and Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AIND10005",
+  "name": "Decolonising the Landscape MultiStudio 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT20007",
+  "name": "Accounting Information: Risks & Controls",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI30014",
+  "name": "Sociology of 'Race' and Ethnicities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST30003",
+  "name": "Green Infrastructure Technologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC10004",
+  "name": "Mind, Brain and Behaviour 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND30005",
+  "name": "Gender Diversity in the Workplace",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM20007",
+  "name": "Cybercrime and Digital Criminology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS30017",
+  "name": "Veterinary Bioscience: Metabolism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90066",
+  "name": "Embedded System Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90041",
+  "name": "Programming and Software Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90051",
+  "name": "Statistical Machine Learning",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS30033",
+  "name": "Health & Disease in Wildlife Populations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90015",
+  "name": "Distributed Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90049",
+  "name": "Public /Social Policy Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20105",
+  "name": "Shakuhachi 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90053",
+  "name": "Mathematics for Economists",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90080",
+  "name": "Applied Investment Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90150",
+  "name": "Music Learning, Teaching and Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10042",
+  "name": "Baroque Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE30029",
+  "name": "Dance Lab 6: Performance Skills",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE10032",
+  "name": "Thinking through Dancing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90047",
+  "name": "Financial Markets and Instruments",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90132",
+  "name": "Transitioning to Advanced Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI20019",
+  "name": "Talking with People: Doing Interviews",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30184",
+  "name": "String Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90140",
+  "name": "Architectural Practice",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "KORE20004",
+  "name": "Korean 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS20026",
+  "name": "Politics and the Media",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA30024",
+  "name": "Performance Design Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM30002",
+  "name": "Global Criminology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM30013",
+  "name": "Marketing Communications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20123",
+  "name": "University Symphonic Ensembles 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PROP30003",
+  "name": "Design and Property Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC30019",
+  "name": "Development of the Thinking Child",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI30013",
+  "name": "Life Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG30024",
+  "name": "Africa: Environment, Development, People",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM20015",
+  "name": "Politics in the Middle East & South Asia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM30006",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC20009",
+  "name": "Personality and Social Psychology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN30008",
+  "name": "Biosystems Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL30014",
+  "name": "Italian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20222",
+  "name": "Creativity, Genius, Expertise and Talent",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG20004",
+  "name": "Market and Business Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT10001",
+  "name": "Accounting Reports and Analysis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW20027",
+  "name": "Archaeology of the Classical Greek World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG30013",
+  "name": "Strategic Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM30012",
+  "name": "Law in Social Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO30002",
+  "name": "Creative Industries in Indonesia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC30067",
+  "name": "Youth and Popular Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GDES20002",
+  "name": "Colour Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20143",
+  "name": "World Music Choir",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BTCH20002",
+  "name": "Biotechnology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HEBR30004",
+  "name": "Hebrew 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL20032",
+  "name": "Poetry, Love, and Death",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN20013",
+  "name": "Australian Film and Television",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC20002",
+  "name": "Comparative Nutrition and Digestion",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST10017",
+  "name": "Gender, Rights, & Leadership in History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20018",
+  "name": "Indonesian Politics and Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT30012",
+  "name": "Management Consulting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS20018",
+  "name": "Art, Market and Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20002",
+  "name": "Introduction to Japanese Communication",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS20025",
+  "name": "International Relations: Key Questions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20209",
+  "name": "Chinese Music Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20013",
+  "name": "Chinese 10",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30047",
+  "name": "Literature, Environment, Crisis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM20011",
+  "name": "Approaches to Media Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE20001",
+  "name": "Thinking Scientifically",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN30005",
+  "name": "Romanticism to Decadence: French Novels",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL10001",
+  "name": "Biology of Australian Flora & Fauna",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT30002",
+  "name": "Enterprise Performance Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10016",
+  "name": "Chinese 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20196",
+  "name": "Riffs: Guitar Cultures & Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS10005",
+  "name": "Ancient Greek 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC20003",
+  "name": "Topics in Animal Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH10001",
+  "name": "Foundations of Design: Representation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO30007",
+  "name": "Indonesian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS10005",
+  "name": "Media, Identity and Everyday Life",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10051",
+  "name": "Sports Coaching: Theory and Practice",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL20033",
+  "name": "Construction Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20008",
+  "name": "Drugs That Shape Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10005",
+  "name": "Being Online: Internet Meets Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20001",
+  "name": "Intermediate Macroeconomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE20003",
+  "name": "Introductory Personal Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL30003",
+  "name": "Contingencies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ERTH20001",
+  "name": "Dangerous Earth",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20009",
+  "name": "Indonesian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG10001",
+  "name": "Principles of Marketing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO10011",
+  "name": "Diversity: Identities in Indonesia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20010",
+  "name": "The First Centuries of Islam",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG30010",
+  "name": "Advertising and Promotions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30002",
+  "name": "Social Problems in Japan",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL10007",
+  "name": "Italian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10007",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN20011",
+  "name": "Chemical Process Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EVSC20007",
+  "name": "Modelling the Real World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL20036",
+  "name": "Environmental Building Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR30006",
+  "name": "Real and Artificial Neural Networks",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10002",
+  "name": "Seminar in Economics and Commerce A",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS20014",
+  "name": "Ancient Greek 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30001",
+  "name": "Stochastic Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10009",
+  "name": "Chinese Cinema",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT30004",
+  "name": "Auditing and Assurance Services",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB30001",
+  "name": "Protein Structure and Function",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT90012",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN30012",
+  "name": "Signals and Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN20001",
+  "name": "Hispanic Cultural Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20018",
+  "name": "Discrete Maths and Operations Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10004",
+  "name": "Introductory Microeconomics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM20003",
+  "name": "German Cultural Studies B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30005",
+  "name": "Advanced Chinese Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20022",
+  "name": "Group Theory and Linear Algebra",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM30004",
+  "name": "Time Series Analysis and Forecasting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR30004",
+  "name": "Complex Functions in Neuroscience",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR20005",
+  "name": "Numerical Methods in Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR90016",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN30011",
+  "name": "Electrical Device Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS30009",
+  "name": "Latin 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB30012",
+  "name": "Current Advances in Molecular Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN10008",
+  "name": "Spanish 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL10005",
+  "name": "Italian 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20003",
+  "name": "Romanticism to Decadence: French Novels",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN30006",
+  "name": "Japanese 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30026",
+  "name": "Chinese 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN10009",
+  "name": "Reading Japanese Literature",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC30008",
+  "name": "Production Animal Physiology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN10005",
+  "name": "French 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN30010",
+  "name": "Systems Modelling and Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90017",
+  "name": "Econometrics of Markets and Competition",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI40006",
+  "name": "Sociology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90023",
+  "name": "Advanced Consumer Behaviour",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90062",
+  "name": "Internship II (Year Long) Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90011",
+  "name": "Marketing Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90157",
+  "name": "Pedagogue Recital",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90316",
+  "name": "The Shaping of Urban Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90072",
+  "name": "DRFS Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90335",
+  "name": "Contract Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90558",
+  "name": "Education Research Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST90032",
+  "name": "Forests, Carbon and Climate Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50028",
+  "name": "Constitutional Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40063",
+  "name": "Honours Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90033",
+  "name": "Music Therapy Methods 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90173",
+  "name": "Health Promotion and Young People",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30166",
+  "name": "Big Band 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90065",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90035",
+  "name": "Conservation Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90017",
+  "name": "Research Project (MMS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM20031",
+  "name": "Performance Skills 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90010",
+  "name": "Strategic Performance Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS40037",
+  "name": "Classics Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10007",
+  "name": "Physics for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90041",
+  "name": "Advanced Dynamics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10197",
+  "name": "Individual Performance Studies 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90012",
+  "name": "Marketing Management for Engineers",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30160",
+  "name": "Acting for Singers 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90838",
+  "name": "Project in Clinical Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30050",
+  "name": "Minor Music Performance 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90030",
+  "name": "Melbourne History Workshop Practicum",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM40011",
+  "name": "Islamic Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90050",
+  "name": "Human Centred Mechanical Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90024",
+  "name": "Strategic Content Creation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90005",
+  "name": "Marketing Strategy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90022",
+  "name": "Advanced Seminars in Specialty 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90075",
+  "name": "Patents and Trade Secrets",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40009",
+  "name": "Genealogies of Place",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90083",
+  "name": "Cognitive Neuroscience and Disorders",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90016",
+  "name": "Taxation for Business Decision Making",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40020",
+  "name": "Australian Theatre and Performance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI40019",
+  "name": "Research Project – WH Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90113",
+  "name": "Professional Psychology Skills 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90027",
+  "name": "Geotechnical Applications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90989",
+  "name": "Capstone Professional Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90017",
+  "name": "Representation Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90020",
+  "name": "Advanced Book Publishing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM40007",
+  "name": "Econometrics of Markets and Competition",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90019",
+  "name": "Journalism Project (Extended) Part 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90077",
+  "name": "Poverty, Microfinance and Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST90077",
+  "name": "Long Research Project B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN40007",
+  "name": "Chinese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90008",
+  "name": "Consumers and Consumption",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND90011",
+  "name": "Gender and Development Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90087",
+  "name": "Paediatric Intensive Care Nursing 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS40022",
+  "name": "Politics & International Thesis Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90017",
+  "name": "Actuarial Science Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10067",
+  "name": "Guitar Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30268",
+  "name": "Interpretation Italian Lyric Repertoire",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90038",
+  "name": "Global Corporate Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90058",
+  "name": "Elements of Statistics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90238",
+  "name": "Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90013",
+  "name": "Social Policy Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM90006",
+  "name": "Analytical & Environmental Chemistry",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90081",
+  "name": "Computer Science Research Project Part 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90033",
+  "name": "Public Budgets and Financial Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA90008",
+  "name": "Asia and the World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40081",
+  "name": "Honours Chamber Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30207",
+  "name": "Vocal Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90054",
+  "name": "International Relations Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90030",
+  "name": "Managing Innovation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90070",
+  "name": "Experimental Methods in Decision Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS30009",
+  "name": "Production Practice 3 - Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN40002",
+  "name": "Honours Japanese B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90027",
+  "name": "Interdisciplinary Industry Project 2",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS40039",
+  "name": "Ancient Greek Honours Seminar 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90054",
+  "name": "Development Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90032",
+  "name": "Sustainability and Behaviour Change",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL40001",
+  "name": "Oral Health Research Project 4A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30041",
+  "name": "Industry Internship",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90034",
+  "name": "International Policymaking in Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90017",
+  "name": "Journalism Project (Extended) Part 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90376",
+  "name": "Urban Design Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40056",
+  "name": "Special Study",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90071",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40013",
+  "name": "New Script",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90034",
+  "name": "Economics of Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS40024",
+  "name": "Art History Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT10017",
+  "name": "Representation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA40005",
+  "name": "Asian Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90009",
+  "name": "HCI Project (Advanced)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90002",
+  "name": "Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90105",
+  "name": "Perioperative Complications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90029",
+  "name": "Media and Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90286",
+  "name": "Professional Practice - Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90039",
+  "name": "CPR, Eye Emergencies & Practical ECC",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG40003",
+  "name": "Indigenous Studies Thesis Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90006",
+  "name": "Environmental Research Review (12.5)",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90022",
+  "name": "Translation Industry Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90008",
+  "name": "Design Realisation and Collaboration B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20025",
+  "name": "Minor Music Performance 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90041",
+  "name": "Complex Case Models in Speech Pathology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90217",
+  "name": "Hot Topics in Public Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90029",
+  "name": "Criminology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90031",
+  "name": "Criminology & Sociology Internship Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10206",
+  "name": "Medieval and Renaissance Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT40011",
+  "name": "Oral Health Sci Research Proj Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20207",
+  "name": "Applied Aural Musicianship 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90165",
+  "name": "Social Entrepreneurship",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90017",
+  "name": "Digital Business and Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40018",
+  "name": "Topics in Contemporary Epistemology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90062",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW40007",
+  "name": "Problems in Greek Prehistory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90009",
+  "name": "Quantitative Methods for Business",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90093",
+  "name": "Agricultural Extension",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90053",
+  "name": "Industrial Systems and Simulation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND90012",
+  "name": "Gender and Development Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90192",
+  "name": "Studio Teaching 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90042",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90046",
+  "name": "Vibrations and Aeroelasticity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90067",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90001",
+  "name": "Structural Editing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40028",
+  "name": "Music and Gender",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90002",
+  "name": "Presenting Academic Discourse",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90010",
+  "name": "Spatial Information Research Project A",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90029",
+  "name": "Clinical Processes B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90030",
+  "name": "Language Disorders Across the Lifespan",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90005",
+  "name": "Thesis (Masters/coursework)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL40012",
+  "name": "Actuarial Analytics and Data II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90033",
+  "name": "Marketing Communications Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90034",
+  "name": "Research Project 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90084",
+  "name": "Quantum Software Fundamentals",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND40006",
+  "name": "Gender Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHTY90040",
+  "name": "Physiotherapy Professional Portfolio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90292",
+  "name": "M.Epidemiology Research Project - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA90012",
+  "name": "International Relations Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90285",
+  "name": "Master of Architecture Studio B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90131",
+  "name": "Clients with Acute and Chronic Illness",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90241",
+  "name": "Representing and Remembering Place (PG)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90015",
+  "name": "Legal Issues for Business",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90119",
+  "name": "Design of Randomised Controlled Trials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90289",
+  "name": "Architectural Cultures 2:After Modernism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90018",
+  "name": "Structural Dynamics and Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90006",
+  "name": "Fieldwork for Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90026",
+  "name": "Chemical Engineering Minor Research Proj",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS10010",
+  "name": "Production Studio 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90072",
+  "name": "Economics Research Report Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90018",
+  "name": "Indigenous Policy Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90054",
+  "name": "Probability and Random Models",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM40001",
+  "name": "Topics in Arabic & Islamic Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20199",
+  "name": "Practical Music 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90060",
+  "name": "Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CONS90001",
+  "name": "Management Systems for Construction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90073",
+  "name": "Minor Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90026",
+  "name": "Global Climate Change In Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90017",
+  "name": "HR Consulting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90208",
+  "name": "Construction Measurement and Estimating",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN90002",
+  "name": "Honours Chinese B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90124",
+  "name": "Statistical Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90205",
+  "name": "Health Inequalities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT40009",
+  "name": "Honours Research Essay Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS40002",
+  "name": "Indigenous Australian Art Histories",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40004",
+  "name": "Long-Run Economic Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90050",
+  "name": "IT Project and Change Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90198",
+  "name": "Professional Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOLS40002",
+  "name": "Socio-Legal Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90080",
+  "name": "Computer Science Research Project Part 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90067",
+  "name": "MSD Thesis -Semester Long (25 Points)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RURA90009",
+  "name": "Health Projects in Aboriginal Settings",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA60012",
+  "name": "Contemporary Art Practice B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10196",
+  "name": "Music Making Laboratory 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90078",
+  "name": "Internship for Agricultural Sciences",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST10016",
+  "name": "Music Theatre Studio 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90040",
+  "name": "Managing Change for IS Professionals",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90023",
+  "name": "Development Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90002",
+  "name": "Financial Statement Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90039",
+  "name": "Understanding Media & Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO40002",
+  "name": "Honours Indonesian B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC40001",
+  "name": "Current Topics in Developmental Psych.",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90033",
+  "name": "Sustainable Food: Policy and Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90148",
+  "name": "Probability and Distribution Theory",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70121",
+  "name": "International Commercial Arbitration",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS90004",
+  "name": "Cultural Complexity and Intelligence",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO40003",
+  "name": "Topics in Indonesian Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS40009",
+  "name": "Russian Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10016",
+  "name": "Mathematics for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST90033",
+  "name": "Farm Trees & Agroforestry",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN40006",
+  "name": "Chinese Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90045",
+  "name": "Statutory Valuation (PG)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10093",
+  "name": "Vocal Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90061",
+  "name": "Mechatronics Systems Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30020",
+  "name": "Chamber Music 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90024",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90038",
+  "name": "Professional Issues and Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN40010",
+  "name": "French Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90109",
+  "name": "Information Systems Min Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90045",
+  "name": "Financial Spreadsheeting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90019",
+  "name": "Internship II (Semester Long)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS70001",
+  "name": "MVSc (Clinical) Practicum # FT",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90146",
+  "name": "Architectural Conservation in East Asia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90048",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90020",
+  "name": "International Journalism - Key Skills",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC40007",
+  "name": "Arabic Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90048",
+  "name": "OMS Clinical Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90072",
+  "name": "The Art of Scientific Computation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90062",
+  "name": "Building Information Modeling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM40009",
+  "name": "Criminology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC40019",
+  "name": "HPS Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20216",
+  "name": "Medieval and Renaissance Ensemble 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90016",
+  "name": "Concrete Design and Technology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90028",
+  "name": "Discourse and Interaction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40107",
+  "name": "Capstone Music Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30049",
+  "name": "Exploring Irish Literature",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MREN90005",
+  "name": "Materials Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30227",
+  "name": "Individual Performance Studies 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HLTH90006",
+  "name": "Basics of Digital Health for Clinicians",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90037",
+  "name": "Managing for Value Creation",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50033",
+  "name": "Equity and Trusts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90418",
+  "name": "Architects in Asia, Practice & Politics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90028",
+  "name": "Monitoring Environmental Impacts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90012",
+  "name": "Managing Diversity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90099",
+  "name": "Categorical Data: Models and Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90008",
+  "name": "Food Safety and Quality",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90134",
+  "name": "Vet Bioscience: Nervous System",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40032",
+  "name": "Historical Performance Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40019",
+  "name": "Media & Communications Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90013",
+  "name": "Condensed Matter Physics 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90176",
+  "name": "People and Capability",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90023",
+  "name": "Spatial Information Research Project B",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20055",
+  "name": "Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90010",
+  "name": "Roles and Processes in Art Department",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30251",
+  "name": "Practical Music 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50058",
+  "name": "Melbourne University Law Review",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS40011",
+  "name": "Cultural Studies Now",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90040",
+  "name": "General Principles and FAST Techniques",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90266",
+  "name": "Inclusive Cities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90033",
+  "name": "Neuropsychological Rehabilitation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90056",
+  "name": "Electronic Circuit Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90008",
+  "name": "Foundations of Spatial Information",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90002",
+  "name": "Supervised Reading (Asia Institute)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20104",
+  "name": "Shakuhachi 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90014",
+  "name": "The World of Engineering Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST30060",
+  "name": "Making History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH30013",
+  "name": "The Anthropological Imagination",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90043",
+  "name": "Cryptography and Security",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30019",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MIIM30015",
+  "name": "Techniques in Immunology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE30002",
+  "name": "Science and Technology Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI30004",
+  "name": "Encounters with Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM30017",
+  "name": "Contemporary Challenges and Islam",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30007",
+  "name": "The Philosophy of Philosophy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30018",
+  "name": "Applied Research Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90199",
+  "name": "Suzuki Practicum Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CCDP10002",
+  "name": "The Electronic Arts: Vision and Sound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO40002",
+  "name": "Seminars in Languages and Linguistics A",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC20023",
+  "name": "Sex and Gender in the Sciences",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LARC10001",
+  "name": "Natural History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE10004",
+  "name": "Human Sciences: From Cells to Societies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30048",
+  "name": "Plant Breeding and Genetics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST20004",
+  "name": "Economic Tools for the Environment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20080",
+  "name": "Witch-Hunting in European Societies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90033",
+  "name": "Integrated Accounting Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90008",
+  "name": "HCI Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90049",
+  "name": "Introduction to Machine Learning",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN30003",
+  "name": "Environmental Systems Modelling & Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30003",
+  "name": "Public Affairs Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE20036",
+  "name": "Dance Lab 4: Composing while Dancing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL10011",
+  "name": "Biology: Life's Complexity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI20038",
+  "name": "Principles of Soil Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40006",
+  "name": "Public Relations and Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM40008",
+  "name": "Criminology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE30030",
+  "name": "Professional Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90026",
+  "name": "Journalism Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90031",
+  "name": "Research Studies in Optometry",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE90002",
+  "name": "Clinical Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20015",
+  "name": "Elements of Quantum Computing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90003",
+  "name": "Regulation of Biotechnology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90014",
+  "name": "Algorithms for Bioinformatics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90026",
+  "name": "Independent Study Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE30004",
+  "name": "Genetic Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10174",
+  "name": "Guitar Group 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST30003",
+  "name": "Green Infrastructure Technologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS30017",
+  "name": "Veterinary Bioscience: Metabolism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90066",
+  "name": "Embedded System Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90041",
+  "name": "Programming and Software Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90051",
+  "name": "Statistical Machine Learning",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS30033",
+  "name": "Health & Disease in Wildlife Populations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90015",
+  "name": "Distributed Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90049",
+  "name": "Public /Social Policy Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE30029",
+  "name": "Dance Lab 6: Performance Skills",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90053",
+  "name": "Mathematics for Economists",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20105",
+  "name": "Shakuhachi 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE10032",
+  "name": "Thinking through Dancing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90080",
+  "name": "Applied Investment Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90047",
+  "name": "Financial Markets and Instruments",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90150",
+  "name": "Music Learning, Teaching and Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90132",
+  "name": "Transitioning to Advanced Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI20019",
+  "name": "Talking with People: Doing Interviews",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10042",
+  "name": "Baroque Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30184",
+  "name": "String Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90140",
+  "name": "Architectural Practice",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "KORE20004",
+  "name": "Korean 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH30002",
+  "name": "Design Studio Epsilon",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS10003",
+  "name": "Introduction to Political Ideas",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10005",
+  "name": "Being Online: Internet Meets Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20001",
+  "name": "Intermediate Macroeconomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL20033",
+  "name": "Construction Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20008",
+  "name": "Drugs That Shape Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS20022",
+  "name": "Modern and Contemporary Chinese Art",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW10007",
+  "name": "Ancient Egyptian 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE20003",
+  "name": "Introductory Personal Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC20068",
+  "name": "Sport, Education and the Media",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20009",
+  "name": "Indonesian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG10001",
+  "name": "Principles of Marketing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO20018",
+  "name": "Indonesian Politics and Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ERTH20001",
+  "name": "Dangerous Earth",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL30003",
+  "name": "Contingencies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM20015",
+  "name": "Surveying and Mapping",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN30001",
+  "name": "Art Cinema and the Love Story",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN30006",
+  "name": "French Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS20018",
+  "name": "Art, Market and Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO10002",
+  "name": "Eurovisions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30039",
+  "name": "Construction Contract Administration",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHRM30009",
+  "name": "Drugs in Biomedical Experiments",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20016",
+  "name": "French and Francophone Cultural Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE20001",
+  "name": "Thinking Scientifically",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20013",
+  "name": "Chinese 10",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30047",
+  "name": "Literature, Environment, Crisis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN20010",
+  "name": "Material and Energy Balances",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN20004",
+  "name": "Chinese 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG20011",
+  "name": "Global Inequalities In The Anthropocene",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS20002",
+  "name": "Australian Art",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS20008",
+  "name": "Public Policy Making",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO30002",
+  "name": "Creative Industries in Indonesia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20225",
+  "name": "Music, Mind & Wellbeing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10016",
+  "name": "Chinese 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20196",
+  "name": "Riffs: Guitar Cultures & Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20022",
+  "name": "Indigenous Cultures and Knowledges",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC30067",
+  "name": "Youth and Popular Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GDES20002",
+  "name": "Colour Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20143",
+  "name": "World Music Choir",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CULS30005",
+  "name": "City Cultures, Urban Ecologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC10003",
+  "name": "Debating Science in Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT20001",
+  "name": "Development in the 21st Century",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20071",
+  "name": "American History: 1945 to Now",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20138",
+  "name": "Indonesian Gamelan Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC20005",
+  "name": "Arabic 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BCMB20002",
+  "name": "Biochemistry and Molecular Biology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL30004",
+  "name": "Actuarial Statistics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN30005",
+  "name": "Heat and Mass Transport Processes",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN30013",
+  "name": "Electronic System Implementation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC40013",
+  "name": "Advanced Psychological Theory & Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHRM30002",
+  "name": "Drugs Affecting the Nervous System",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS10014",
+  "name": "Latin 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS20026",
+  "name": "Latin 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CEDB30004",
+  "name": "Stem Cells in Development & Regeneration",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS20007",
+  "name": "Russian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10002",
+  "name": "Physics 2: Advanced",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS20012",
+  "name": "Global Human Rights Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN20003",
+  "name": "Spanish 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC30070",
+  "name": "Applying Coaching Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30001",
+  "name": "Classic Chinese Civilisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20132",
+  "name": "Melbourne Big Band 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20007",
+  "name": "Globalisation and the World Economy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB20014",
+  "name": "Food For a Healthy Planet II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20208",
+  "name": "Electronic Dance Music Technique",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30022",
+  "name": "Experimental Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20005",
+  "name": "Competition and Strategy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL30010",
+  "name": "Imaging Italy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20010",
+  "name": "Japanese Grammar in Action",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "KORE20002",
+  "name": "Contemporary Korea",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ERTH10002",
+  "name": "Understanding Planet Earth",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL20040",
+  "name": "Greek Philosophy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10008",
+  "name": "From the Solar System to the Cosmos",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC20004",
+  "name": "Animals and Society 2: Humans & Animals",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10005",
+  "name": "German 2",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN30017",
+  "name": "Mechanics & Materials",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30022",
+  "name": "Decision Making",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT40005",
+  "name": "Anatomy & Neurosci Research Proj Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN10004",
+  "name": "Spanish 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM30001",
+  "name": "German Cultural Studies B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT20006",
+  "name": "Principles of Human Structure",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10002",
+  "name": "Chinese 10",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30006",
+  "name": "Analysis of Contemporary Chinese Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30002",
+  "name": "Economic Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR90018",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10007",
+  "name": "Linear Algebra",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH10002",
+  "name": "Construction as Alchemy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN10008",
+  "name": "Japanese 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20008",
+  "name": "Japanese 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90018",
+  "name": "Clinical Practice in Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90113",
+  "name": "Information Systems Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90364",
+  "name": "Industry Based Research - Property",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90042",
+  "name": "Casework/Research Report 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUST20014",
+  "name": "Music Theatre Combination Skills 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90010",
+  "name": "Applied Linguistics Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90016",
+  "name": "Biological Psychology & Pharmacotherapy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL10004",
+  "name": "Oral Health Sciences 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS40036",
+  "name": "Classics Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90011",
+  "name": "Energy Efficiency Technology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90916",
+  "name": "Place Based Elective (Alternative)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90027",
+  "name": "Screen Language 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EVSC90019",
+  "name": "Graduate Seminar: Environmental Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO20004",
+  "name": "Usability Evaluation Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90028",
+  "name": "Advanced Seminars in Specialty 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90015",
+  "name": "Advanced Psychopathology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90287",
+  "name": "Architectural Technology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90093",
+  "name": "Ensemble A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90276",
+  "name": "M.Epidemiology Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90008",
+  "name": "Language Program Evaluation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90050",
+  "name": "Scheduling and Optimisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BINF90004",
+  "name": "Bioinformatics Case Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC30023",
+  "name": "Computational Behavioural Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90422",
+  "name": "SI-Lab: Scanning and Virtual Reality",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90022",
+  "name": "Computational Biomechanics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS30008",
+  "name": "Production Practice 3 - Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40012",
+  "name": "Development Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90641",
+  "name": "Identity, Equity and Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90151",
+  "name": "Music Performance Curriculum& Assessment",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90055",
+  "name": "Development Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD90007",
+  "name": "Food Processing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90018",
+  "name": "Structural Dynamics and Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40107",
+  "name": "Capstone Music Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90028",
+  "name": "Discourse and Interaction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL30049",
+  "name": "Exploring Irish Literature",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90006",
+  "name": "Fieldwork for Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50033",
+  "name": "Equity and Trusts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90418",
+  "name": "Architects in Asia, Practice & Politics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MREN90005",
+  "name": "Materials Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90028",
+  "name": "Monitoring Environmental Impacts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50047",
+  "name": "Family Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30160",
+  "name": "Acting for Singers 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90031",
+  "name": "Geography Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90838",
+  "name": "Project in Clinical Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90140",
+  "name": "Disputes and Ethics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90026",
+  "name": "Global Climate Change In Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90017",
+  "name": "HR Consulting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90238",
+  "name": "Music, Learning & Technology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "IBUS90003",
+  "name": "The Multinational",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL40002",
+  "name": "Oral Health Research Project 4B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90077",
+  "name": "Research Project Part C",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIEN90002",
+  "name": "Biochemical Engineering Design Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90080",
+  "name": "Major Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90312",
+  "name": "Cost Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90133",
+  "name": "Partial Differential Equations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90068",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90085",
+  "name": "Construction History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90045",
+  "name": "Programming Language Implementation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90021",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90100",
+  "name": "Applied Research Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90108",
+  "name": "Data Science Research Project Pt1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10004",
+  "name": "Computing for Musicians",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90396",
+  "name": "MSD Minor Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90101",
+  "name": "Veterinary Bioscience 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90102",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90019",
+  "name": "Advances in Criminological Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90065",
+  "name": "Veterinary Bioscience 2 Part B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70067",
+  "name": "International Legal Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90049",
+  "name": "Digital Business Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90315",
+  "name": "Participatory Planning",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM30001",
+  "name": "Crime and Public Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM40001",
+  "name": "Topics in Arabic & Islamic Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90012",
+  "name": "Microeconomics II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90012",
+  "name": "Managing Diversity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50031",
+  "name": "Legal Theory",
+  "offered": [
+   "semester_2",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "FOOD40002",
+  "name": "Food Science Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90057",
+  "name": "Advanced Valve and Aortic Pathology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30050",
+  "name": "Minor Music Performance 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90030",
+  "name": "Melbourne History Workshop Practicum",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90293",
+  "name": "Commercial Construction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT40003",
+  "name": "Advances in Oral Health Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90271",
+  "name": "Infectious Diseases Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90032",
+  "name": "Process Dynamics And Control",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90077",
+  "name": "Not for Profits and the Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90033",
+  "name": "Law Apps",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90027",
+  "name": "International Human Resources",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50093",
+  "name": "Insolvency Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90056",
+  "name": "Investment Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90020",
+  "name": "International Journalism - Key Skills",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC40007",
+  "name": "Arabic Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NRMT90007",
+  "name": "Communities and Ecosystem Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20210",
+  "name": "Saxophone Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90021",
+  "name": "Editing Masterclass",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90036",
+  "name": "Capstone Project A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM40005",
+  "name": "Modelling the Australian Macroeconomy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90280",
+  "name": "City Lights: Cities, Culture and History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90074",
+  "name": "Economics Thesis Workshop Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90048",
+  "name": "Transport Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90018",
+  "name": "Mobile Computing Systems Programming",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40013",
+  "name": "Monetary Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS20013",
+  "name": "Production Studio 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90004",
+  "name": "The Power of Ideas: Ten Great Books",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90416",
+  "name": "Land and Property Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV40006",
+  "name": "Research Paper (Animation)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90014",
+  "name": "Research Proposal 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90098",
+  "name": "Approximation, Algorithms and Heuristics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90012",
+  "name": "Industry Investigation Project B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST90034",
+  "name": "International Relations Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CREA90019",
+  "name": "Creative Arts Therapies Research 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90285",
+  "name": "Research Project in Public Health Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90052",
+  "name": "Advanced Materials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC40002",
+  "name": "Animal Sci & Mgt Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20179",
+  "name": "Ensemble Studies 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90140",
+  "name": "Management Competencies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90022",
+  "name": "International Internship in Environment",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM90014",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90026",
+  "name": "Solid Mechanics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40020",
+  "name": "Topics in Experimental Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10057",
+  "name": "Early Voices 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90334",
+  "name": "Minor Project in Education 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90048",
+  "name": "Advanced Case Studies Practicum",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90062",
+  "name": "Mental Health and Young People",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA60014",
+  "name": "Critical Issues in Contemporary Art B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PUBL90023",
+  "name": "Publishing and Communications Thesis Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90788",
+  "name": "Applications of Positive Psychology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH40009",
+  "name": "Anthropology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BMEN90011",
+  "name": "Tissue Engineering & Stem Cells",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGL40026",
+  "name": "English & Theatre Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90069",
+  "name": "Sexual and Reproductive Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90088",
+  "name": "Paediatric Nursing 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PLAN30005",
+  "name": "Urban Precinct Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90012",
+  "name": "Marketing Management for Engineers",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90073",
+  "name": "Minor Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90004",
+  "name": "Climate Change Politics and Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90304",
+  "name": "Flexible Urban Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV20016",
+  "name": "Animation Studio 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECOM90003",
+  "name": "Applied Microeconometric Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90009",
+  "name": "Advanced Non Fiction Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90050",
+  "name": "Human Centred Mechanical Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM40011",
+  "name": "Islamic Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90059",
+  "name": "Probability, Reliability and Quality",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90024",
+  "name": "Strategic Content Creation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90106",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90151",
+  "name": "Biostatistics Research Project - D",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90075",
+  "name": "Patents and Trade Secrets",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CWRI40009",
+  "name": "Genealogies of Place",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90072",
+  "name": "The Art of Scientific Computation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90048",
+  "name": "OMS Clinical Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90016",
+  "name": "Taxation for Business Decision Making",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90062",
+  "name": "Building Information Modeling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90128",
+  "name": "Advanced Environmental Computation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN40009",
+  "name": "Japanese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90038",
+  "name": "Haemato, Neurologic & Global Conditions",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS40007",
+  "name": "Russian Language & Culture 4B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90025",
+  "name": "Advanced Industry Practice – PR",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL40011",
+  "name": "Actuarial Studies Projects Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90084",
+  "name": "Internship for Agricultural Sciences Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POPH90231",
+  "name": "Qualitative Research in Public Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90022",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90051",
+  "name": "Civil Hydraulics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90020",
+  "name": "Additive Manufacturing of Metals",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10015",
+  "name": "Foundation Mathematics 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS40017",
+  "name": "Veterinary Clinical Skills",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM30013",
+  "name": "Land Administration Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM20002",
+  "name": "Human Structure and Function",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACUR90010",
+  "name": "Art Curatorship Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM20009",
+  "name": "Race, Ethnicity, Crime and Justice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90036",
+  "name": "Legal Drafting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DENT90040",
+  "name": "Forensic Odontology 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST40040",
+  "name": "History Thesis Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90139",
+  "name": "Veterinary Professional Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90045",
+  "name": "Vet Public Health Research Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90032",
+  "name": "Marketing Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90007",
+  "name": "Life Insurance Models 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90047",
+  "name": "Congenital,Obsetric& Medical Conditions",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING90039",
+  "name": "Concepts in Applied Linguistics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90118",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90071",
+  "name": "Offshore Geotechnical Engineering",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90100",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30230",
+  "name": "Interactive Composition 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW40017",
+  "name": "Ancient World Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ESLA90002",
+  "name": "Advanced Self-Editing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90405",
+  "name": "Energy & Carbon in the Built Environment",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCRN40009",
+  "name": "Screen Media and Political Aesthetics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI40081",
+  "name": "Honours Chamber Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA90008",
+  "name": "Asia and the World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90033",
+  "name": "Public Budgets and Financial Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30207",
+  "name": "Vocal Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90081",
+  "name": "Computer Science Research Project Part 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90027",
+  "name": "Interdisciplinary Industry Project 2",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AUDI90021",
+  "name": "Clinical Audiology A",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20178",
+  "name": "Individual Performance Studies 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS40039",
+  "name": "Ancient Greek Honours Seminar 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90032",
+  "name": "Sustainability and Behaviour Change",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ORAL40001",
+  "name": "Oral Health Research Project 4A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30041",
+  "name": "Industry Internship",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL40022",
+  "name": "Philosophy Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10011",
+  "name": "Experimental Design and Data Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20176",
+  "name": "Ensemble Studies 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90335",
+  "name": "Minor Project in Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC90012",
+  "name": "General Relativity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90006",
+  "name": "Engineering Contracts and Procurement",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90031",
+  "name": "Sustainability Reporting & Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90064",
+  "name": "Advanced Control Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90025",
+  "name": "Parallel and Multicore Computing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90233",
+  "name": "Core Skills in Opera 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90060",
+  "name": "Integrated Design - Civil",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10226",
+  "name": "Chamber Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN40007",
+  "name": "Public Policy & Management Thesis Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS90003",
+  "name": "Design Projects 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO90002",
+  "name": "Database Systems & Information Modelling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN90016",
+  "name": "Software Processes and Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90119",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SWEN90006",
+  "name": "Security & Software Testing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90032",
+  "name": "Building Services and Operations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO30008",
+  "name": "Interactive Technology Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV70047",
+  "name": "Major Screenwriting Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90032",
+  "name": "Environmental Analysis Tools",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OTOL40003",
+  "name": "Otolaryngology Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30061",
+  "name": "Landscape Studio: Designed Ecologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90238",
+  "name": "Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MEDI90088",
+  "name": "Graduate Research Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90031",
+  "name": "Project Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO90003",
+  "name": "Graduate Indonesian B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90096",
+  "name": "Thesis (Masters/coursework) Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90115",
+  "name": "Information Systems Res Project Pt 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC40018",
+  "name": "HPS Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE90070",
+  "name": "Experimental Methods in Decision Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DPSS30009",
+  "name": "Production Practice 3 - Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20081",
+  "name": "Early Voices 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90014",
+  "name": "Macroeconomics II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90155",
+  "name": "Second Instrument / Vocal Study 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10053",
+  "name": "Brass Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST90016",
+  "name": "Environmental Research Project (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS70002",
+  "name": "MVSc (Clinical) Practicum # PT",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISYS90032",
+  "name": "Emerging Technologies and Issues",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON90015",
+  "name": "Managerial Economics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS90136",
+  "name": "Veterinary Public Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90015",
+  "name": "Management of Neuro-ophthalmic Disorders",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN90019",
+  "name": "Advanced Thermodynamics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA40005",
+  "name": "Research Paper (Visual Art)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN90083",
+  "name": "Electrical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90028",
+  "name": "Criminology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO40009",
+  "name": "Indonesian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90061",
+  "name": "Internship II (Year Long) Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90003",
+  "name": "Specialised Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90164",
+  "name": "MLS Tax Clinic",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS90035",
+  "name": "Great Power Politics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "TRAN90010",
+  "name": "Translation Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90209",
+  "name": "EMA Career Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LANG40004",
+  "name": "Seminar in Languages 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACTL90011",
+  "name": "Actuarial Practice and Control II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40009",
+  "name": "Positive Political Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DRAM10035",
+  "name": "Performance Preparation 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON40010",
+  "name": "Game Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV90019",
+  "name": "Screenwriting and Creative Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30258",
+  "name": "Chamber Choir 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS30024",
+  "name": "Virtual Worlds in Japanese Art",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90094",
+  "name": "Neonatal Intensive Care 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90031",
+  "name": "Ore Reserve Estimation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEND30007",
+  "name": "Transgender Studies Terms and Debates",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI90195",
+  "name": "Professional Practice 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20087",
+  "name": "MCM Indonesian Gamelan Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90035",
+  "name": "Graduate Research Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM30003",
+  "name": "Biomedical Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM30002",
+  "name": "Perspectives in Global Media Cultures",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI20037",
+  "name": "Crop Production and Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AHIS30019",
+  "name": "Theory and Practice of Art History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PATH30003",
+  "name": "Frontiers in Human Disease",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90009",
+  "name": "Strategic Cost Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR90036",
+  "name": "Leadership for Innovation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO40002",
+  "name": "Seminars in Languages and Linguistics A",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC20023",
+  "name": "Sex and Gender in the Sciences",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENST20004",
+  "name": "Economic Tools for the Environment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90049",
+  "name": "Introduction to Machine Learning",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN30003",
+  "name": "Environmental Systems Modelling & Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "OPTO90031",
+  "name": "Research Studies in Optometry",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE90002",
+  "name": "Clinical Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90026",
+  "name": "Independent Study Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20015",
+  "name": "Elements of Quantum Computing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90003",
+  "name": "Regulation of Biotechnology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM40006",
+  "name": "Public Relations and Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30003",
+  "name": "Public Affairs Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE20036",
+  "name": "Dance Lab 4: Composing while Dancing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI20038",
+  "name": "Principles of Soil Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JOUR90026",
+  "name": "Journalism Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM40008",
+  "name": "Criminology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE30030",
+  "name": "Professional Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL10011",
+  "name": "Biology: Life's Complexity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90014",
+  "name": "Algorithms for Bioinformatics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE30004",
+  "name": "Genetic Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM30014",
+  "name": "Specialised Topics in Chemistry B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90036",
+  "name": "Foundations of Marketing & Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYS30012",
+  "name": "Physiology: Adapting to Challenges",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90083",
+  "name": "Computational Statistics & Data Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE30028",
+  "name": "Choreographic Production",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NRMT90002",
+  "name": "Biosecurity: Managing Invasive Species",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENP40001",
+  "name": "Primary Care Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30027",
+  "name": "Modern Applied Statistics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90055",
+  "name": "Nursing as Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE90025",
+  "name": "Clinical Genome Variant Analysis 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90022",
+  "name": "Commercialisation of Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FRST20015",
+  "name": "Fire in the Australian Landscape",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BOTA30005",
+  "name": "Plant Molecular Biology & Biotechnology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GENE20004",
+  "name": "Applications of Genetics and Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INFO30006",
+  "name": "Information Security and Privacy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EVSC30007",
+  "name": "Landscape Ecosystem Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN20002",
+  "name": "French 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS30005",
+  "name": "Russian Culture Through Film",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10059",
+  "name": "Performance, Potential and Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE30001",
+  "name": "Investments",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH10001",
+  "name": "Anthropology: Studying Self and Other",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDO10013",
+  "name": "Translation: Intercultural Indonesian",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL30016",
+  "name": "Knowledge and Reality",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING20010",
+  "name": "Language, Society and Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC30020",
+  "name": "The Integrated Brain",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL10003",
+  "name": "Philosophy: The Great Thinkers",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10010",
+  "name": "Generating the Wealth of Nations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT20002",
+  "name": "Intermediate Financial Accounting",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC10003",
+  "name": "Debating Science in Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT20001",
+  "name": "Development in the 21st Century",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20138",
+  "name": "Indonesian Gamelan Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA90001",
+  "name": "Human Rights in Southeast Asia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN30005",
+  "name": "Heat and Mass Transport Processes",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20029",
+  "name": "Engineering Mathematics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ELEN30013",
+  "name": "Electronic System Implementation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHRM30002",
+  "name": "Drugs Affecting the Nervous System",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS10014",
+  "name": "Latin 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS20026",
+  "name": "Latin 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CEDB30004",
+  "name": "Stem Cells in Development & Regeneration",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARBC30005",
+  "name": "Arabic 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL20001",
+  "name": "Italian Cultural Studies B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20004",
+  "name": "Japanese 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW20022",
+  "name": "History of Greece: Homer to Alexander",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ASIA10002",
+  "name": "Asian Century: Meaning and Impact",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20164",
+  "name": "Free Play New Music Improvisation Ensem",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN30018",
+  "name": "Thermodynamics and Fluid Mechanics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT30004",
+  "name": "Managing Globally",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BOTA20002",
+  "name": "Plant Biodiversity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS20007",
+  "name": "Russian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "UNIB10018",
+  "name": "Insects Shaping Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN20003",
+  "name": "Spanish 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR20003",
+  "name": "Engineering Materials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC30070",
+  "name": "Applying Coaching Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30001",
+  "name": "Classic Chinese Civilisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20132",
+  "name": "Melbourne Big Band 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30021",
+  "name": "Complex Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CONS10001",
+  "name": "Principles of Building",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10162",
+  "name": "Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10006",
+  "name": "Physics 2: Life Sciences & Environment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "RUSS30002",
+  "name": "Russian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LING10001",
+  "name": "The Secret Life of Language",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM30013",
+  "name": "Marketing Communications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20123",
+  "name": "University Symphonic Ensembles 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20135",
+  "name": "Chinese Music Ensemble 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG20004",
+  "name": "Market and Business Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT10001",
+  "name": "Accounting Reports and Analysis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST20010",
+  "name": "The First Centuries of Islam",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10007",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL20036",
+  "name": "Environmental Building Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30001",
+  "name": "Stochastic Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR30006",
+  "name": "Real and Artificial Neural Networks",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT30004",
+  "name": "Auditing and Assurance Services",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10004",
+  "name": "Physics 2: Physical Science & Technology",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL30016",
+  "name": "Italian 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM20008",
+  "name": "Terrorism: Shifting Paradigms",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE30001",
+  "name": "Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PROP20003",
+  "name": "Design and Property Industry Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC30022",
+  "name": "Trends in Personality& Social Psychology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10049",
+  "name": "Creative Projects-Digital Technologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30020",
+  "name": "Arts Internship: Not for Profit",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10002",
+  "name": "Physics 2: Advanced",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE10002",
+  "name": "Principles of Finance",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS20012",
+  "name": "Global Human Rights Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM20005",
+  "name": "German 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT20004",
+  "name": "Managing People at Work",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANTH20012",
+  "name": "Self, Culture and Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL30010",
+  "name": "Imaging Italy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANCW20003",
+  "name": "Egypt Under the Pharaohs",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20010",
+  "name": "Japanese Grammar in Action",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA10035",
+  "name": "Still Life: Nature Morte",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "KORE20002",
+  "name": "Contemporary Korea",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG20003",
+  "name": "Aboriginal Women and Coloniality",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM30013",
+  "name": "Chemical Research Project",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30009",
+  "name": "Chinese 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANSC20004",
+  "name": "Animals and Society 2: Humans & Animals",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOL30002",
+  "name": "Experimental Reproductive Physiology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHYC10008",
+  "name": "From the Solar System to the Cosmos",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10005",
+  "name": "German 2",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC40013",
+  "name": "Advanced Psychological Theory & Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MCEN30017",
+  "name": "Mechanics & Materials",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST30022",
+  "name": "Decision Making",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM30001",
+  "name": "German Cultural Studies B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ANAT20006",
+  "name": "Principles of Human Structure",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN10002",
+  "name": "Chinese 10",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHIN30006",
+  "name": "Analysis of Contemporary Chinese Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON30002",
+  "name": "Economic Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NEUR90018",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH10002",
+  "name": "Construction as Alchemy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN10008",
+  "name": "Japanese 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "JAPN20008",
+  "name": "Japanese 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90015",
+  "name": "Terror, Law and War",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90012",
+  "name": "Electrophysiological Assessment A",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90062",
+  "name": "Materials Modelling and Characterisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90002",
+  "name": "Foundations of Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90026",
+  "name": "Minor Thesis 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90141",
+  "name": "Business Analysis & Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70046",
+  "name": "Script Development Hothouse",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN90014",
+  "name": "Masters Software Engineering Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV40009",
+  "name": "Research Paper (Film and Television)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20040",
+  "name": "Enterprise Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50049",
+  "name": "Human Rights Law and Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90001",
+  "name": "Researching/Writing Stories",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90028",
+  "name": "International Relations Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE40006",
+  "name": "Finance Research Essay",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90265",
+  "name": "History of Landscape Architecture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90193",
+  "name": "Studio Teaching 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90005",
+  "name": "Interpreting Exhibitions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40013",
+  "name": "Topics in the Philosophy of Language",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40003",
+  "name": "International Trade",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90025",
+  "name": "Research Project In Geoscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90030",
+  "name": "Public Policy in the Asian Century",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC90002",
+  "name": "Graduate Arabic B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40101",
+  "name": "Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90013",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90137",
+  "name": "Veterinary Bacteriology and Mycology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90283",
+  "name": "Ecology for Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20201",
+  "name": "Performance 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90024",
+  "name": "Production Collaboration",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90397",
+  "name": "MSD Minor Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90083",
+  "name": "Computational Modelling and Simulation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90104",
+  "name": "Chronic Disease Management: Foundations",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90082",
+  "name": "Software Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90078",
+  "name": "Computer Science Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90100",
+  "name": "Recital 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JEWI30005",
+  "name": "Research in Contemporary Jewish Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30262",
+  "name": "French Lyric Diction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90042",
+  "name": "Child Neuropsychological Disorders",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90050",
+  "name": "Doppler Echocardiography",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90013",
+  "name": "Investigative Journalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90869",
+  "name": "Doctor of Education Thesis Proposal",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90902",
+  "name": "Diverse and Inclusive Classrooms (Sec)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90007",
+  "name": "Environmental Research Project (25)",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90026",
+  "name": "Marketing Metrics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10015",
+  "name": "Screenwriting Practices 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30048",
+  "name": "Architecture Design Studio: Air",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40074",
+  "name": "Music and Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40064",
+  "name": "The Research Process for Musicians",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90375",
+  "name": "Landscape Architecture Design Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH90026",
+  "name": "Climate Modelling and Climate Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90012",
+  "name": "Research Design 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90082",
+  "name": "Major Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PAED90026",
+  "name": "Cancer Care in Young People",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90082",
+  "name": "Applied Risk Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90047",
+  "name": "IE Research Project 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP30013",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA70009",
+  "name": "Studio Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG10002",
+  "name": "Landscape Information Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90071",
+  "name": "Quality Use of Medicines",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90022",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10059",
+  "name": "Conservatorium Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND90007",
+  "name": "Rethinking Rights and Global Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90136",
+  "name": "Criminal Institutions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90296",
+  "name": "Indigenous Health & History Insights",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90002",
+  "name": "Social Impact Assessment and Evaluation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90050",
+  "name": "Public /Social Policy Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70024",
+  "name": "Corporate Tax A",
+  "offered": [
+   "april",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90027",
+  "name": "Life Cycle Analysis and Sustainability",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90023",
+  "name": "Practical Earth Science B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90105",
+  "name": "Chronic Disease Management: In Practice",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90002",
+  "name": "Mathematics of Finance II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90101",
+  "name": "Obstetrics Gynaecology and Practicum",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI90018",
+  "name": "Advanced Writing Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90026",
+  "name": "Biomolecular Structure Determination",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90001",
+  "name": "Principles of Arts Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40067",
+  "name": "Honours Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90014",
+  "name": "Advanced Econometric Techniques 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90100",
+  "name": "Abdominal and Peri-Arrest Ultrasound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST10005",
+  "name": "Exploring Science and Environment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30068",
+  "name": "Design Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM10006",
+  "name": "Introduction to Media Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN90004",
+  "name": "Graduate French B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM20034",
+  "name": "Theatre Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30164",
+  "name": "Baroque Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20094",
+  "name": "Symphonic Ensembles 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90028",
+  "name": "Geography Practical",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90011",
+  "name": "Financial Econometrics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90237",
+  "name": "Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90020",
+  "name": "Environmental Industry Research (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90022",
+  "name": "Practical Earth Science A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40062",
+  "name": "Honours Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90241",
+  "name": "Theories of Inclusive Music Teaching",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90037",
+  "name": "Research in Music Therapy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT20017",
+  "name": "Landscape Design 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL40016",
+  "name": "Italian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN90002",
+  "name": "Film Production: From Script to Screen",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90236",
+  "name": "EMA Special Project (Year Long) Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90031",
+  "name": "Climate Change and Ethical Dilemmas",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND40007",
+  "name": "Gender Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20175",
+  "name": "Individual Performance Studies 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90109",
+  "name": "Data Science Research Project Pt2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40060",
+  "name": "Concerto",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90019",
+  "name": "Book Markets: Structures and Strategies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90015",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20030",
+  "name": "Studio Studies 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90043",
+  "name": "Gastrointestinal Tract Pancreas Adrenals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT40007",
+  "name": "Special Research Topics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50034",
+  "name": "Criminal Law and Procedure",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10008",
+  "name": "Screen Practice 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90009",
+  "name": "Translating from Chinese to English",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90015",
+  "name": "Journalism Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90012",
+  "name": "Collaborative Dramaturgies Project 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUST30018",
+  "name": "Production Studio 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90078",
+  "name": "Algorithmic Trading",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90048",
+  "name": "Project Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN40017",
+  "name": "Screen & Cultural Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM40016",
+  "name": "German Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90005",
+  "name": "Environmental Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40027",
+  "name": "English & Theatre Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90239",
+  "name": "Professional Practice - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90015",
+  "name": "Grattan Street Press",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90191",
+  "name": "The Research Process For Musicians (RHD)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90107",
+  "name": "Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN40007",
+  "name": "Spanish & Latin American Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90072",
+  "name": "Major Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90105",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40007",
+  "name": "Actuarial Practice and Control II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90045",
+  "name": "Engineering Project Implementation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN40008",
+  "name": "Spanish & Latin American Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM20014",
+  "name": "Visual Communication and Digital Media",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90021",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW40003",
+  "name": "Archaeology of Complex Societies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90078",
+  "name": "Structuring and Managing Patient Data",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40003",
+  "name": "Medieval Passions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90069",
+  "name": "Applications in Animal Health 2 Part B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90021",
+  "name": "Translation, Interpreting, Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90019",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40091",
+  "name": "Music Internship",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BISY90009",
+  "name": "Managing Information Technology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90011",
+  "name": "Advanced Property Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10044",
+  "name": "Plant Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90012",
+  "name": "Modelling the Australian Macroeconomy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90037",
+  "name": "MFPI Internship Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90039",
+  "name": "Executive Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN90003",
+  "name": "Graduate Japanese B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90043",
+  "name": "Gastrointestinal Tract Pancreas Adrenals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40017",
+  "name": "Practical Study 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50034",
+  "name": "Criminal Law and Procedure",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT40007",
+  "name": "Special Research Topics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90009",
+  "name": "Translating from Chinese to English",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90015",
+  "name": "Journalism Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90048",
+  "name": "Project Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUST30018",
+  "name": "Production Studio 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90078",
+  "name": "Algorithmic Trading",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90012",
+  "name": "Collaborative Dramaturgies Project 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90005",
+  "name": "Environmental Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90079",
+  "name": "Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90003",
+  "name": "Accounting Research Report",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90016",
+  "name": "Engineering Management Capstone",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90036",
+  "name": "Property Investment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90043",
+  "name": "Enterprise Applications & Architectures",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90191",
+  "name": "Treaty: Indigenous-settler Agreements",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90035",
+  "name": "Landscape Documentation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90035",
+  "name": "International Relations Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30051",
+  "name": "Minor Music Performance 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90018",
+  "name": "Biomedical Engineering Capstone Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90202",
+  "name": "Foundations in Qualitative Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90176",
+  "name": "Landscape Studio 2: Site and Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90148",
+  "name": "Consulting Fundamentals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LANG40003",
+  "name": "Seminar in Languages 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90039",
+  "name": "Clinical Training in Music Therapy 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90005",
+  "name": "Life Contingencies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90156",
+  "name": "Performing to Teach 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90024",
+  "name": "Adv Clinical Practice in Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90089",
+  "name": "Rural Critical Care Nursing 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10046",
+  "name": "Foundations of Agricultural Sciences 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90029",
+  "name": "Vet Public Health Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS10005",
+  "name": "Artefact and Performance 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90022",
+  "name": "Photojournalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90040",
+  "name": "Mathematics of Spatial Information",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS40010",
+  "name": "Russian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90002",
+  "name": "Managing in Asia",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90066",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90020",
+  "name": "Global Media: Theory and Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90389",
+  "name": "Urban Design Studio C",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90042",
+  "name": "Liver, Spleen and Sampling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90018",
+  "name": "The Economics of Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90018",
+  "name": "Film Craft",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90020",
+  "name": "Minor Thesis 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90064",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM40007",
+  "name": "Change in Journalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90207",
+  "name": "Management & Marketing Special Topics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90028",
+  "name": "Arts Management Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC10002",
+  "name": "Animal Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90057",
+  "name": "Education Capstone Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90016",
+  "name": "Principles of Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90093",
+  "name": "Economic Evaluation 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90081",
+  "name": "Business Process Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90027",
+  "name": "Arts Management Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90126",
+  "name": "Advanced Statistical Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90021",
+  "name": "Topics in Insurance and Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90010",
+  "name": "Strategic Human Resources",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90010",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90402",
+  "name": "Design Strategies of Asian Gardens",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90890",
+  "name": "3-8 Year-Olds Learning and Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50029",
+  "name": "Contracts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90022",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10221",
+  "name": "Practical Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90058",
+  "name": "Construction Engineering",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90094",
+  "name": "Managing Innovation and Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUST10015",
+  "name": "Music Theatre Contextual Studies 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VISM40009",
+  "name": "Visual Media: Experimental Projects",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90358",
+  "name": "Research in Construction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90024",
+  "name": "New Writing Dramaturgy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90065",
+  "name": "Exactly Solvable Models",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90197",
+  "name": "Consumer Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90011",
+  "name": "Bioenvironmental Engineering",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90331",
+  "name": "ICT in Building",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90057",
+  "name": "Advanced Theoretical Computer Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10051",
+  "name": "Genetics for Agriculture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN40011",
+  "name": "French Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90015",
+  "name": "English Phonetics and Phonology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM30031",
+  "name": "Performance Skills 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90012",
+  "name": "Trade Policy Politics & Governance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70023",
+  "name": "Narrative Projects 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90013",
+  "name": "Labour Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90036",
+  "name": "Advanced Clinical Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI40015",
+  "name": "Biomedicine Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90056",
+  "name": "IE Research Project 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH40011",
+  "name": "Critical Anthropological Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PADM90004",
+  "name": "Public Administration Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90016",
+  "name": "Journalism Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20212",
+  "name": "Practical Anatomy for Classical Voice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10006",
+  "name": "Introductory Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20011",
+  "name": "Gaming and the Writer",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90030",
+  "name": "Geography Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90035",
+  "name": "Steel and Composite Structures Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HLTH90020",
+  "name": "Digital Health Information Services",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90931",
+  "name": "Education Research Design Part 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90117",
+  "name": "Twenty-first Century Architecture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90075",
+  "name": "Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90016",
+  "name": "International Financial Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP60002",
+  "name": "Preventive Health Care",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30019",
+  "name": "Chamber Music 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90049",
+  "name": "Principles of Ultrasound Heart Scan",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90031",
+  "name": "Energy Systems Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20013",
+  "name": "Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG40004",
+  "name": "Indigenous Studies Thesis Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90013",
+  "name": "Communication for Research Scientists",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM30038",
+  "name": "Professional Practice Theatre 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90048",
+  "name": "Managing ICT Infrastructure",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN90007",
+  "name": "Software Design and Architecture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90026",
+  "name": "Fundamentals of Information Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90072",
+  "name": "Engineering Project Implementation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90282",
+  "name": "Strategic Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90039",
+  "name": "Creating Innovative Professionals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90021",
+  "name": "Critical Communication for Engineers",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90041",
+  "name": "Engineering Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN30020",
+  "name": "Systems Modelling and Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM30001",
+  "name": "Frontiers in Biomedicine",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90937",
+  "name": "International Issues in Arts Education",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90041",
+  "name": "Engineering Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90033",
+  "name": "Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN30021",
+  "name": "Mechanical Systems Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN30020",
+  "name": "Systems Modelling and Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS10003",
+  "name": "The World in Twenty Art Works",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30034",
+  "name": "Applied Data Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN90004",
+  "name": "Graduate Spanish B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL20003",
+  "name": "Stochastic Techniques in Insurance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM30001",
+  "name": "Frontiers in Biomedicine",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL30006",
+  "name": "Intermediate Financial Mathematics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90062",
+  "name": "Capstone Studies in Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90039",
+  "name": "Pharmaceutical & Biochemical Production",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS30018",
+  "name": "Veterinary Bioscience:Respiratory System",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUST10017",
+  "name": "The Art of Working Online",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LARC30002",
+  "name": "Interpreting Australian Landscape Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH40007",
+  "name": "Clinical Path Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90007",
+  "name": "Information Visualisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90038",
+  "name": "Algorithms and Complexity",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM20035",
+  "name": "Theatre Skills 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM10006",
+  "name": "Chemistry for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI30005",
+  "name": "Sociology Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20036",
+  "name": "Ecology and Grazing Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP20008",
+  "name": "Elements of Data Processing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC30002",
+  "name": "Animal Disease Biotechnology 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI90019",
+  "name": "Advanced Creative Writing Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90005",
+  "name": "Technical Writing and Editing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30024",
+  "name": "Condensed Matter Physics 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90012",
+  "name": "Science Communication",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90072",
+  "name": "Advanced Nursing Practice in Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90022",
+  "name": "Advanced Clinical Genomics 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90005",
+  "name": "Genomics in Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10069",
+  "name": "String Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90424",
+  "name": "Introduction to High-Performance Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA30004",
+  "name": "Vegetation Management and Conservation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90006",
+  "name": "Writing and Editing for Digital Media",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90002",
+  "name": "Metabolomics and Proteomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM10026",
+  "name": "Up Close and Personal with MTC",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20028",
+  "name": "Architecture Design Studio: Water",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS10009",
+  "name": "AI, Ethics and the Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20004",
+  "name": "French Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20034",
+  "name": "The Theatre Experience",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS20006",
+  "name": "Contemporary Political Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20041",
+  "name": "Phenomenology and Existentialism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN10002",
+  "name": "Japanese 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GDES30003",
+  "name": "Graphic Design Studio 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10017",
+  "name": "Our Planet, Our Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR10002",
+  "name": "Hebrew 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN20019",
+  "name": "Spanish 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10005",
+  "name": "Quantitative Methods 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20190",
+  "name": "Advanced Recording Studio Techniques",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30057",
+  "name": "Asia Pacific Modernities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CONS20002",
+  "name": "Measurement of Building Designs",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10023",
+  "name": "The Making of Melbourne",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10222",
+  "name": "The Wellbeing Orchestra",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10023",
+  "name": "Music Language 1: the Diatonic World",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20028",
+  "name": "Architecture Design Studio: Water",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS10009",
+  "name": "AI, Ethics and the Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20004",
+  "name": "French Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30003",
+  "name": "Japanese Through Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PROP10001",
+  "name": "Economics and Cities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB20018",
+  "name": "Going Places - Travelling Smarter",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI30001",
+  "name": "Novels",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20163",
+  "name": "Samba Band",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NUTR20001",
+  "name": "Food Nutrition and Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN30009",
+  "name": "Structural Theory and Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30008",
+  "name": "Japanese 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GDES30003",
+  "name": "Graphic Design Studio 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10003",
+  "name": "Physics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30017",
+  "name": "Australian Indigenous Public Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30003",
+  "name": "Japanese Through Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PROP10001",
+  "name": "Economics and Cities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CULS20017",
+  "name": "Gender and Contemporary Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10005",
+  "name": "Quantitative Methods 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10010",
+  "name": "Making Movies 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20034",
+  "name": "The Theatre Experience",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS20006",
+  "name": "Contemporary Political Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CONS20002",
+  "name": "Measurement of Building Designs",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10023",
+  "name": "The Making of Melbourne",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10222",
+  "name": "The Wellbeing Orchestra",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10023",
+  "name": "Music Language 1: the Diatonic World",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR20004",
+  "name": "Engineering Mechanics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AIND20011",
+  "name": "Indigenous Art and Changing the Nation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL30003",
+  "name": "Sedimentary Geology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG20002",
+  "name": "Indigenous Environmental Heritage",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS30024",
+  "name": "Public Trials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM20008",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20041",
+  "name": "The Figure in Performance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD30009",
+  "name": "Food Research & Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM20006",
+  "name": "Punishment and Social Control",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BLAW30002",
+  "name": "Taxation Law I",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW30004",
+  "name": "Beyond Babylon",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA30002",
+  "name": "Plant Evolution",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR10006",
+  "name": "Hebrew 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30003",
+  "name": "Agricultural Systems Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL20010",
+  "name": "Italian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL30052",
+  "name": "Race and Gender: Philosophical Issues",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA30000",
+  "name": "Business Judgement",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20005",
+  "name": "Statistics",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH30001",
+  "name": "Design Studio Delta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM30003",
+  "name": "Medical and Applied Immunology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20080",
+  "name": "School Experience as Breadth",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10006",
+  "name": "Calculus 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS20008",
+  "name": "Human Physiology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20174",
+  "name": "The Laptop Recording Studio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20053",
+  "name": "Construction of Concrete Buildings",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM10002",
+  "name": "Islam and Modernity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE30005",
+  "name": "Human and Medical Genetics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS20013",
+  "name": "Health Law, Ethics and Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10020",
+  "name": "Refugees, Borders, Nationalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20011",
+  "name": "Reading Japanese Literature",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30011",
+  "name": "Sub-atomic Physics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20070",
+  "name": "Learning via Sport and Outdoor Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PROP30002",
+  "name": "Sustainable Management of Design Assets",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM20019",
+  "name": "Practical Chemistry 2",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR90015",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN20005",
+  "name": "Foundations of Electrical Networks",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC20007",
+  "name": "Arabic 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM10002",
+  "name": "German 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30026",
+  "name": "Metric and Hilbert Spaces",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30270",
+  "name": "Topics in Musicology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC10002",
+  "name": "Arabic 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP20005",
+  "name": "Engineering Computation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30003",
+  "name": "Chinese News Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30033",
+  "name": "Statistical Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL10010",
+  "name": "Italian 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10005",
+  "name": "Calculus 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10010",
+  "name": "Data Analysis 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10021",
+  "name": "Calculus 2: Advanced",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT30001",
+  "name": "Financial Accounting Theory",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM30012",
+  "name": "Integrated Spatial Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN10003",
+  "name": "French 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20004",
+  "name": "Probability",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20026",
+  "name": "Advanced Chinese Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR90017",
+  "name": "Project in Neuroscience",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP30026",
+  "name": "Models of Computation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT30008",
+  "name": "Viscera and Visceral Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30028",
+  "name": "Chinese 10",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN10002",
+  "name": "Spanish 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10004",
+  "name": "Chinese 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20026",
+  "name": "Real Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO30019",
+  "name": "Translation: Intercultural Indonesian",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HLTH90011",
+  "name": "Research Project in Human Genomics 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB40010",
+  "name": "Biochemistry Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10018",
+  "name": "Chinese 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CEDB30003",
+  "name": "Developmental Biology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN20002",
+  "name": "Anatomy & Physiology for Bioengineering",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS30001",
+  "name": "Industry Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "WELF90008",
+  "name": "Genetic Counselling Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90010",
+  "name": "Quantitative Analysis of Finance II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90019",
+  "name": "International Trade",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90052",
+  "name": "Practice in Diverse Communities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90191",
+  "name": "The Research Process For Musicians (RHD)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90102",
+  "name": "Linear Regression",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90138",
+  "name": "Veterinary Parasitology B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90013",
+  "name": "Finance and Budgeting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90114",
+  "name": "Information Systems Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90228",
+  "name": "Managing Growth and Pathways to Market",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90235",
+  "name": "EMA Special Project (Year Long) Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90073",
+  "name": "Laboratory Rotation 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90213",
+  "name": "Commercial Data Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC30001",
+  "name": "Arabic in Context 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20022",
+  "name": "Modernism and Avant Garde",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP20003",
+  "name": "Algorithms and Data Structures",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH20003",
+  "name": "Past Climates: Icehouse to Greenhouse",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN30009",
+  "name": "Electrical Network Analysis and Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHRM20001",
+  "name": "Pharmacology: How Drugs Work",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30008",
+  "name": "Managing Sustainably",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30040",
+  "name": "Measurement of Building Works",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30009",
+  "name": "Macroeconomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BLAW10002",
+  "name": "Free Speech and Media Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30003",
+  "name": "Industrial Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR20008",
+  "name": "Hebrew 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE10002",
+  "name": "Korean 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10007",
+  "name": "Introduction to Climate Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM30014",
+  "name": "Medical Microbiology: Virology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC20015",
+  "name": "Special Relativity and Electromagnetism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30046",
+  "name": "Music Language 3: Modern Directions",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30011",
+  "name": "Environmental Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10021",
+  "name": "Interactive Art Media 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM30012",
+  "name": "Analytical & Environmental Chemistry",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BISY90009",
+  "name": "Managing Information Technology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40001",
+  "name": "Actuarial Studies Research Essay",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90085",
+  "name": "Communicating Current Issues in Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90044",
+  "name": "Research Methods",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90033",
+  "name": "Quantitative Analysis of Finance I",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90011",
+  "name": "Particle Physics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90006",
+  "name": "Audiences and the Arts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90140",
+  "name": "Animal Production Systems: Applications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90016",
+  "name": "Research Project (MMS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90138",
+  "name": "Multivariate Statistics for Data Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90106",
+  "name": "Post-op Quality of Recovery Practicum",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90042",
+  "name": "Special Studies in Food",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90016",
+  "name": "The United Nations: Review and Reform",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90030",
+  "name": "Chemical Engineering Minor Thesis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20032",
+  "name": "Critical and Theoretical Studies 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90003",
+  "name": "Mobility, Culture and Communication",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90009",
+  "name": "Advertising and Communications Strategy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90054",
+  "name": "Ultrasound Guided Procedures",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90191",
+  "name": "Treaty: Indigenous-settler Agreements",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90035",
+  "name": "Landscape Documentation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90035",
+  "name": "International Relations Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA90013",
+  "name": "International Relations Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90018",
+  "name": "Biomedical Engineering Capstone Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90202",
+  "name": "Foundations in Qualitative Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30051",
+  "name": "Minor Music Performance 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LANG40003",
+  "name": "Seminar in Languages 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90039",
+  "name": "Clinical Training in Music Therapy 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90148",
+  "name": "Consulting Fundamentals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90176",
+  "name": "Landscape Studio 2: Site and Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90005",
+  "name": "Life Contingencies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10046",
+  "name": "Foundations of Agricultural Sciences 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90029",
+  "name": "Vet Public Health Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90089",
+  "name": "Rural Critical Care Nursing 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90156",
+  "name": "Performing to Teach 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS10005",
+  "name": "Artefact and Performance 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90024",
+  "name": "Adv Clinical Practice in Specialty 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90025",
+  "name": "Environmental Industry Research (25)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS40010",
+  "name": "Russian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90079",
+  "name": "Health IT Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90059",
+  "name": "Advanced Echocardiography Interpretation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90022",
+  "name": "Photojournalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90040",
+  "name": "Mathematics of Spatial Information",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20113",
+  "name": "Vocal Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20202",
+  "name": "Performance 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90035",
+  "name": "Music Therapy Methods 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90125",
+  "name": "Bayesian Statistical Learning",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90051",
+  "name": "Impact of Digitisation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90059",
+  "name": "Veterinary Bioscience 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90135",
+  "name": "Vet Bioscience: Reproduction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA90007",
+  "name": "Perspectives in Art & Cultural Theory 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR90009",
+  "name": "Performance and Community Engagement",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90019",
+  "name": "Research Project (MMS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90079",
+  "name": "Computer Science Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90087",
+  "name": "Sustainable Investment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40076",
+  "name": "Musics of the World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90035",
+  "name": "Biosignal Processing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90060",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR10005",
+  "name": "Statics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40025",
+  "name": "Global Crime Narratives",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90005",
+  "name": "Information Architecture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40074",
+  "name": "Music and Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40064",
+  "name": "The Research Process for Musicians",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90375",
+  "name": "Landscape Architecture Design Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH90026",
+  "name": "Climate Modelling and Climate Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90012",
+  "name": "Research Design 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90082",
+  "name": "Major Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PAED90026",
+  "name": "Cancer Care in Young People",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90082",
+  "name": "Applied Risk Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90047",
+  "name": "IE Research Project 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP30013",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA70009",
+  "name": "Studio Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG10002",
+  "name": "Landscape Information Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90071",
+  "name": "Quality Use of Medicines",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90022",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10059",
+  "name": "Conservatorium Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90049",
+  "name": "Marketing, Society and Sustainability",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90009",
+  "name": "Global Crisis Reporting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90045",
+  "name": "Interpretivist Research in Music Therapy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM20030",
+  "name": "Performance Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN90003",
+  "name": "Graduate Japanese B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90052",
+  "name": "Practice in Diverse Communities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90228",
+  "name": "Managing Growth and Pathways to Market",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90235",
+  "name": "EMA Special Project (Year Long) Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90073",
+  "name": "Laboratory Rotation 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90102",
+  "name": "Linear Regression",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90213",
+  "name": "Commercial Data Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90138",
+  "name": "Veterinary Parasitology B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90013",
+  "name": "Finance and Budgeting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90114",
+  "name": "Information Systems Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90191",
+  "name": "The Research Process For Musicians (RHD)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90107",
+  "name": "Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN40007",
+  "name": "Spanish & Latin American Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90072",
+  "name": "Major Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90105",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40007",
+  "name": "Actuarial Practice and Control II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90045",
+  "name": "Engineering Project Implementation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN40008",
+  "name": "Spanish & Latin American Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM20014",
+  "name": "Visual Communication and Digital Media",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90021",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW40003",
+  "name": "Archaeology of Complex Societies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90152",
+  "name": "Bower Studio - Community Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30250",
+  "name": "Practical Music 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90030",
+  "name": "Criminology & Sociology Internship Pt 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL10002",
+  "name": "Society and Health 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90197",
+  "name": "Professional Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90118",
+  "name": "Applications in Animal Health B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90029",
+  "name": "Graduate Research Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90046",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90002",
+  "name": "Neural Information Processing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90922",
+  "name": "Place Based Elective (International)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90005",
+  "name": "Remote Sensing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30044",
+  "name": "Industry Partner project Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40102",
+  "name": "Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90110",
+  "name": "Information Systems Min Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI40013",
+  "name": "Research Project - SVHM Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20184",
+  "name": "Music Making Laboratory 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90058",
+  "name": "Applications of Echocardiography",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90033",
+  "name": "Satellite Positioning Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90001",
+  "name": "Issues in Art Conservation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90032",
+  "name": "Applied Syndicate Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT40007",
+  "name": "Special Research Topics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50034",
+  "name": "Criminal Law and Procedure",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10008",
+  "name": "Screen Practice 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90009",
+  "name": "Translating from Chinese to English",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90015",
+  "name": "Journalism Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90012",
+  "name": "Collaborative Dramaturgies Project 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUST30018",
+  "name": "Production Studio 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90078",
+  "name": "Algorithmic Trading",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90048",
+  "name": "Project Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN40017",
+  "name": "Screen & Cultural Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM40016",
+  "name": "German Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90005",
+  "name": "Environmental Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40027",
+  "name": "English & Theatre Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90239",
+  "name": "Professional Practice - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90015",
+  "name": "Grattan Street Press",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90036",
+  "name": "Property Investment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90325",
+  "name": "Prefabrication in Building",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90046",
+  "name": "Treasury Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIEN90003",
+  "name": "Biochemical Engineering Minor Thesis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30253",
+  "name": "Performance 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90014",
+  "name": "Advanced Econometric Techniques 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90100",
+  "name": "Abdominal and Peri-Arrest Ultrasound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN90004",
+  "name": "Graduate French B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM10006",
+  "name": "Introduction to Media Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40067",
+  "name": "Honours Composition 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST10005",
+  "name": "Exploring Science and Environment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30164",
+  "name": "Baroque Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM20034",
+  "name": "Theatre Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90011",
+  "name": "Financial Econometrics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90237",
+  "name": "Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20094",
+  "name": "Symphonic Ensembles 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90028",
+  "name": "Geography Practical",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90241",
+  "name": "Theories of Inclusive Music Teaching",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90020",
+  "name": "Environmental Industry Research (50)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90022",
+  "name": "Practical Earth Science A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40062",
+  "name": "Honours Chamber Music 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90037",
+  "name": "Research in Music Therapy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT20017",
+  "name": "Landscape Design 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL40016",
+  "name": "Italian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN90002",
+  "name": "Film Production: From Script to Screen",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90236",
+  "name": "EMA Special Project (Year Long) Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND40007",
+  "name": "Gender Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90031",
+  "name": "Climate Change and Ethical Dilemmas",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90109",
+  "name": "Data Science Research Project Pt2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC90026",
+  "name": "Modelling Species Distributions & Niches",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20175",
+  "name": "Individual Performance Studies 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90032",
+  "name": "Operations and Process Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90056",
+  "name": "Advanced Anatomy and Doppler Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30213",
+  "name": "Composition 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90026",
+  "name": "Transcultural Communication at Work",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90090",
+  "name": "Public Transport Network Planning",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90019",
+  "name": "Data Analytics in Insurance 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90055",
+  "name": "Control Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH40010",
+  "name": "Anthropology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90131",
+  "name": "Internship II",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90027",
+  "name": "Ecosystem Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH30005",
+  "name": "Design Visualisation: Digital Techniques",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90018",
+  "name": "Managing Behaviour in Organisations",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90047",
+  "name": "Aerospace Propulsion",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90034",
+  "name": "Sustainable Food Production",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90290",
+  "name": "Fundamentals of Built Environment Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10009",
+  "name": "Screen Culture 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90031",
+  "name": "Speech Disorders Across the Lifespan",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30018",
+  "name": "Critical and Theoretical Studies 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90003",
+  "name": "Introduction to Action Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90002",
+  "name": "Managing in Asia",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90118",
+  "name": "Applied Architectural Technology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC90012",
+  "name": "Trust, Communication and Expertise",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90066",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90040",
+  "name": "Nutrition Politics and Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20026",
+  "name": "Minor Music Performance 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90020",
+  "name": "Global Media: Theory and Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90017",
+  "name": "Environmental Policy Instruments",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90042",
+  "name": "Liver, Spleen and Sampling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90389",
+  "name": "Urban Design Studio C",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10019",
+  "name": "Animation Studio 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91030",
+  "name": "Research in Educational Relationships",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90018",
+  "name": "Film Craft",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90064",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90018",
+  "name": "The Economics of Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS40025",
+  "name": "Key Debates in Political Science 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90045",
+  "name": "Political Economy of Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90640",
+  "name": "Diversity, Inclusion and Transitions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL90004",
+  "name": "Graduate Italian B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90035",
+  "name": "Plant Food Products",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90003",
+  "name": "Public Relations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90015",
+  "name": "English Phonetics and Phonology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM30031",
+  "name": "Performance Skills 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90008",
+  "name": "Microeconometrics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90021",
+  "name": "Director, Actor and Text",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH40011",
+  "name": "Critical Anthropological Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90056",
+  "name": "IE Research Project 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90016",
+  "name": "Journalism Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20011",
+  "name": "Gaming and the Writer",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10006",
+  "name": "Introductory Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90019",
+  "name": "Consumerism and the Growth Economy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90141",
+  "name": "Machine Learning for Biostatistics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90200",
+  "name": "Suzuki Practicum Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI40016",
+  "name": "Creative Writing Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10048",
+  "name": "Plant Production Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS40019",
+  "name": "The Book: Late Antiquity to Renaissance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40021",
+  "name": "Philosophy Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90011",
+  "name": "Directed Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90021",
+  "name": "Research Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN40018",
+  "name": "Screen & Cultural Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90194",
+  "name": "Instrumental Pedagogy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING40015",
+  "name": "LAL Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90054",
+  "name": "AI Planning for Autonomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10061",
+  "name": "Symphonic Ensembles 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90408",
+  "name": "Professional Practice & Seminar Sec 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90035",
+  "name": "Steel and Composite Structures Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90030",
+  "name": "Geography Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90931",
+  "name": "Education Research Design Part 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90117",
+  "name": "Twenty-first Century Architecture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90075",
+  "name": "Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90006",
+  "name": "Scientists,Communication & the Workplace",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90152",
+  "name": "Second Instrument / Vocal Study 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90020",
+  "name": "Engineering Management Capstone",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI40007",
+  "name": "Sociology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90153",
+  "name": "Professional Practice 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90923",
+  "name": "Place Based Elective (Rural / Remote)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN40011",
+  "name": "French Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE40009",
+  "name": "Advanced Derivative Securities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20224",
+  "name": "Music and Gender",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90016",
+  "name": "International Financial Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP60002",
+  "name": "Preventive Health Care",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90048",
+  "name": "Managing ICT Infrastructure",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN90007",
+  "name": "Software Design and Architecture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90072",
+  "name": "Engineering Project Implementation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90282",
+  "name": "Strategic Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90207",
+  "name": "Management & Marketing Special Topics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90028",
+  "name": "Arts Management Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC10002",
+  "name": "Animal Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90012",
+  "name": "Modelling the Australian Macroeconomy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90057",
+  "name": "Education Capstone Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90027",
+  "name": "Arts Management Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90021",
+  "name": "Topics in Insurance and Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90126",
+  "name": "Advanced Statistical Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90010",
+  "name": "Strategic Human Resources",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VISM40009",
+  "name": "Visual Media: Experimental Projects",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10221",
+  "name": "Practical Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90358",
+  "name": "Research in Construction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUST10015",
+  "name": "Music Theatre Contextual Studies 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10051",
+  "name": "Genetics for Agriculture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90018",
+  "name": "Internship I (Placement Only)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90059",
+  "name": "Commercial Law in Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90048",
+  "name": "Landscape Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG40004",
+  "name": "Indigenous Studies Thesis Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90013",
+  "name": "Communication for Research Scientists",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM30038",
+  "name": "Professional Practice Theatre 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM30020",
+  "name": "Islam and Democracy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20108",
+  "name": "MCM Chinese Music Ensemble",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90937",
+  "name": "International Issues in Arts Education",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90039",
+  "name": "Creating Innovative Professionals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90021",
+  "name": "Critical Communication for Engineers",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90041",
+  "name": "Engineering Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90033",
+  "name": "Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN30021",
+  "name": "Mechanical Systems Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN30020",
+  "name": "Systems Modelling and Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS10003",
+  "name": "The World in Twenty Art Works",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50055",
+  "name": "Advocacy",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE20037",
+  "name": "Digital Dance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30046",
+  "name": "Agronomy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ZOOL30009",
+  "name": "Tropical Field Ecology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90061",
+  "name": "Communication Networks",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN30009",
+  "name": "Introduction to Biomaterials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90008",
+  "name": "Video Journalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90004",
+  "name": "New Media: Harnessing Digital Disruption",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90024",
+  "name": "Frontiers in Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90018",
+  "name": "Corporate Financial Policy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO30007",
+  "name": "Visual Neuroscience",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90107",
+  "name": "Data Science Project Pt2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20092",
+  "name": "String Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH10003",
+  "name": "Geology For Engineers",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN30001",
+  "name": "Environmental Eng Systems Capstone",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20070",
+  "name": "Baroque Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BTCH90005",
+  "name": "Advanced Molecular Biology Techniques",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30040",
+  "name": "Measurement of Building Works",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30009",
+  "name": "Macroeconomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BLAW10002",
+  "name": "Free Speech and Media Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI90019",
+  "name": "Advanced Creative Writing Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90072",
+  "name": "Advanced Nursing Practice in Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90005",
+  "name": "Genomics in Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90022",
+  "name": "Advanced Clinical Genomics 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI30005",
+  "name": "Sociology Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30024",
+  "name": "Condensed Matter Physics 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10069",
+  "name": "String Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90424",
+  "name": "Introduction to High-Performance Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA30004",
+  "name": "Vegetation Management and Conservation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90006",
+  "name": "Writing and Editing for Digital Media",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90002",
+  "name": "Metabolomics and Proteomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM10026",
+  "name": "Up Close and Personal with MTC",
+  "offered": [
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10003",
+  "name": "Physics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM30003",
+  "name": "Islam and Ethics: Doctrines and Debates",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30017",
+  "name": "Australian Indigenous Public Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20034",
+  "name": "The Theatre Experience",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS20006",
+  "name": "Contemporary Political Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20041",
+  "name": "Phenomenology and Existentialism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN10002",
+  "name": "Japanese 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GDES30003",
+  "name": "Graphic Design Studio 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10017",
+  "name": "Our Planet, Our Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR10002",
+  "name": "Hebrew 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN20019",
+  "name": "Spanish 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10005",
+  "name": "Quantitative Methods 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20190",
+  "name": "Advanced Recording Studio Techniques",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30057",
+  "name": "Asia Pacific Modernities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CONS20002",
+  "name": "Measurement of Building Designs",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10023",
+  "name": "The Making of Melbourne",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10222",
+  "name": "The Wellbeing Orchestra",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10023",
+  "name": "Music Language 1: the Diatonic World",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20028",
+  "name": "Architecture Design Studio: Water",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS10009",
+  "name": "AI, Ethics and the Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20004",
+  "name": "French Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30003",
+  "name": "Japanese Through Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PROP10001",
+  "name": "Economics and Cities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CULS20017",
+  "name": "Gender and Contemporary Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10010",
+  "name": "Making Movies 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20044",
+  "name": "The Ethics of Capitalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT10002",
+  "name": "Principles of Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL30005",
+  "name": "Applied Geophysics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD20006",
+  "name": "Food Microbiology and Safety",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30008",
+  "name": "Managing Sustainably",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO10006",
+  "name": "Indonesian 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20023",
+  "name": "American Classics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN30001",
+  "name": "Gender in Hispanic Cultures",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM30004",
+  "name": "Media Futures and New Technologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10014",
+  "name": "Philosophy, Politics and Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20008",
+  "name": "Ethical Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL30006",
+  "name": "Economic Geology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT20005",
+  "name": "Business Decision Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC30002",
+  "name": "Problem Solving in Environmental Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20022",
+  "name": "Modernism and Avant Garde",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP20003",
+  "name": "Algorithms and Data Structures",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH20003",
+  "name": "Past Climates: Icehouse to Greenhouse",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30013",
+  "name": "Japanese Grammar in Action",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN20003",
+  "name": "Political Leadership",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10179",
+  "name": "Making Music For Film And Animation 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST30064",
+  "name": "Controversies in Australian History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD30010",
+  "name": "Functional Foods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20025",
+  "name": "The House of Fiction: Literary Realism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10021",
+  "name": "Ancient Greek 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHRM20001",
+  "name": "Pharmacology: How Drugs Work",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH20002",
+  "name": "Design Studio Gamma",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN30004",
+  "name": "Film Noir: History and Sexuality",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST30010",
+  "name": "Hitler's Germany and Fascism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS20005",
+  "name": "Russian 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING30002",
+  "name": "Phonology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30011",
+  "name": "Environmental Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM30012",
+  "name": "Analytical & Environmental Chemistry",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CREA10001",
+  "name": "Contemporary Art and Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20053",
+  "name": "Construction of Concrete Buildings",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10021",
+  "name": "Interactive Art Media 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20061",
+  "name": "Music Language 2: Chromaticism & Beyond",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN20003",
+  "name": "Object Oriented Software Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20174",
+  "name": "The Laptop Recording Studio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM10002",
+  "name": "Islam and Modernity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20017",
+  "name": "French 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10054",
+  "name": "Drawing, Painting and Sensory Knowing",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30011",
+  "name": "Sub-atomic Physics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE30005",
+  "name": "Human and Medical Genetics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN20002",
+  "name": "Anatomy & Physiology for Bioengineering",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS30001",
+  "name": "Industry Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS30024",
+  "name": "Public Trials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM20008",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20041",
+  "name": "The Figure in Performance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD30009",
+  "name": "Food Research & Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM20006",
+  "name": "Punishment and Social Control",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BLAW30002",
+  "name": "Taxation Law I",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW30004",
+  "name": "Beyond Babylon",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA30002",
+  "name": "Plant Evolution",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI30001",
+  "name": "Novels",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL30052",
+  "name": "Race and Gender: Philosophical Issues",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA30000",
+  "name": "Business Judgement",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH30001",
+  "name": "Design Studio Delta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN30009",
+  "name": "Structural Theory and Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC10001",
+  "name": "Wonders Of The Weather",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING20006",
+  "name": "Syntax",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30030",
+  "name": "American Politics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30026",
+  "name": "East Timor Field Class",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ZOOL20006",
+  "name": "Comparative Animal Physiology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM20002",
+  "name": "German 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30022",
+  "name": "Global Environmental Politics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30019",
+  "name": "Behavioural Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN30015",
+  "name": "Spanish 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO30003",
+  "name": "European Modernism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON20003",
+  "name": "Quantitative Methods 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST30059",
+  "name": "Race in the Americas",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE20005",
+  "name": "Corporate Financial Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC10002",
+  "name": "Arabic 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP20005",
+  "name": "Engineering Computation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10005",
+  "name": "Calculus 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10010",
+  "name": "Data Analysis 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30003",
+  "name": "Chinese News Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT30001",
+  "name": "Financial Accounting Theory",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30033",
+  "name": "Statistical Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM30012",
+  "name": "Integrated Spatial Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN10003",
+  "name": "French 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20026",
+  "name": "Advanced Chinese Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10018",
+  "name": "Chinese 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20026",
+  "name": "Real Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST30004",
+  "name": "Nature, Conservation and Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH20003",
+  "name": "Experimental Pathology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "WELF90005",
+  "name": "Principles of Counselling 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS20031",
+  "name": "Latin 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90173",
+  "name": "Health Promotion and Young People",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90033",
+  "name": "Music Therapy Methods 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90227",
+  "name": "Orchestral Performance Practicum 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90086",
+  "name": "Computer Vision",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30166",
+  "name": "Big Band 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90065",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90017",
+  "name": "Representation Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90016",
+  "name": "Digital Politics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40068",
+  "name": "Honours Composition 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30261",
+  "name": "Medieval and Renaissance Ensemble 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI90015",
+  "name": "Creative Writing Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90989",
+  "name": "Capstone Professional Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90055",
+  "name": "International Relations Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90063",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50084",
+  "name": "Construction Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL90042",
+  "name": "Time",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90017",
+  "name": "Research Project (MMS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM20031",
+  "name": "Performance Skills 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90173",
+  "name": "Advanced Planting Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90130",
+  "name": "Internship I",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90035",
+  "name": "Conservation Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90359",
+  "name": "Research Practicum in Construction",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM40007",
+  "name": "Econometrics of Markets and Competition",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL40011",
+  "name": "Research Project - RMH Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90020",
+  "name": "Advanced Book Publishing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90019",
+  "name": "Journalism Project (Extended) Part 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90016",
+  "name": "Actuarial Science Research Report Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30182",
+  "name": "Guitar Ensemble 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10017",
+  "name": "Fundamentals of Mathematics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40088",
+  "name": "Integrated Musical Practice 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI90016",
+  "name": "Creative Writing Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90030",
+  "name": "Project Evaluation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS20012",
+  "name": "Production Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90017",
+  "name": "Journalism Project (Extended) Part 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN40007",
+  "name": "Chinese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90008",
+  "name": "Consumers and Consumption",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM30036",
+  "name": "Theatre Practice 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM30013",
+  "name": "Land Administration Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90015",
+  "name": "Human Resource Fundamentals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS90004",
+  "name": "The Print Room",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90022",
+  "name": "Healthy Communities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90164",
+  "name": "EMA Special Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20017",
+  "name": "Screenwriting Practices 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90020",
+  "name": "Business of Producing 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90064",
+  "name": "Industry Core and Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90005",
+  "name": "Advanced Derivative Securities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RADI90012",
+  "name": "Radiology Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90076",
+  "name": "Short Research Project B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90031",
+  "name": "Corporate Real Estate Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90046",
+  "name": "Research Project 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90045",
+  "name": "Microeconomics 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM20002",
+  "name": "Human Structure and Function",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90010",
+  "name": "Art Curatorship Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90021",
+  "name": "Editing Masterclass",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20210",
+  "name": "Saxophone Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40105",
+  "name": "Dissertation Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50028",
+  "name": "Constitutional Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CREA90012",
+  "name": "Creative Arts Therapies in Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI40019",
+  "name": "Research Project – WH Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90035",
+  "name": "Integrated Marketing Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MREN90004",
+  "name": "Ceramics and Brittle Materials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90053",
+  "name": "Industrial Systems and Simulation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90327",
+  "name": "Procurement Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30263",
+  "name": "Jazz & Improv Composition Workshop",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS40002",
+  "name": "Indigenous Australian Art Histories",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40028",
+  "name": "Music and Gender",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90010",
+  "name": "Spatial Information Research Project A",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90029",
+  "name": "Clinical Processes B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40012",
+  "name": "Actuarial Analytics and Data II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90033",
+  "name": "Marketing Communications Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90034",
+  "name": "Research Project 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90084",
+  "name": "Quantum Software Fundamentals",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90023",
+  "name": "Spatial Information Research Project B",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90013",
+  "name": "Condensed Matter Physics 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHTY90040",
+  "name": "Physiotherapy Professional Portfolio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90292",
+  "name": "M.Epidemiology Research Project - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND40006",
+  "name": "Gender Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA90012",
+  "name": "International Relations Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90148",
+  "name": "Probability and Distribution Theory",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90077",
+  "name": "Poverty, Microfinance and Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90077",
+  "name": "Long Research Project B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90084",
+  "name": "Fintech: Foundations and Applications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90011",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90376",
+  "name": "Urban Design Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40056",
+  "name": "Special Study",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90034",
+  "name": "Economics of Finance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90058",
+  "name": "Elements of Statistics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI40013",
+  "name": "New Script",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90009",
+  "name": "HCI Project (Advanced)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90002",
+  "name": "Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90382",
+  "name": "Urban and Cultural Heritage Minor Thesis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40111",
+  "name": "Honours Music Studies 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90017",
+  "name": "Science and Technology Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM40004",
+  "name": "Financial Econometrics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN40008",
+  "name": "Japanese Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90558",
+  "name": "Education Research Design",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90032",
+  "name": "Forests, Carbon and Climate Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20207",
+  "name": "Applied Aural Musicianship 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90061",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90017",
+  "name": "Digital Business and Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40018",
+  "name": "Topics in Contemporary Epistemology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90062",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90093",
+  "name": "Agricultural Extension",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND90012",
+  "name": "Gender and Development Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90192",
+  "name": "Studio Teaching 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20056",
+  "name": "Composition 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90042",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PAED40005",
+  "name": "Paediatrics Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90042",
+  "name": "Social Media and Viral Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RURA90009",
+  "name": "Health Projects in Aboriginal Settings",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10196",
+  "name": "Music Making Laboratory 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90078",
+  "name": "Internship for Agricultural Sciences",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90111",
+  "name": "Genetic Epidemiology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50096",
+  "name": "Media Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA60012",
+  "name": "Contemporary Art Practice B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM40017",
+  "name": "German Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90334",
+  "name": "Minor Project in Education 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90036",
+  "name": "Cardiovascular & Respiratory Emergencies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90048",
+  "name": "Advanced Case Studies Practicum",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90188",
+  "name": "Music and Health Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90741",
+  "name": "Effective Clinical Teaching",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90231",
+  "name": "Qualitative Research in Public Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90025",
+  "name": "Advanced Industry Practice – PR",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70333",
+  "name": "Taxation of Trusts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90170",
+  "name": "Adolescent Health Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90013",
+  "name": "Professional Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RADI90018",
+  "name": "Diagnostic Radiology 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90031",
+  "name": "Applied High Performance Computing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN90029",
+  "name": "Water and Waste Water Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90019",
+  "name": "Advanced Thermodynamics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUST20015",
+  "name": "Music Theatre Studio 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90026",
+  "name": "History, Memory and Violence in Asia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90010",
+  "name": "Translation Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI40015",
+  "name": "Creative Writing Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LANG40004",
+  "name": "Seminar in Languages 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90011",
+  "name": "Actuarial Practice and Control II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90018",
+  "name": "Mobile Computing Systems Programming",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20013",
+  "name": "Animation Lab 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90133",
+  "name": "Partial Differential Equations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIEN90002",
+  "name": "Biochemical Engineering Design Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90080",
+  "name": "Major Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90068",
+  "name": "Computer Science Research Project Pt3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90037",
+  "name": "Russia and the World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90108",
+  "name": "Data Science Research Project Pt1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90098",
+  "name": "Approximation, Algorithms and Heuristics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90012",
+  "name": "Industry Investigation Project B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90023",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90057",
+  "name": "Manufacturing Automation and IT",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE30003",
+  "name": "Science Research Project Abroad",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90052",
+  "name": "Advanced Materials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC40002",
+  "name": "Animal Sci & Mgt Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90140",
+  "name": "Management Competencies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20179",
+  "name": "Ensemble Studies 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90022",
+  "name": "International Internship in Environment",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90019",
+  "name": "Advances in Criminological Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90104",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC40001",
+  "name": "Current Topics in Developmental Psych.",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90033",
+  "name": "Sustainable Food: Policy and Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90053",
+  "name": "Electronic System Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND90011",
+  "name": "Gender and Development Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS40022",
+  "name": "Politics & International Thesis Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90017",
+  "name": "Actuarial Science Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90032",
+  "name": "Advanced Linguistics Analysis B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90004",
+  "name": "Marketing Management",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30255",
+  "name": "Applied Aural Musicianship 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90082",
+  "name": "Clinical Skills in Neuropsychology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS40024",
+  "name": "Art History Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT10017",
+  "name": "Representation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA40005",
+  "name": "Asian Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90046",
+  "name": "3-D Echocardiography & New Technologies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90028",
+  "name": "Sensory Evaluation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90105",
+  "name": "Perioperative Complications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90029",
+  "name": "Media and Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90006",
+  "name": "Environmental Research Review (12.5)",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMSC40008",
+  "name": "Medical Biology Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90037",
+  "name": "Positive Political Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90028",
+  "name": "Criminology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO40009",
+  "name": "Indonesian Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90061",
+  "name": "Internship II (Year Long) Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30214",
+  "name": "Composition 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90209",
+  "name": "EMA Career Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30015",
+  "name": "Independent Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90051",
+  "name": "Ventricular Function",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90068",
+  "name": "Prevention and Control of STIs and HIV",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90007",
+  "name": "Internet Technologies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR40007",
+  "name": "Research Paper (Music Theatre)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90108",
+  "name": "Information Systems Maj Res Project Pt 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI40010",
+  "name": "Contemporary Eco-Fictions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90004",
+  "name": "The Power of Ideas: Ten Great Books",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV40006",
+  "name": "Research Paper (Animation)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90312",
+  "name": "Cost Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10004",
+  "name": "Computing for Musicians",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90396",
+  "name": "MSD Minor Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90101",
+  "name": "Veterinary Bioscience 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH40006",
+  "name": "Population Health Research Project 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90102",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90281",
+  "name": "Housing Markets, Policy and Planning",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90362",
+  "name": "Research Thesis - Property",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90023",
+  "name": "International Business Journalism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90032",
+  "name": "Research Design 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90026",
+  "name": "Solid Mechanics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90014",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40020",
+  "name": "Topics in Experimental Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10057",
+  "name": "Early Voices 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30037",
+  "name": "Architecture Design Studio: Fire",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90076",
+  "name": "Industry Internship",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90061",
+  "name": "Urban Design Studio A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM20003",
+  "name": "Internet Communication",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90275",
+  "name": "Population & Global Mental Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT40010",
+  "name": "Oral Health Sci Research Proj Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40089",
+  "name": "Integrated Musical Practice 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91029",
+  "name": "Understanding the Student as Learner",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90084",
+  "name": "Internship for Agricultural Sciences Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90022",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40011",
+  "name": "Actuarial Studies Projects Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP40003",
+  "name": "Research Paper (Social Practice)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90024",
+  "name": "Advanced Audio: Podcasting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30006",
+  "name": "Industry Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90072",
+  "name": "Landscape Studio 5:Sustainable Urbanism",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PLAN30005",
+  "name": "Urban Precinct Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ESLA90004",
+  "name": "Intercultural Professional Communication",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90294",
+  "name": "Consumer Participatory Health Technology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA40005",
+  "name": "Research Paper (Visual Art)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90091",
+  "name": "Semiconductor Devices",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90003",
+  "name": "Specialised Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN40013",
+  "name": "Censorship: Film, Art and Media",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40009",
+  "name": "Positive Political Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM10035",
+  "name": "Performance Preparation 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40010",
+  "name": "Game Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90014",
+  "name": "Managing Markets",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90019",
+  "name": "Screenwriting and Creative Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30252",
+  "name": "Performance 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40013",
+  "name": "Monetary Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90048",
+  "name": "Transport Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS20013",
+  "name": "Production Studio 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90034",
+  "name": "Marketing & Media in a Global Context",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90045",
+  "name": "Statutory Valuation (PG)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10093",
+  "name": "Vocal Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90033",
+  "name": "Mine Safety and Engineering",
+  "offered": [
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90061",
+  "name": "Mechatronics Systems Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30020",
+  "name": "Chamber Music 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90024",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10052",
+  "name": "Agricultural Genetics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40104",
+  "name": "Dissertation Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90006",
+  "name": "Spatial Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS40023",
+  "name": "Art History Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90288",
+  "name": "Biostatistics Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT40006",
+  "name": "Honours Research Essay Accounting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90146",
+  "name": "Architectural Conservation in East Asia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90048",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM10002",
+  "name": "Exploring Biomedicine",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL20002",
+  "name": "Health Promotion 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90102",
+  "name": "Attitude and Behaviour Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90117",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90120",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90010",
+  "name": "Technology Innovation Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90126",
+  "name": "Vet Bioscience: Respiratory System",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90035",
+  "name": "Great Power Politics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90022",
+  "name": "Publishing and Communications Thesis Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90021",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90034",
+  "name": "B2B Electronic Commerce",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL20004",
+  "name": "Oral Health Sciences 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND30007",
+  "name": "Transgender Studies Terms and Debates",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90195",
+  "name": "Professional Practice 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20087",
+  "name": "MCM Indonesian Gamelan Ensemble 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90035",
+  "name": "Graduate Research Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90036",
+  "name": "Leadership for Innovation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM30003",
+  "name": "Biomedical Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM30002",
+  "name": "Perspectives in Global Media Cultures",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20037",
+  "name": "Crop Production and Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL30003",
+  "name": "Case Studies In Computational Biology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS30019",
+  "name": "Theory and Practice of Art History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH30003",
+  "name": "Frontiers in Human Disease",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90059",
+  "name": "Introduction to Programming",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90009",
+  "name": "Strategic Cost Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI10003",
+  "name": "Inequalities: Challenges for the Future",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90012",
+  "name": "Second Language Acquisition",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90154",
+  "name": "Professional Practice 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90034",
+  "name": "Creating Innovative Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM30017",
+  "name": "Medical Microbiology: Parasitology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHRM40006",
+  "name": "Pharmacology Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CICU30012",
+  "name": "Creating Screen and Cultural Worlds",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30021",
+  "name": "Laboratory and Computational Physics 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH30004",
+  "name": "Advanced Investigation of Human Disease",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN30015",
+  "name": "Safety and Sustainability Case Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING30001",
+  "name": "Exploring Linguistic Diversity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90008",
+  "name": "International Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90046",
+  "name": "Landscape Governance and Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AIND10005",
+  "name": "Decolonising the Landscape MultiStudio 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT20007",
+  "name": "Accounting Information: Risks & Controls",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI30014",
+  "name": "Sociology of 'Race' and Ethnicities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST30003",
+  "name": "Green Infrastructure Technologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC10004",
+  "name": "Mind, Brain and Behaviour 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND30005",
+  "name": "Gender Diversity in the Workplace",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM20007",
+  "name": "Cybercrime and Digital Criminology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90081",
+  "name": "Applied Research Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30022",
+  "name": "Theoretical Physics 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM30014",
+  "name": "Specialised Topics in Chemistry B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS30012",
+  "name": "Physiology: Adapting to Challenges",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90083",
+  "name": "Computational Statistics & Data Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90025",
+  "name": "Clinical Genome Variant Analysis 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST20015",
+  "name": "Fire in the Australian Landscape",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA30005",
+  "name": "Plant Molecular Biology & Biotechnology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE20004",
+  "name": "Applications of Genetics and Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC30007",
+  "name": "Landscape Ecosystem Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10039",
+  "name": "Australia in the Wine World",
+  "offered": [
+   "february",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN20014",
+  "name": "Ensemble Filmmaking, Art and Industry",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30007",
+  "name": "Derivative Securities",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20206",
+  "name": "The Business of Music",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10223",
+  "name": "Sound in Performance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30017",
+  "name": "Statistical Physics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10059",
+  "name": "Performance, Potential and Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20010",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR20006",
+  "name": "Hebrew 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PLAN10002",
+  "name": "Introduction to Urban Planning",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS20026",
+  "name": "Politics and the Media",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30024",
+  "name": "Performance Design Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM30002",
+  "name": "Global Criminology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM30013",
+  "name": "Marketing Communications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20123",
+  "name": "University Symphonic Ensembles 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PROP30003",
+  "name": "Design and Property Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30019",
+  "name": "Development of the Thinking Child",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI30013",
+  "name": "Life Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30024",
+  "name": "Africa: Environment, Development, People",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM20015",
+  "name": "Politics in the Middle East & South Asia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM30006",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC20009",
+  "name": "Personality and Social Psychology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN30008",
+  "name": "Biosystems Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL30014",
+  "name": "Italian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20222",
+  "name": "Creativity, Genius, Expertise and Talent",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG20004",
+  "name": "Market and Business Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT10001",
+  "name": "Accounting Reports and Analysis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20027",
+  "name": "Archaeology of the Classical Greek World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG30013",
+  "name": "Strategic Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM30012",
+  "name": "Law in Social Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO30002",
+  "name": "Creative Industries in Indonesia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC30067",
+  "name": "Youth and Popular Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GDES20002",
+  "name": "Colour Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20143",
+  "name": "World Music Choir",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BTCH20002",
+  "name": "Biotechnology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR30004",
+  "name": "Hebrew 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20032",
+  "name": "Poetry, Love, and Death",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN20013",
+  "name": "Australian Film and Television",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC20002",
+  "name": "Comparative Nutrition and Digestion",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST10017",
+  "name": "Gender, Rights, & Leadership in History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20018",
+  "name": "Indonesian Politics and Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30012",
+  "name": "Management Consulting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS20018",
+  "name": "Art, Market and Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20002",
+  "name": "Introduction to Japanese Communication",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS20025",
+  "name": "International Relations: Key Questions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20209",
+  "name": "Chinese Music Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20013",
+  "name": "Chinese 10",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL30047",
+  "name": "Literature, Environment, Crisis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM20011",
+  "name": "Approaches to Media Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE20001",
+  "name": "Thinking Scientifically",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN30005",
+  "name": "Romanticism to Decadence: French Novels",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL10001",
+  "name": "Biology of Australian Flora & Fauna",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT30002",
+  "name": "Enterprise Performance Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10016",
+  "name": "Chinese 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20196",
+  "name": "Riffs: Guitar Cultures & Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10005",
+  "name": "Ancient Greek 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC20003",
+  "name": "Topics in Animal Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH10001",
+  "name": "Foundations of Design: Representation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO30007",
+  "name": "Indonesian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CULS10005",
+  "name": "Media, Identity and Everyday Life",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10051",
+  "name": "Sports Coaching: Theory and Practice",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20033",
+  "name": "Construction Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB20008",
+  "name": "Drugs That Shape Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10005",
+  "name": "Being Online: Internet Meets Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON20001",
+  "name": "Intermediate Macroeconomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE20003",
+  "name": "Introductory Personal Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL30003",
+  "name": "Contingencies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH20001",
+  "name": "Dangerous Earth",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20009",
+  "name": "Indonesian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG10001",
+  "name": "Principles of Marketing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO10011",
+  "name": "Diversity: Identities in Indonesia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20010",
+  "name": "The First Centuries of Islam",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG30010",
+  "name": "Advertising and Promotions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30002",
+  "name": "Social Problems in Japan",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL10007",
+  "name": "Italian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM10007",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN20011",
+  "name": "Chemical Process Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC20007",
+  "name": "Modelling the Real World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20036",
+  "name": "Environmental Building Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR30006",
+  "name": "Real and Artificial Neural Networks",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10002",
+  "name": "Seminar in Economics and Commerce A",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS20014",
+  "name": "Ancient Greek 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30001",
+  "name": "Stochastic Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10009",
+  "name": "Chinese Cinema",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT30004",
+  "name": "Auditing and Assurance Services",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB30001",
+  "name": "Protein Structure and Function",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90012",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN30012",
+  "name": "Signals and Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN20001",
+  "name": "Hispanic Cultural Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20018",
+  "name": "Discrete Maths and Operations Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM20002",
+  "name": "Microbes, Infections and Responses",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB40011",
+  "name": "Biochemistry Research Project Part 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30021",
+  "name": "Psychological Science: Theory & Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS10002",
+  "name": "Russian 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL20009",
+  "name": "Italian Cultural Studies A",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30261",
+  "name": "Medieval and Renaissance Ensemble 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90063",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90055",
+  "name": "International Relations Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI90015",
+  "name": "Creative Writing Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL90042",
+  "name": "Time",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30182",
+  "name": "Guitar Ensemble 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10017",
+  "name": "Fundamentals of Mathematics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90011",
+  "name": "Geography Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90084",
+  "name": "Fintech: Foundations and Applications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90004",
+  "name": "Marketing Management",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90007",
+  "name": "Social Computing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90891",
+  "name": "Becoming a Clinical Practitioner (EC)",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA60010",
+  "name": "Studio Materials and Methods B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI90005",
+  "name": "Social Research Design and Evaluation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90144",
+  "name": "The Teacher as Conductor",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN10007",
+  "name": "French 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO30018",
+  "name": "Diversity: Identities in Indonesia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA20001",
+  "name": "Visualisation and Data Wrangling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90013",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN10004",
+  "name": "Japanese 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30028",
+  "name": "Numerical Methods & Scientific Computing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR30005",
+  "name": "Developmental Neurobiology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20021",
+  "name": "Analysis of Contemporary Chinese Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANAT90014",
+  "name": "Project in Anatomy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30030",
+  "name": "Topics in Asian Economic History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20007",
+  "name": "Indonesian 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR30004",
+  "name": "Numerical Algorithms in Engineering",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90013",
+  "name": "Theory of Financial Accounting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM90023",
+  "name": "Applied Dramaturgy 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST40037",
+  "name": "The Long History of Globalisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90384",
+  "name": "MUP Studio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90360",
+  "name": "MUCH Heritage Industry Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90025",
+  "name": "People and Change",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90020",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30173",
+  "name": "Early Voices 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90010",
+  "name": "Strategic Performance Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40037",
+  "name": "Classics Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10007",
+  "name": "Physics for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90041",
+  "name": "Advanced Dynamics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10197",
+  "name": "Individual Performance Studies 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90012",
+  "name": "Marketing Management for Engineers",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30160",
+  "name": "Acting for Singers 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90838",
+  "name": "Project in Clinical Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30050",
+  "name": "Minor Music Performance 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90030",
+  "name": "Melbourne History Workshop Practicum",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM40011",
+  "name": "Islamic Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90050",
+  "name": "Human Centred Mechanical Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90024",
+  "name": "Strategic Content Creation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90005",
+  "name": "Marketing Strategy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90022",
+  "name": "Advanced Seminars in Specialty 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90075",
+  "name": "Patents and Trade Secrets",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI40009",
+  "name": "Genealogies of Place",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90083",
+  "name": "Cognitive Neuroscience and Disorders",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90016",
+  "name": "Taxation for Business Decision Making",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40020",
+  "name": "Australian Theatre and Performance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI40019",
+  "name": "Research Project – WH Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90113",
+  "name": "Professional Psychology Skills 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90027",
+  "name": "Geotechnical Applications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90989",
+  "name": "Capstone Professional Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90017",
+  "name": "Representation Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90020",
+  "name": "Advanced Book Publishing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM40007",
+  "name": "Econometrics of Markets and Competition",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90019",
+  "name": "Journalism Project (Extended) Part 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90077",
+  "name": "Poverty, Microfinance and Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90077",
+  "name": "Long Research Project B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN40007",
+  "name": "Chinese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90008",
+  "name": "Consumers and Consumption",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND90011",
+  "name": "Gender and Development Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90087",
+  "name": "Paediatric Intensive Care Nursing 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS40022",
+  "name": "Politics & International Thesis Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90017",
+  "name": "Actuarial Science Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10067",
+  "name": "Guitar Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30268",
+  "name": "Interpretation Italian Lyric Repertoire",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90038",
+  "name": "Global Corporate Governance",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90058",
+  "name": "Elements of Statistics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90238",
+  "name": "Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI90013",
+  "name": "Social Policy Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM90006",
+  "name": "Analytical & Environmental Chemistry",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90081",
+  "name": "Computer Science Research Project Part 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90033",
+  "name": "Public Budgets and Financial Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA90008",
+  "name": "Asia and the World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40081",
+  "name": "Honours Chamber Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30207",
+  "name": "Vocal Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90054",
+  "name": "International Relations Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90030",
+  "name": "Managing Innovation",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90070",
+  "name": "Experimental Methods in Decision Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS30009",
+  "name": "Production Practice 3 - Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN40002",
+  "name": "Honours Japanese B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90027",
+  "name": "Interdisciplinary Industry Project 2",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40039",
+  "name": "Ancient Greek Honours Seminar 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90054",
+  "name": "Development Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90032",
+  "name": "Sustainability and Behaviour Change",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL40001",
+  "name": "Oral Health Research Project 4A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30041",
+  "name": "Industry Internship",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90034",
+  "name": "International Policymaking in Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW40018",
+  "name": "The Roman Countryside",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC40012",
+  "name": "Models of Psychological Processes",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90048",
+  "name": "B2B Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90012",
+  "name": "General Relativity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90036",
+  "name": "Biofluid Mechanics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC40002",
+  "name": "Honours Arabic B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90045",
+  "name": "Vet Public Health Research Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90025",
+  "name": "Parallel and Multicore Computing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90032",
+  "name": "Marketing Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90047",
+  "name": "Congenital,Obsetric& Medical Conditions",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10226",
+  "name": "Chamber Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90060",
+  "name": "Integrated Design - Civil",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN40007",
+  "name": "Public Policy & Management Thesis Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70047",
+  "name": "Major Screenwriting Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10049",
+  "name": "Animal Production Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ESLA90002",
+  "name": "Advanced Self-Editing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90405",
+  "name": "Energy & Carbon in the Built Environment",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN40009",
+  "name": "Screen Media and Political Aesthetics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90088",
+  "name": "Graduate Research Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90031",
+  "name": "Project Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90041",
+  "name": "Complex Case Models in Speech Pathology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90217",
+  "name": "Hot Topics in Public Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90029",
+  "name": "Criminology Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90031",
+  "name": "Criminology & Sociology Internship Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10206",
+  "name": "Medieval and Renaissance Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT40011",
+  "name": "Oral Health Sci Research Proj Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20207",
+  "name": "Applied Aural Musicianship 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90165",
+  "name": "Social Entrepreneurship",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90017",
+  "name": "Digital Business and Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40018",
+  "name": "Topics in Contemporary Epistemology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90062",
+  "name": "Computer Science Research Project Pt1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW40007",
+  "name": "Problems in Greek Prehistory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90009",
+  "name": "Quantitative Methods for Business",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90093",
+  "name": "Agricultural Extension",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90053",
+  "name": "Industrial Systems and Simulation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND90012",
+  "name": "Gender and Development Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90192",
+  "name": "Studio Teaching 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90042",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90046",
+  "name": "Vibrations and Aeroelasticity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90067",
+  "name": "Computer Science Research Project Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90056",
+  "name": "Riemann Surfaces and Complex Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90104",
+  "name": "A First Course In Statistical Learning",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20090",
+  "name": "Guitar Ensemble 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90006",
+  "name": "Engineering Contracts and Procurement",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90031",
+  "name": "Sustainability Reporting & Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50126",
+  "name": "Sustainability Business Clinic",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30002",
+  "name": "Studio Studies 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC90012",
+  "name": "Advanced Dynamical Meteorology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90064",
+  "name": "Advanced Control Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90233",
+  "name": "Core Skills in Opera 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI40003",
+  "name": "Understanding The Life Course",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING40006",
+  "name": "Linguistic Field Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90007",
+  "name": "Life Insurance Models 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90008",
+  "name": "Fluid Dynamics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90039",
+  "name": "Concepts in Applied Linguistics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS90003",
+  "name": "Design Projects 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90002",
+  "name": "Database Systems & Information Modelling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20214",
+  "name": "Chamber Choir 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40041",
+  "name": "Latin Honours Seminar 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90090",
+  "name": "Health Program Evaluation 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90289",
+  "name": "Architectural Cultures 2:After Modernism",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90018",
+  "name": "Structural Dynamics and Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90006",
+  "name": "Fieldwork for Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90026",
+  "name": "Chemical Engineering Minor Research Proj",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS10010",
+  "name": "Production Studio 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90072",
+  "name": "Economics Research Report Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI90018",
+  "name": "Indigenous Policy Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90054",
+  "name": "Probability and Random Models",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM40001",
+  "name": "Topics in Arabic & Islamic Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20199",
+  "name": "Practical Music 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90060",
+  "name": "Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CONS90001",
+  "name": "Management Systems for Construction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90073",
+  "name": "Minor Research Project Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90026",
+  "name": "Global Climate Change In Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90017",
+  "name": "HR Consulting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90208",
+  "name": "Construction Measurement and Estimating",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN90002",
+  "name": "Honours Chinese B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90124",
+  "name": "Statistical Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90205",
+  "name": "Health Inequalities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT40009",
+  "name": "Honours Research Essay Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40008",
+  "name": "Labour Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90102",
+  "name": "Vessels Nerves Lungs and Musculoskeletal",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90076",
+  "name": "Research Project Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40108",
+  "name": "Capstone Music Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50093",
+  "name": "Insolvency Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90004",
+  "name": "Time Series Analysis and Forecasting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NRMT90007",
+  "name": "Communities and Ecosystem Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10194",
+  "name": "Interactive Composition 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20072",
+  "name": "Big Band 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20008",
+  "name": "Screenwriting 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90204",
+  "name": "Leading for Strategic Advantage",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90291",
+  "name": "Indigenous Health in a Global Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA90009",
+  "name": "Perspectives in Art & Cultural Theory 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90002",
+  "name": "Independent Study",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40016",
+  "name": "Practical Study 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40017",
+  "name": "Mathematics for Economists",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING40016",
+  "name": "LAL Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90306",
+  "name": "MUP Independent Study",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10193",
+  "name": "Contextual Studies 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD40002",
+  "name": "Food Science Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90004",
+  "name": "Climate Change Politics and Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90304",
+  "name": "Flexible Urban Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20016",
+  "name": "Animation Studio 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90057",
+  "name": "Advanced Valve and Aortic Pathology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40080",
+  "name": "Honours Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL40002",
+  "name": "Oral Health Research Project 4B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90077",
+  "name": "Research Project Part C",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90206",
+  "name": "Management & Marketing Special Topics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90003",
+  "name": "The Multinational",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90293",
+  "name": "Commercial Construction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT40003",
+  "name": "Advances in Oral Health Research",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90271",
+  "name": "Infectious Diseases Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90106",
+  "name": "Research Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90059",
+  "name": "Probability, Reliability and Quality",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90032",
+  "name": "Process Dynamics And Control",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90059",
+  "name": "Social Enterprise Incubator",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90033",
+  "name": "Law Apps",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90027",
+  "name": "International Human Resources",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90009",
+  "name": "International Relations Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90056",
+  "name": "Investment Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM10002",
+  "name": "Exploring Biomedicine",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90014",
+  "name": "Human Resource Management in Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90203",
+  "name": "Foundations in Quantitative Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90004",
+  "name": "States, Governments and the Arts",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90035",
+  "name": "Integrated Marketing Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90031",
+  "name": "Audiovisual Communication",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70003",
+  "name": "Minor Thesis (LLM) # P/T",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90038",
+  "name": "MFPI Internship Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90525",
+  "name": "Business and Economics Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40084",
+  "name": "Research Paper",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20056",
+  "name": "Composition 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PAED40005",
+  "name": "Paediatrics Research Project Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90042",
+  "name": "Social Media and Viral Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90280",
+  "name": "Managerial Decision Analytics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50060",
+  "name": "Melbourne Journal of International Law",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90111",
+  "name": "Genetic Epidemiology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM40017",
+  "name": "German Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50096",
+  "name": "Media Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CREA90007",
+  "name": "Creative Arts Therapies in Education",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90189",
+  "name": "NDIS and Disability Benefits Clinic",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50047",
+  "name": "Family Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90012",
+  "name": "Microeconomics II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90140",
+  "name": "Disputes and Ethics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50031",
+  "name": "Legal Theory",
+  "offered": [
+   "semester_2",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90031",
+  "name": "Geography Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90009",
+  "name": "Advanced Non Fiction Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM90003",
+  "name": "Applied Microeconometric Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90238",
+  "name": "Music, Learning & Technology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90106",
+  "name": "Advanced Nursing Practice: Primary Care",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30232",
+  "name": "Music Making Laboratory 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90077",
+  "name": "Not for Profits and the Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90151",
+  "name": "Biostatistics Research Project - D",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90073",
+  "name": "Security Analytics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20200",
+  "name": "Practical Music 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90012",
+  "name": "Process Equipment Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90100",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS10007",
+  "name": "The History of Cool: Fashion & Attitude",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS40006",
+  "name": "Physiology Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30029",
+  "name": "International Macroeconomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90037",
+  "name": "Engineering Capstone Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL10004",
+  "name": "Knowledge Practices 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90033",
+  "name": "Mine Safety and Engineering",
+  "offered": [
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90014",
+  "name": "Auditing and Assurance Services",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUST10002",
+  "name": "Land Food and Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90042",
+  "name": "Applications of Music in Therapy B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90062",
+  "name": "High Speed Electronics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI10052",
+  "name": "Agricultural Genetics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90149",
+  "name": "Applied Instrumental and Vocal Teaching",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50059",
+  "name": "Legal Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "june",
+   "semester_2",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO40001",
+  "name": "Introduction to European Critical Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90102",
+  "name": "Attitude and Behaviour Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL20002",
+  "name": "Health Promotion 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DRAM30037",
+  "name": "Theatre Skills 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90281",
+  "name": "Management Competencies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30024",
+  "name": "Behaviour Change and Well-being",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90127",
+  "name": "Animal Production Systems: Intensive",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40019",
+  "name": "Economics Research Essay Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90117",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90120",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90010",
+  "name": "Technology Innovation Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PATH30004",
+  "name": "Advanced Investigation of Human Disease",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN30015",
+  "name": "Safety and Sustainability Case Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING30001",
+  "name": "Exploring Linguistic Diversity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHRM40006",
+  "name": "Pharmacology Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90057",
+  "name": "Communication Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90012",
+  "name": "Second Language Acquisition",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90154",
+  "name": "Professional Practice 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90034",
+  "name": "Creating Innovative Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM30017",
+  "name": "Medical Microbiology: Parasitology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CICU30012",
+  "name": "Creating Screen and Cultural Worlds",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30021",
+  "name": "Laboratory and Computational Physics 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90008",
+  "name": "International Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90046",
+  "name": "Landscape Governance and Policy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AIND10005",
+  "name": "Decolonising the Landscape MultiStudio 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC10004",
+  "name": "Mind, Brain and Behaviour 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT20007",
+  "name": "Accounting Information: Risks & Controls",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM20007",
+  "name": "Cybercrime and Digital Criminology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEND30005",
+  "name": "Gender Diversity in the Workplace",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI30014",
+  "name": "Sociology of 'Race' and Ethnicities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20060",
+  "name": "Total War: World War II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM20001",
+  "name": "Econometrics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC30005",
+  "name": "Arabic 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL20001",
+  "name": "Italian Cultural Studies B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ATOC30006",
+  "name": "Modern and Future Climate",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20004",
+  "name": "Japanese 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG10003",
+  "name": "Global Youth",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE10027",
+  "name": "Dancing the Dance 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT10002",
+  "name": "Introductory Financial Accounting",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS30022",
+  "name": "Renaissance Art in Global Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN30018",
+  "name": "Thermodynamics and Fluid Mechanics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG30009",
+  "name": "Digital Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA20002",
+  "name": "Plant Biodiversity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GDES10001",
+  "name": "Graphic Design Studio 1: Image & Text",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20022",
+  "name": "History of Greece: Homer to Alexander",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20164",
+  "name": "Free Play New Music Improvisation Ensem",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30004",
+  "name": "Managing Globally",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA10002",
+  "name": "Asian Century: Meaning and Impact",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM30003",
+  "name": "Applied Microeconometric Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE10002",
+  "name": "Principles of Finance",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE20004",
+  "name": "Korean 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH30002",
+  "name": "Design Studio Epsilon",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS10003",
+  "name": "Introduction to Political Ideas",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10005",
+  "name": "Being Online: Internet Meets Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON20001",
+  "name": "Intermediate Macroeconomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20033",
+  "name": "Construction Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB20008",
+  "name": "Drugs That Shape Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS20022",
+  "name": "Modern and Contemporary Chinese Art",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW10007",
+  "name": "Ancient Egyptian 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE20003",
+  "name": "Introductory Personal Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20068",
+  "name": "Sport, Education and the Media",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20009",
+  "name": "Indonesian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG10001",
+  "name": "Principles of Marketing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20018",
+  "name": "Indonesian Politics and Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH20001",
+  "name": "Dangerous Earth",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL30003",
+  "name": "Contingencies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM20015",
+  "name": "Surveying and Mapping",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN30001",
+  "name": "Art Cinema and the Love Story",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN30006",
+  "name": "French Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AHIS20018",
+  "name": "Art, Market and Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO20016",
+  "name": "Translation: Intercultural Indonesian",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10018",
+  "name": "Insects Shaping Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM10002",
+  "name": "Law in Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR20003",
+  "name": "Engineering Materials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS10001",
+  "name": "Foundations of Information Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10184",
+  "name": "Pop Song Writing 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10048",
+  "name": "Creativity, Play and the Arts",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20003",
+  "name": "Egypt Under the Pharaohs",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30021",
+  "name": "Complex Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CONS10001",
+  "name": "Principles of Building",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10162",
+  "name": "Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA10035",
+  "name": "Still Life: Nature Morte",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10006",
+  "name": "Physics 2: Life Sciences & Environment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN10006",
+  "name": "Chinese 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA10032",
+  "name": "Critical and Theoretical Studies 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM30013",
+  "name": "Chemical Research Project",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30020",
+  "name": "The Integrated Brain",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING20010",
+  "name": "Language, Society and Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO10003",
+  "name": "Fundamentals of Interaction Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL10003",
+  "name": "Philosophy: The Great Thinkers",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CULS30005",
+  "name": "City Cultures, Urban Ecologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC10003",
+  "name": "Debating Science in Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT20001",
+  "name": "Development in the 21st Century",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20071",
+  "name": "American History: 1945 to Now",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20138",
+  "name": "Indonesian Gamelan Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARBC20005",
+  "name": "Arabic 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB20002",
+  "name": "Biochemistry and Molecular Biology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL30004",
+  "name": "Actuarial Statistics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN30005",
+  "name": "Heat and Mass Transport Processes",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN30013",
+  "name": "Electronic System Implementation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC40013",
+  "name": "Advanced Psychological Theory & Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHRM30002",
+  "name": "Drugs Affecting the Nervous System",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10014",
+  "name": "Latin 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS20026",
+  "name": "Latin 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CEDB30004",
+  "name": "Stem Cells in Development & Regeneration",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS20007",
+  "name": "Russian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10002",
+  "name": "Physics 2: Advanced",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS20012",
+  "name": "Global Human Rights Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN20003",
+  "name": "Spanish 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC30070",
+  "name": "Applying Coaching Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30012",
+  "name": "Management Consulting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL10001",
+  "name": "Modern and Contemporary Literature",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20002",
+  "name": "Introduction to Japanese Communication",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS20025",
+  "name": "International Relations: Key Questions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20209",
+  "name": "Chinese Music Ensemble 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP10001",
+  "name": "Foundations of Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM20011",
+  "name": "Approaches to Media Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH10003",
+  "name": "Design Studio Alpha",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM20020",
+  "name": "Chemistry: Structure and Properties",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20028",
+  "name": "Chinese 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI20016",
+  "name": "Sociology of Culture",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN30005",
+  "name": "Romanticism to Decadence: French Novels",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO10002",
+  "name": "Indonesian 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL10001",
+  "name": "Biology of Australian Flora & Fauna",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT30002",
+  "name": "Enterprise Performance Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20030",
+  "name": "Logical Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM30022",
+  "name": "German 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20016",
+  "name": "Japanese Through Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30027",
+  "name": "Local Sites, Global Connections",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ESLA10003",
+  "name": "Academic English 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN20016",
+  "name": "Chinese Cinema",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL20008",
+  "name": "Italian 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BLAW10001",
+  "name": "Principles of Business Law",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM30002",
+  "name": "Econometrics 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20011",
+  "name": "Science Communication and Employability",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC20003",
+  "name": "Topics in Animal Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR30004",
+  "name": "Hebrew 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL20032",
+  "name": "Poetry, Love, and Death",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN20013",
+  "name": "Australian Film and Television",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10004",
+  "name": "Introductory Microeconomics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO30007",
+  "name": "Indonesian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM20003",
+  "name": "German Cultural Studies B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30005",
+  "name": "Advanced Chinese Translation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20022",
+  "name": "Group Theory and Linear Algebra",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM30004",
+  "name": "Time Series Analysis and Forecasting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR30004",
+  "name": "Complex Functions in Neuroscience",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR20005",
+  "name": "Numerical Methods in Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN10008",
+  "name": "Spanish 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL10005",
+  "name": "Italian 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20003",
+  "name": "Romanticism to Decadence: French Novels",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90027",
+  "name": "Screen Language 1B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC90019",
+  "name": "Graduate Seminar: Environmental Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO20004",
+  "name": "Usability Evaluation Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90028",
+  "name": "Advanced Seminars in Specialty 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90015",
+  "name": "Advanced Psychopathology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90287",
+  "name": "Architectural Technology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90093",
+  "name": "Ensemble A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90276",
+  "name": "M.Epidemiology Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90008",
+  "name": "Language Program Evaluation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90050",
+  "name": "Scheduling and Optimisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BINF90004",
+  "name": "Bioinformatics Case Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30023",
+  "name": "Computational Behavioural Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90422",
+  "name": "SI-Lab: Scanning and Virtual Reality",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90022",
+  "name": "Computational Biomechanics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS30008",
+  "name": "Production Practice 3 - Part A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40012",
+  "name": "Development Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90641",
+  "name": "Identity, Equity and Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90151",
+  "name": "Music Performance Curriculum& Assessment",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90055",
+  "name": "Development Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90007",
+  "name": "Food Processing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90018",
+  "name": "Structural Dynamics and Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40107",
+  "name": "Capstone Music Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90028",
+  "name": "Discourse and Interaction",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL30049",
+  "name": "Exploring Irish Literature",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90006",
+  "name": "Fieldwork for Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50033",
+  "name": "Equity and Trusts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90418",
+  "name": "Architects in Asia, Practice & Politics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MREN90005",
+  "name": "Materials Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN90028",
+  "name": "Monitoring Environmental Impacts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50047",
+  "name": "Family Law",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30160",
+  "name": "Acting for Singers 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90031",
+  "name": "Geography Minor Research Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90838",
+  "name": "Project in Clinical Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90140",
+  "name": "Disputes and Ethics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90026",
+  "name": "Global Climate Change In Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90017",
+  "name": "HR Consulting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90238",
+  "name": "Music, Learning & Technology",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "IBUS90003",
+  "name": "The Multinational",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL40002",
+  "name": "Oral Health Research Project 4B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90077",
+  "name": "Research Project Part C",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90206",
+  "name": "Management & Marketing Special Topics 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30232",
+  "name": "Music Making Laboratory 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90005",
+  "name": "Marketing Strategy",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90059",
+  "name": "Social Enterprise Incubator",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90022",
+  "name": "Advanced Seminars in Specialty 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90083",
+  "name": "Cognitive Neuroscience and Disorders",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40020",
+  "name": "Australian Theatre and Performance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST40037",
+  "name": "The Long History of Globalisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90384",
+  "name": "MUP Studio",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90360",
+  "name": "MUCH Heritage Industry Internship",
+  "offered": [
+   "january",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30173",
+  "name": "Early Voices 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90020",
+  "name": "Research Project (MDS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40037",
+  "name": "Classics Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HLTH90006",
+  "name": "Basics of Digital Health for Clinicians",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90037",
+  "name": "Managing for Value Creation",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10007",
+  "name": "Physics for Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30227",
+  "name": "Individual Performance Studies 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90041",
+  "name": "Advanced Dynamics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20199",
+  "name": "Practical Music 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90060",
+  "name": "Internship in Development",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90147",
+  "name": "Performing to Teach 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30037",
+  "name": "Architecture Design Studio: Fire",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90076",
+  "name": "Industry Internship",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90061",
+  "name": "Urban Design Studio A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90741",
+  "name": "Effective Clinical Teaching",
+  "offered": [
+   "february",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90188",
+  "name": "Music and Health Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90036",
+  "name": "Cardiovascular & Respiratory Emergencies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70333",
+  "name": "Taxation of Trusts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90170",
+  "name": "Adolescent Health Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20083",
+  "name": "Conservatorium Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30006",
+  "name": "Industry Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP40003",
+  "name": "Research Paper (Social Practice)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90024",
+  "name": "Advanced Audio: Podcasting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RADI90018",
+  "name": "Diagnostic Radiology 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90015",
+  "name": "Human Resource Fundamentals",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90164",
+  "name": "EMA Special Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT90064",
+  "name": "Industry Core and Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90005",
+  "name": "Advanced Derivative Securities",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RADI90012",
+  "name": "Radiology Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40105",
+  "name": "Dissertation Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20210",
+  "name": "Saxophone Ensemble",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90021",
+  "name": "Editing Masterclass",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90036",
+  "name": "Capstone Project A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECOM40005",
+  "name": "Modelling the Australian Macroeconomy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90280",
+  "name": "City Lights: Cities, Culture and History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90074",
+  "name": "Economics Thesis Workshop Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90048",
+  "name": "Transport Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90018",
+  "name": "Mobile Computing Systems Programming",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40013",
+  "name": "Monetary Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS20013",
+  "name": "Production Studio 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90004",
+  "name": "The Power of Ideas: Ten Great Books",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90416",
+  "name": "Land and Property Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV40006",
+  "name": "Research Paper (Animation)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90014",
+  "name": "Research Proposal 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90098",
+  "name": "Approximation, Algorithms and Heuristics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90012",
+  "name": "Industry Investigation Project B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST90034",
+  "name": "International Relations Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CREA90019",
+  "name": "Creative Arts Therapies Research 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90285",
+  "name": "Research Project in Public Health Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90052",
+  "name": "Advanced Materials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANSC40002",
+  "name": "Animal Sci & Mgt Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20179",
+  "name": "Ensemble Studies 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90140",
+  "name": "Management Competencies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90022",
+  "name": "International Internship in Environment",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM90014",
+  "name": "Research Project (SBS)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90026",
+  "name": "Solid Mechanics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON40020",
+  "name": "Topics in Experimental Economics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10057",
+  "name": "Early Voices 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90334",
+  "name": "Minor Project in Education 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90048",
+  "name": "Advanced Case Studies Practicum",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90062",
+  "name": "Mental Health and Young People",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA60014",
+  "name": "Critical Issues in Contemporary Art B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90023",
+  "name": "Publishing and Communications Thesis Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90788",
+  "name": "Applications of Positive Psychology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH40009",
+  "name": "Anthropology Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN90011",
+  "name": "Tissue Engineering & Stem Cells",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGL40026",
+  "name": "English & Theatre Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90069",
+  "name": "Sexual and Reproductive Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90088",
+  "name": "Paediatric Nursing 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PLAN30005",
+  "name": "Urban Precinct Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV20017",
+  "name": "Screenwriting Practices 2B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV90020",
+  "name": "Business of Producing 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90076",
+  "name": "Short Research Project B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30226",
+  "name": "Ensemble Studies 6",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90094",
+  "name": "Ensemble B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90167",
+  "name": "Design Communications Workshop (P/G)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN30011",
+  "name": "Smart Transportation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90235",
+  "name": "Practice-Led Music Research Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30252",
+  "name": "Performance 5",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90057",
+  "name": "Contemporary Nursing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20014",
+  "name": "Chamber Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90034",
+  "name": "Marketing & Media in a Global Context",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH40006",
+  "name": "Population Health Research Project 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90017",
+  "name": "Graduate Seminar in Vision Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40110",
+  "name": "Honours Music Studies 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA10034",
+  "name": "Studio Studies 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90104",
+  "name": "Information Systems Maj Res Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM40012",
+  "name": "Islamic Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM90004",
+  "name": "Graduate German B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90036",
+  "name": "MFPI Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN40009",
+  "name": "Japanese Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90038",
+  "name": "Haemato, Neurologic & Global Conditions",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS40007",
+  "name": "Russian Language & Culture 4B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90025",
+  "name": "Advanced Industry Practice – PR",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL40011",
+  "name": "Actuarial Studies Projects Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90084",
+  "name": "Internship for Agricultural Sciences Pt2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90231",
+  "name": "Qualitative Research in Public Health",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90022",
+  "name": "Project in Vision Science",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90051",
+  "name": "Civil Hydraulics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90020",
+  "name": "Additive Manufacturing of Metals",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10015",
+  "name": "Foundation Mathematics 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS40017",
+  "name": "Veterinary Clinical Skills",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM30013",
+  "name": "Land Administration Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM20002",
+  "name": "Human Structure and Function",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACUR90010",
+  "name": "Art Curatorship Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM20009",
+  "name": "Race, Ethnicity, Crime and Justice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90036",
+  "name": "Legal Drafting",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DENT90040",
+  "name": "Forensic Odontology 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST40040",
+  "name": "History Thesis Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90139",
+  "name": "Veterinary Professional Practice 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90045",
+  "name": "Vet Public Health Research Project Pt 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90032",
+  "name": "Marketing Communications Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACTL90007",
+  "name": "Life Insurance Models 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90047",
+  "name": "Congenital,Obsetric& Medical Conditions",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING90039",
+  "name": "Concepts in Applied Linguistics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90118",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90071",
+  "name": "Offshore Geotechnical Engineering",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90100",
+  "name": "Information Systems Maj Res Project Pt 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30230",
+  "name": "Interactive Composition 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW40017",
+  "name": "Ancient World Studies Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ESLA90002",
+  "name": "Advanced Self-Editing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90405",
+  "name": "Energy & Carbon in the Built Environment",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCRN40009",
+  "name": "Screen Media and Political Aesthetics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40081",
+  "name": "Honours Chamber Music 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA90008",
+  "name": "Asia and the World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90033",
+  "name": "Public Budgets and Financial Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30207",
+  "name": "Vocal Ensemble 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90081",
+  "name": "Computer Science Research Project Part 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90027",
+  "name": "Interdisciplinary Industry Project 2",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AUDI90021",
+  "name": "Clinical Audiology A",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20178",
+  "name": "Individual Performance Studies 4",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS40039",
+  "name": "Ancient Greek Honours Seminar 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90032",
+  "name": "Sustainability and Behaviour Change",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL40001",
+  "name": "Oral Health Research Project 4A",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30041",
+  "name": "Industry Internship",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL40022",
+  "name": "Philosophy Thesis Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10011",
+  "name": "Experimental Design and Data Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20176",
+  "name": "Ensemble Studies 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90335",
+  "name": "Minor Project in Education",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC90012",
+  "name": "General Relativity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90006",
+  "name": "Engineering Contracts and Procurement",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90031",
+  "name": "Sustainability Reporting & Management",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90064",
+  "name": "Advanced Control Systems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90025",
+  "name": "Parallel and Multicore Computing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90233",
+  "name": "Core Skills in Opera 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90060",
+  "name": "Integrated Design - Civil",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10226",
+  "name": "Chamber Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN40007",
+  "name": "Public Policy & Management Thesis Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS90003",
+  "name": "Design Projects 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90002",
+  "name": "Database Systems & Information Modelling",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN90016",
+  "name": "Software Processes and Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90119",
+  "name": "Research Project (Psych)",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SWEN90006",
+  "name": "Security & Software Testing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90032",
+  "name": "Building Services and Operations",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO30008",
+  "name": "Interactive Technology Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV70047",
+  "name": "Major Screenwriting Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN90032",
+  "name": "Environmental Analysis Tools",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "OTOL40003",
+  "name": "Otolaryngology Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30061",
+  "name": "Landscape Studio: Designed Ecologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90238",
+  "name": "Research Report Part 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MEDI90088",
+  "name": "Graduate Research Internship",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90031",
+  "name": "Project Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO90003",
+  "name": "Graduate Indonesian B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90096",
+  "name": "Thesis (Masters/coursework) Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90115",
+  "name": "Information Systems Res Project Pt 3",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC40018",
+  "name": "HPS Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90070",
+  "name": "Experimental Methods in Decision Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS30009",
+  "name": "Production Practice 3 - Part B",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20081",
+  "name": "Early Voices 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON90014",
+  "name": "Macroeconomics II",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "OPTO90006",
+  "name": "Anterior Eye Disease and Dry Eye",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90054",
+  "name": "Development Studies Thesis Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI40106",
+  "name": "Research Paper (Jazz & Improvisation)",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90034",
+  "name": "International Policymaking in Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90038",
+  "name": "Researching Media & Communications",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90255",
+  "name": "Research Project in Public Health - S",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90104",
+  "name": "A First Course In Statistical Learning",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90056",
+  "name": "Riemann Surfaces and Complex Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90048",
+  "name": "B2B Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90008",
+  "name": "Fluid Dynamics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI40003",
+  "name": "Understanding The Life Course",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING40006",
+  "name": "Linguistic Field Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "TRAN90013",
+  "name": "Translation and Interpreting Thesis 2",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90229",
+  "name": "Health Economics 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90041",
+  "name": "Fundamentals in Accounting",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM10001",
+  "name": "Discovering Biomedicine",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90307",
+  "name": "MSD Vocational Placement",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "may",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DPSS10007",
+  "name": "The History of Cool: Fashion & Attitude",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90037",
+  "name": "Engineering Capstone Project Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH30013",
+  "name": "The Anthropological Imagination",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30019",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE30002",
+  "name": "Science and Technology Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MIIM30015",
+  "name": "Techniques in Immunology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL30007",
+  "name": "The Philosophy of Philosophy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM30017",
+  "name": "Contemporary Challenges and Islam",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30018",
+  "name": "Applied Research Methods",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90199",
+  "name": "Suzuki Practicum Part 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90014",
+  "name": "The World of Engineering Management",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST30060",
+  "name": "Making History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90043",
+  "name": "Cryptography and Security",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI30004",
+  "name": "Encounters with Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON30029",
+  "name": "International Macroeconomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS40006",
+  "name": "Physiology Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LARC10001",
+  "name": "Natural History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30048",
+  "name": "Plant Breeding and Genetics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE10004",
+  "name": "Human Sciences: From Cells to Societies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20080",
+  "name": "Witch-Hunting in European Societies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90033",
+  "name": "Integrated Accounting Studies",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO90008",
+  "name": "HCI Project",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CCDP10002",
+  "name": "The Electronic Arts: Vision and Sound",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL30003",
+  "name": "Case Studies In Computational Biology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90059",
+  "name": "Introduction to Programming",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV10023",
+  "name": "Introduction to Screenwriting Practices",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR10006",
+  "name": "Engineering Modelling and Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LANG30001",
+  "name": "Languages at Work",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20024",
+  "name": "Ancient Egyptian 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30021",
+  "name": "The Disaster Resilient City",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI10003",
+  "name": "Inequalities: Challenges for the Future",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30012",
+  "name": "Foundations of FinTech",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10022",
+  "name": "Entrepreneurship Principles and Tools",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20084",
+  "name": "Red Empire: The Soviet Union and After",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG20017",
+  "name": "Spatial Analysis in Geography",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NUTR30004",
+  "name": "Advanced Topics in Nutrition",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANTH20013",
+  "name": "Diplomat, Soldier, Spy: The Deep State",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS30032",
+  "name": "Animal Production Systems 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90011",
+  "name": "Derivative Securities",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS30011",
+  "name": "Clinical and Translational Physiology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL10010",
+  "name": "Introductory Biology: Life's Complexity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90081",
+  "name": "Applied Research Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC30022",
+  "name": "Theoretical Physics 3",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM30014",
+  "name": "Specialised Topics in Chemistry B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90036",
+  "name": "Foundations of Marketing & Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYS30012",
+  "name": "Physiology: Adapting to Challenges",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90083",
+  "name": "Computational Statistics & Data Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE30028",
+  "name": "Choreographic Production",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NRMT90002",
+  "name": "Biosecurity: Managing Invasive Species",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENP40001",
+  "name": "Primary Care Research Project Part 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30027",
+  "name": "Modern Applied Statistics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90055",
+  "name": "Nursing as Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE90025",
+  "name": "Clinical Genome Variant Analysis 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90022",
+  "name": "Commercialisation of Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST20015",
+  "name": "Fire in the Australian Landscape",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA30005",
+  "name": "Plant Molecular Biology & Biotechnology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GENE20004",
+  "name": "Applications of Genetics and Genomics",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INFO30006",
+  "name": "Information Security and Privacy",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC30007",
+  "name": "Landscape Ecosystem Project",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20002",
+  "name": "French 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS30005",
+  "name": "Russian Culture Through Film",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10059",
+  "name": "Performance, Potential and Development",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30001",
+  "name": "Investments",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10227",
+  "name": "Musics of the World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW10002",
+  "name": "Myth, Art and Empire: Greece and Rome",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10011",
+  "name": "The Secret Life of the Body 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN30004",
+  "name": "French 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH20001",
+  "name": "Design Studio Beta",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PROP30003",
+  "name": "Design and Property Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30019",
+  "name": "Development of the Thinking Child",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM30002",
+  "name": "Global Criminology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CWRI30013",
+  "name": "Life Writing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BMEN30008",
+  "name": "Biosystems Design",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30003",
+  "name": "International Finance",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN20002",
+  "name": "Earth Processes for Engineering",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20027",
+  "name": "Archaeology of the Classical Greek World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG30013",
+  "name": "Strategic Marketing",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM30012",
+  "name": "Law in Social Theory",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG20013",
+  "name": "Health Geography",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20088",
+  "name": "Introduction to Indigenous History",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG30010",
+  "name": "Advertising and Promotions",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN30002",
+  "name": "Social Problems in Japan",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN20001",
+  "name": "Hispanic Cultural Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL20001",
+  "name": "Italian Cultural Studies B",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JAPN20004",
+  "name": "Japanese 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ANCW20022",
+  "name": "History of Greece: Homer to Alexander",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ASIA10002",
+  "name": "Asian Century: Meaning and Impact",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20164",
+  "name": "Free Play New Music Improvisation Ensem",
+  "offered": [
+   "february",
+   "semester_1",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN30018",
+  "name": "Thermodynamics and Fluid Mechanics",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30004",
+  "name": "Managing Globally",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA20002",
+  "name": "Plant Biodiversity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS20007",
+  "name": "Russian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10018",
+  "name": "Insects Shaping Society",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN20003",
+  "name": "Spanish 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR20003",
+  "name": "Engineering Materials",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC30070",
+  "name": "Applying Coaching Science",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHIN30001",
+  "name": "Classic Chinese Civilisation",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20132",
+  "name": "Melbourne Big Band 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30021",
+  "name": "Complex Analysis",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CONS10001",
+  "name": "Principles of Building",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10162",
+  "name": "Choir 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10006",
+  "name": "Physics 2: Life Sciences & Environment",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS30002",
+  "name": "Russian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LING10001",
+  "name": "The Secret Life of Language",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM30013",
+  "name": "Marketing Communications",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20123",
+  "name": "University Symphonic Ensembles 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20135",
+  "name": "Chinese Music Ensemble 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG20004",
+  "name": "Market and Business Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT10001",
+  "name": "Accounting Reports and Analysis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20010",
+  "name": "The First Centuries of Islam",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM10007",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL20036",
+  "name": "Environmental Building Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST30001",
+  "name": "Stochastic Modelling",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "NEUR30006",
+  "name": "Real and Artificial Neural Networks",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT30004",
+  "name": "Auditing and Assurance Services",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10004",
+  "name": "Physics 2: Physical Science & Technology",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL30016",
+  "name": "Italian 8",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM20008",
+  "name": "Terrorism: Shifting Paradigms",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE30001",
+  "name": "Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PROP20003",
+  "name": "Design and Property Industry Studies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30022",
+  "name": "Trends in Personality& Social Psychology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10049",
+  "name": "Creative Projects-Digital Technologies",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30020",
+  "name": "Arts Internship: Not for Profit",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG20008",
+  "name": "Inside the City of Diversity",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20010",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PLAN20002",
+  "name": "Urban Design for People and Places",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM10003",
+  "name": "Chemistry 1",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HEBR20006",
+  "name": "Hebrew 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT10001",
+  "name": "First Peoples in a Global Context",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "UNIB10019",
+  "name": "Thinking Tools for Wicked Problems",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS20016",
+  "name": "Ancient Greek 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA30024",
+  "name": "Performance Design Studio",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM30006",
+  "name": "German 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC20009",
+  "name": "Personality and Social Psychology",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM20015",
+  "name": "Politics in the Middle East & South Asia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE10004",
+  "name": "Korean 4",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG30024",
+  "name": "Africa: Environment, Development, People",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL30014",
+  "name": "Italian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC30035",
+  "name": "The Dynamics of Scientific Change",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20222",
+  "name": "Creativity, Genius, Expertise and Talent",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC20083",
+  "name": "Story, Children and the Arts",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDO10011",
+  "name": "Diversity: Identities in Indonesia",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC10001",
+  "name": "From Plato to Einstein",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR10019",
+  "name": "Clear Speech and Communication",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL10007",
+  "name": "Italian 6",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN20011",
+  "name": "Chemical Process Analysis",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC20007",
+  "name": "Modelling the Real World",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10002",
+  "name": "Seminar in Economics and Commerce A",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN30012",
+  "name": "Signals and Systems",
+  "offered": [
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC30021",
+  "name": "Psychological Science: Theory & Practice",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "RUSS10002",
+  "name": "Russian 2",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20018",
+  "name": "Discrete Maths and Operations Research",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BCMB40011",
+  "name": "Biochemistry Research Project Part 1",
+  "offered": [
+   "semester_2"
+  ],
+  "online": true
+ }
 ]

--- a/subject-utils/subject-lists/subjects_2021_september.json
+++ b/subject-utils/subject-lists/subjects_2021_september.json
@@ -1,215 +1,19 @@
 [
  {
-  "code": "ABPL90029",
-  "name": "Construction Studies",
+  "code": "NURS90142",
+  "name": "Alcohol, Other Drugs and Recovery",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL90075",
-  "name": "Urban and Landscape Heritage",
+  "code": "POPH90145",
+  "name": "Survival Analysis & Regression for Rates",
   "offered": [
    "september"
-  ]
- },
- {
-  "code": "ABPL90120",
-  "name": "Building Sustainability",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "ABPL90371",
-  "name": "Design Activism",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "ABPL90411",
-  "name": "Political Economy of Design",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "AGRI20030",
-  "name": "Wine & Spirits:An Australian Perspective",
-  "offered": [
-   "february",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "AGRI90077",
-  "name": "Value Chain Analysis",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "BISY90017",
-  "name": "Quant. Decision Making & Optimisation",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "BUSA90001",
-  "name": "Financial Accounting",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90026",
-  "name": "Business Strategy",
-  "offered": [
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90027",
-  "name": "Business Strategy",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "BUSA90053",
-  "name": "Corporate Strategy",
-  "offered": [
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90060",
-  "name": "Data Analysis",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90093",
-  "name": "Finance",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90167",
-  "name": "Investments",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "BUSA90172",
-  "name": "Leadership and Change",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "BUSA90193",
-  "name": "Managerial Economics",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90194",
-  "name": "Managerial Economics",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "BUSA90224",
-  "name": "Managing People",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90227",
-  "name": "Operations",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90243",
-  "name": "Marketing",
-  "offered": [
-   "january",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90258",
-  "name": "Marketing Research",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "BUSA90261",
-  "name": "Marketing Strategy",
-  "offered": [
-   "april",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90403",
-  "name": "Business Tools: Money People & Processes",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "BUSA90458",
-  "name": "Managerial Judgement",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "BUSA90480",
-  "name": "Leadership",
-  "offered": [
-   "summer_term",
-   "march",
-   "june",
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90481",
@@ -220,132 +24,93 @@
    "march",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90490",
-  "name": "Integrative Business Capstone",
+  "code": "MUSI90190",
+  "name": "Keyboard Repertoire and the Teacher",
   "offered": [
-   "summer_term",
-   "june",
-   "winter_term",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "BUSA90510",
-  "name": "Executive Management 6",
+  "code": "LAWS90081",
+  "name": "Advanced Payment Devices and Fintech",
   "offered": [
    "september"
-  ]
- },
- {
-  "code": "BUSA90530",
-  "name": "Managing Sustainability for Strat. Adv.",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "CRIM90017",
-  "name": "Violence, Trauma and Reconciliation",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "CVEN90068",
-  "name": "Port Access and Navigation",
-  "offered": [
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "DEVT90073",
   "name": "Leading Development",
   "offered": [
    "september"
-  ]
- },
- {
-  "code": "DEVT90074",
-  "name": "Contemporary Development",
-  "offered": [
-   "march",
-   "september"
-  ]
- },
- {
-  "code": "EDUC90137",
-  "name": "Personal and Interpersonal Leadership",
-  "offered": [
-   "january",
-   "september"
-  ]
- },
- {
-  "code": "EDUC90139",
-  "name": "Leading a Learning Community",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "EDUC90221",
-  "name": "Consultation in Educational Settings",
-  "offered": [
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90578",
   "name": "Linking School and Community",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90612",
-  "name": "Teaching for Student Engagement",
+  "code": "BUSA90053",
+  "name": "Corporate Strategy",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT90043",
+  "name": "Tree Identification and Selection",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90751",
-  "name": "Understanding Schools",
+  "code": "EDUC90139",
+  "name": "Leading a Learning Community",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC90846",
-  "name": "Learning Intervention 2",
+  "code": "BUSA90026",
+  "name": "Business Strategy",
   "offered": [
    "april",
+   "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EDUC91031",
-  "name": "Language in Diverse Contexts",
+  "code": "NURS90122",
+  "name": "Foundations of Critical Care Nursing",
   "offered": [
+   "march",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ENEN90014",
-  "name": "Sustainable Buildings",
+  "code": "AGRI20030",
+  "name": "Wine & Spirits:An Australian Perspective",
   "offered": [
+   "june",
    "september"
-  ]
- },
- {
-  "code": "EVSC90023",
-  "name": "Building Behaviour in Bushfires",
-  "offered": [
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "FINA20033",
@@ -356,7 +121,101 @@
    "april",
    "june",
    "september"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90458",
+  "name": "Managerial Judgement",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "POLS30034",
+  "name": "Political Psychology",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70149",
+  "name": "Construction Risk",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS40022",
+  "name": "Professional Veterinary Practice Part 1",
+  "offered": [
+   "semester_1",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90141",
+  "name": "Psychotherapy Essentials",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90530",
+  "name": "Managing Sustainability for Strat. Adv.",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90093",
+  "name": "Finance",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90258",
+  "name": "Marketing Research",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90117",
+  "name": "Foundations in Neonatal Care",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70046",
+  "name": "Trade Marks and Unfair Competition",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90846",
+  "name": "Learning Intervention 2",
+  "offered": [
+   "april",
+   "september"
+  ],
+  "online": false
  },
  {
   "code": "FINA20045",
@@ -368,105 +227,291 @@
    "winter_term",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FRST90017",
-  "name": "Bushfire Planning & Management",
+  "code": "POPH90145",
+  "name": "Survival Analysis & Regression for Rates",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOL90032",
-  "name": "Introduction to Mineralogy",
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
   "offered": [
+   "summer_term",
+   "april",
+   "march",
+   "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "HIST90032",
-  "name": "Historical Themes in Australian Politics",
+  "code": "MUSI90190",
+  "name": "Keyboard Repertoire and the Teacher",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90081",
+  "name": "Advanced Payment Devices and Fintech",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "DEVT90073",
+  "name": "Leading Development",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90578",
+  "name": "Linking School and Community",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90053",
+  "name": "Corporate Strategy",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90142",
+  "name": "Alcohol, Other Drugs and Recovery",
+  "offered": [
+   "september"
+  ],
+  "online": false
  },
  {
   "code": "HORT90043",
   "name": "Tree Identification and Selection",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90026",
+  "name": "Business Strategy",
+  "offered": [
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90139",
+  "name": "Leading a Learning Community",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90122",
+  "name": "Foundations of Critical Care Nursing",
+  "offered": [
+   "march",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI20030",
+  "name": "Wine & Spirits:An Australian Perspective",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20033",
+  "name": "Introduction to Printmaking Processes",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90063",
+  "name": "Social Work Practice: Indigenous Peoples",
+  "offered": [
+   "february",
+   "september"
+  ],
+  "online": false
  },
  {
   "code": "HORT90046",
   "name": "Designing Green Roofs and Walls",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70033",
-  "name": "International Criminal Law",
+  "code": "ABPL90411",
+  "name": "Political Economy of Design",
   "offered": [
    "september"
-  ]
- },
- {
-  "code": "LAWS70042",
-  "name": "Company Takeovers",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "LAWS70046",
-  "name": "Trade Marks and Unfair Competition",
-  "offered": [
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS70053",
   "name": "Workplace Health and Safety",
   "offered": [
    "september"
-  ]
- },
- {
-  "code": "LAWS70081",
-  "name": "Capital Gains Tax: Problems in Practice",
-  "offered": [
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS70082",
   "name": "Privacy Law",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70112",
-  "name": "Remedies in the Construction Context",
+  "code": "LAWS70218",
+  "name": "International Employment Law",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70128",
-  "name": "Advanced Construction Law",
+  "code": "LAWS90158",
+  "name": "Current Issues in International Tax",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70149",
-  "name": "Construction Risk",
+  "code": "NURS90144",
+  "name": "Emergency Nursing 2",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90019",
+  "name": "Management and Leadership for Engineers",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90070",
+  "name": "Implementing Evidence for Practice",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91031",
+  "name": "Language in Diverse Contexts",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90612",
+  "name": "Teaching for Student Engagement",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "HIST90032",
+  "name": "Historical Themes in Australian Politics",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90003",
+  "name": "Comparative Social Policy",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90032",
+  "name": "Introduction to Mineralogy",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90403",
+  "name": "Business Tools: Money People & Processes",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70081",
+  "name": "Capital Gains Tax: Problems in Practice",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS40023",
+  "name": "Professional Veterinary Practice Part 2",
+  "offered": [
+   "march",
+   "semester_2",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90227",
+  "name": "Operations",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
  },
  {
   "code": "LAWS70217",
@@ -476,198 +521,59 @@
    "may",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70218",
-  "name": "International Employment Law",
+  "code": "BUSA90510",
+  "name": "Executive Management 6",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "LAWS70230",
   "name": "Commercial Law in Asia",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "LAWS70366",
-  "name": "International Refugee Law",
+  "code": "AGRI90077",
+  "name": "Value Chain Analysis",
   "offered": [
    "september"
-  ]
- },
- {
-  "code": "LAWS70462",
-  "name": "Sports Integrity and Investigations",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "LAWS90081",
-  "name": "Advanced Payment Devices and Fintech",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "LAWS90119",
-  "name": "Law and Public Administration",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "LAWS90227",
-  "name": "Human Rights and the Digital State",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "MGMT90128",
-  "name": "Project Management",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "MGMT90234",
-  "name": "Leaders, Business & Culture in Florence",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "MUSI90190",
-  "name": "Keyboard Repertoire and the Teacher",
-  "offered": [
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MUSI90243",
   "name": "Opera Atelier",
   "offered": [
    "september"
-  ]
- },
- {
-  "code": "NURS90070",
-  "name": "Implementing Evidence for Practice",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "NURS90074",
-  "name": "Psychosocial Aspects of Palliative Care",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "NURS90117",
-  "name": "Foundations in Neonatal Care",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "NURS90122",
-  "name": "Foundations of Critical Care Nursing",
-  "offered": [
-   "march",
-   "september"
-  ]
- },
- {
-  "code": "NURS90127",
-  "name": "Intensive Care Nursing 2",
-  "offered": [
-   "march",
-   "september"
-  ]
- },
- {
-  "code": "NURS90141",
-  "name": "Psychotherapy Essentials",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "NURS90142",
-  "name": "Alcohol, Other Drugs and Recovery",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "NURS90144",
-  "name": "Emergency Nursing 2",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "PHTY90097",
-  "name": "Musculoskeletal Disorders in Women",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "POLS30034",
-  "name": "Political Psychology",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "POLS90053",
-  "name": "India and the World",
-  "offered": [
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "POPH90020",
   "name": "Health Promotion",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "POPH90066",
-  "name": "Women and Global Health",
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
   "offered": [
+   "january",
+   "april",
+   "june",
    "september"
-  ]
- },
- {
-  "code": "POPH90088",
-  "name": "Disability and Global Development",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "POPH90145",
-  "name": "Survival Analysis & Regression for Rates",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "POPH90191",
-  "name": "Practice of Public Health Leadership",
-  "offered": [
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "PPMN90007",
@@ -675,56 +581,787 @@
   "offered": [
    "march",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PPMN90032",
-  "name": "Innovative Design and Service Delivery",
+  "code": "BUSA90480",
+  "name": "Leadership",
+  "offered": [
+   "summer_term",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90069",
+  "name": "Researching Social Work Practice 1",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90261",
+  "name": "Marketing Strategy",
+  "offered": [
+   "april",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90137",
+  "name": "Personal and Interpersonal Leadership",
+  "offered": [
+   "january",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90221",
+  "name": "Consultation in Educational Settings",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90074",
+  "name": "Psychosocial Aspects of Palliative Care",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90490",
+  "name": "Integrative Business Capstone",
+  "offered": [
+   "summer_term",
+   "june",
+   "winter_term",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90193",
+  "name": "Managerial Economics",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90017",
+  "name": "Violence, Trauma and Reconciliation",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70033",
+  "name": "International Criminal Law",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90120",
+  "name": "Building Sustainability",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90068",
+  "name": "Port Access and Navigation",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90167",
+  "name": "Investments",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENEN90014",
+  "name": "Sustainable Buildings",
+  "offered": [
+   "september"
+  ],
+  "online": false
  },
  {
   "code": "PSYT90057",
   "name": "Mental Illness in Young People II",
   "offered": [
    "september"
-  ]
- },
- {
-  "code": "PSYT90099",
-  "name": "Mental Ill-health in Young People 1",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "PSYT90103",
-  "name": "Biological Interventions with Youth",
-  "offered": [
-   "september"
-  ]
- },
- {
-  "code": "PSYT90104",
-  "name": "Working with Marginalised Young People",
-  "offered": [
-   "september"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "PSYT90115",
   "name": "Managing Youth Self-harm and Suicide 2",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCWK90038",
-  "name": "Social Work Practice: Mental Health",
+  "code": "SCWK90070",
+  "name": "Working in Human Service Organisations",
   "offered": [
    "september"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90371",
+  "name": "Design Activism",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90077",
+  "name": "Value Chain Analysis",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70230",
+  "name": "Commercial Law in Asia",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "PPMN90007",
+  "name": "Public Policy Analysis",
+  "offered": [
+   "march",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS90119",
+  "name": "Law and Public Administration",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "CVEN90068",
+  "name": "Port Access and Navigation",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BISY90017",
+  "name": "Quant. Decision Making & Optimisation",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70462",
+  "name": "Sports Integrity and Investigations",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90029",
+  "name": "Construction Studies",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90128",
+  "name": "Project Management",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90167",
+  "name": "Investments",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90480",
+  "name": "Leadership",
+  "offered": [
+   "summer_term",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCWK90069",
+  "name": "Researching Social Work Practice 1",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "CRIM90017",
+  "name": "Violence, Trauma and Reconciliation",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70033",
+  "name": "International Criminal Law",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90612",
+  "name": "Teaching for Student Engagement",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS70081",
+  "name": "Capital Gains Tax: Problems in Practice",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90227",
+  "name": "Operations",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90032",
+  "name": "Introduction to Mineralogy",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "VETS40023",
+  "name": "Professional Veterinary Practice Part 2",
+  "offered": [
+   "march",
+   "semester_2",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "SOCI90003",
+  "name": "Comparative Social Policy",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGM90019",
+  "name": "Management and Leadership for Engineers",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "CUMC90030",
+  "name": "Conservation Assessment and Treatment 1",
+  "offered": [
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90142",
+  "name": "Alcohol, Other Drugs and Recovery",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90145",
+  "name": "Survival Analysis & Regression for Rates",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
+  "offered": [
+   "summer_term",
+   "april",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90190",
+  "name": "Keyboard Repertoire and the Teacher",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90081",
+  "name": "Advanced Payment Devices and Fintech",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90073",
+  "name": "Leading Development",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90578",
+  "name": "Linking School and Community",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90053",
+  "name": "Corporate Strategy",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90043",
+  "name": "Tree Identification and Selection",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90139",
+  "name": "Leading a Learning Community",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90026",
+  "name": "Business Strategy",
+  "offered": [
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90122",
+  "name": "Foundations of Critical Care Nursing",
+  "offered": [
+   "march",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20030",
+  "name": "Wine & Spirits:An Australian Perspective",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20033",
+  "name": "Introduction to Printmaking Processes",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90458",
+  "name": "Managerial Judgement",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS30034",
+  "name": "Political Psychology",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70149",
+  "name": "Construction Risk",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS40022",
+  "name": "Professional Veterinary Practice Part 1",
+  "offered": [
+   "semester_1",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90141",
+  "name": "Psychotherapy Essentials",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90530",
+  "name": "Managing Sustainability for Strat. Adv.",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90093",
+  "name": "Finance",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90258",
+  "name": "Marketing Research",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90117",
+  "name": "Foundations in Neonatal Care",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70046",
+  "name": "Trade Marks and Unfair Competition",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90846",
+  "name": "Learning Intervention 2",
+  "offered": [
+   "april",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20045",
+  "name": "Introduction to Screenprinting",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "winter_term",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90142",
+  "name": "Alcohol, Other Drugs and Recovery",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90145",
+  "name": "Survival Analysis & Regression for Rates",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
+  "offered": [
+   "summer_term",
+   "april",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90190",
+  "name": "Keyboard Repertoire and the Teacher",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90081",
+  "name": "Advanced Payment Devices and Fintech",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "DEVT90073",
+  "name": "Leading Development",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90578",
+  "name": "Linking School and Community",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90053",
+  "name": "Corporate Strategy",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "HORT90043",
+  "name": "Tree Identification and Selection",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90139",
+  "name": "Leading a Learning Community",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90026",
+  "name": "Business Strategy",
+  "offered": [
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90122",
+  "name": "Foundations of Critical Care Nursing",
+  "offered": [
+   "march",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI20030",
+  "name": "Wine & Spirits:An Australian Perspective",
+  "offered": [
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20033",
+  "name": "Introduction to Printmaking Processes",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90088",
+  "name": "Disability and Global Development",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90055",
+  "name": "Legal and Ethical Contexts of Practice",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90054",
+  "name": "Assessing Risk and Vulnerability",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70042",
+  "name": "Company Takeovers",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN90014",
+  "name": "Sustainable Buildings",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90017",
+  "name": "Bushfire Planning & Management",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90066",
+  "name": "Women and Global Health",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90053",
+  "name": "India and the World",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHTY90097",
+  "name": "Musculoskeletal Disorders in Women",
+  "offered": [
+   "september"
+  ],
+  "online": true
  },
  {
   "code": "SCWK90048",
@@ -734,65 +1371,453 @@
    "may",
    "september",
    "november"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCWK90054",
-  "name": "Assessing Risk and Vulnerability",
+  "code": "LAWS70112",
+  "name": "Remedies in the Construction Context",
   "offered": [
    "september"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCWK90055",
-  "name": "Legal and Ethical Contexts of Practice",
+  "code": "ABPL90371",
+  "name": "Design Activism",
   "offered": [
    "september"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCWK90056",
-  "name": "Program Planning and Evaluation",
+  "code": "BUSA90027",
+  "name": "Business Strategy",
   "offered": [
    "september"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCWK90063",
-  "name": "Social Work Practice: Indigenous Peoples",
+  "code": "EDUC90751",
+  "name": "Understanding Schools",
   "offered": [
-   "february",
    "september"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCWK90069",
-  "name": "Researching Social Work Practice 1",
+  "code": "EVSC90023",
+  "name": "Building Behaviour in Bushfires",
   "offered": [
    "september"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70366",
+  "name": "International Refugee Law",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90057",
+  "name": "Mental Illness in Young People II",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90115",
+  "name": "Managing Youth Self-harm and Suicide 2",
+  "offered": [
+   "september"
+  ],
+  "online": true
  },
  {
   "code": "SCWK90070",
   "name": "Working in Human Service Organisations",
   "offered": [
    "september"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SOCI90003",
-  "name": "Comparative Social Policy",
+  "code": "ABPL90075",
+  "name": "Urban and Landscape Heritage",
   "offered": [
    "september"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "VETS40022",
-  "name": "Professional Veterinary Practice Part 1",
+  "code": "MGMT90234",
+  "name": "Leaders, Business & Culture in Florence",
   "offered": [
-   "semester_1",
    "september"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90030",
+  "name": "Conservation Assessment and Treatment 1",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90088",
+  "name": "Disability and Global Development",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90054",
+  "name": "Assessing Risk and Vulnerability",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90055",
+  "name": "Legal and Ethical Contexts of Practice",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90751",
+  "name": "Understanding Schools",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90027",
+  "name": "Business Strategy",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POLS90053",
+  "name": "India and the World",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EVSC90023",
+  "name": "Building Behaviour in Bushfires",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70042",
+  "name": "Company Takeovers",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90048",
+  "name": "Supervised Field Placement 1A",
+  "offered": [
+   "february",
+   "may",
+   "september",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "FRST90017",
+  "name": "Bushfire Planning & Management",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHTY90097",
+  "name": "Musculoskeletal Disorders in Women",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70366",
+  "name": "International Refugee Law",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90066",
+  "name": "Women and Global Health",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI90243",
+  "name": "Opera Atelier",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70112",
+  "name": "Remedies in the Construction Context",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90075",
+  "name": "Urban and Landscape Heritage",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90510",
+  "name": "Executive Management 6",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "POPH90020",
+  "name": "Health Promotion",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENEN90014",
+  "name": "Sustainable Buildings",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90057",
+  "name": "Mental Illness in Young People II",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYT90115",
+  "name": "Managing Youth Self-harm and Suicide 2",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90070",
+  "name": "Working in Human Service Organisations",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90371",
+  "name": "Design Activism",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90077",
+  "name": "Value Chain Analysis",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70230",
+  "name": "Commercial Law in Asia",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90001",
+  "name": "Financial Accounting",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "PPMN90007",
+  "name": "Public Policy Analysis",
+  "offered": [
+   "march",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS90119",
+  "name": "Law and Public Administration",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "CVEN90068",
+  "name": "Port Access and Navigation",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BISY90017",
+  "name": "Quant. Decision Making & Optimisation",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70462",
+  "name": "Sports Integrity and Investigations",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90029",
+  "name": "Construction Studies",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90128",
+  "name": "Project Management",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90167",
+  "name": "Investments",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90480",
+  "name": "Leadership",
+  "offered": [
+   "summer_term",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90069",
+  "name": "Researching Social Work Practice 1",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90017",
+  "name": "Violence, Trauma and Reconciliation",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70033",
+  "name": "International Criminal Law",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90612",
+  "name": "Teaching for Student Engagement",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS70081",
+  "name": "Capital Gains Tax: Problems in Practice",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90227",
+  "name": "Operations",
+  "offered": [
+   "january",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90032",
+  "name": "Introduction to Mineralogy",
+  "offered": [
+   "september"
+  ],
+  "online": true
  },
  {
   "code": "VETS40023",
@@ -801,6 +1826,31 @@
    "march",
    "semester_2",
    "september"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "SOCI90003",
+  "name": "Comparative Social Policy",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGM90019",
+  "name": "Management and Leadership for Engineers",
+  "offered": [
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "CUMC90030",
+  "name": "Conservation Assessment and Treatment 1",
+  "offered": [
+   "september"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_summer_term.json
+++ b/subject-utils/subject-lists/subjects_2021_summer_term.json
@@ -1,573 +1,21 @@
 [
  {
-  "code": "ABPL90115",
-  "name": "Master of Architecture Studio E",
+  "code": "MGMT90141",
+  "name": "Business Analysis & Decision Making",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "ABPL90142",
-  "name": "Master of Architecture Studio C",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90143",
-  "name": "Master of Architecture Studio D",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90153",
-  "name": "Complex Building Energy Modelling",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "ABPL90222",
-  "name": "Ex_Lab: Timber Furniture",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90277",
-  "name": "Humanitarian Construction",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "ABPL90306",
-  "name": "MUP Independent Study",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90307",
-  "name": "MSD Vocational Placement",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "may",
-   "semester_2"
-  ]
- },
- {
-  "code": "ABPL90378",
-  "name": "DF_Lab: Designing Making",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "ABPL90412",
-  "name": "R_Lab: Made by Robots",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "ACCT10001",
-  "name": "Accounting Reports and Analysis",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT10002",
-  "name": "Introductory Financial Accounting",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT20002",
-  "name": "Intermediate Financial Accounting",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ACCT90004",
-  "name": "Accounting for Decision Making",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI30022",
-  "name": "Special Studies",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI30041",
-  "name": "Industry Internship",
-  "offered": [
-   "summer_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "AGRI90076",
-  "name": "Industry Internship",
-  "offered": [
-   "summer_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "AIND10003",
-  "name": "Ancient & Contemporary Indigenous Arts",
-  "offered": [
-   "summer_term",
-   "june"
-  ]
- },
- {
-  "code": "AIND20012",
-  "name": "Ancient & Contemporary Indigenous Arts 2",
-  "offered": [
-   "summer_term",
-   "winter_term"
-  ]
- },
- {
-  "code": "ARCH30004",
-  "name": "Environmental Design in Housing",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "BIEN90001",
-  "name": "Biochemical Engineering Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "BIEN90003",
-  "name": "Biochemical Engineering Minor Thesis",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "BIOL10008",
-  "name": "Introductory Biology: Life's Machinery",
-  "offered": [
-   "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "BIOM30003",
-  "name": "Biomedical Science Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "BLAW20003",
-  "name": "Consumer Law",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "BOTA20004",
-  "name": "Flora of Victoria",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "BOTA30006",
-  "name": "Field Botany",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "BOTA90005",
-  "name": "Flora of Victoria",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "BUSA90013",
-  "name": "Brand Management",
-  "offered": [
-   "summer_term",
-   "june"
-  ]
- },
- {
-  "code": "BUSA90014",
-  "name": "Brand Management",
-  "offered": [
-   "summer_term",
-   "april",
-   "june"
-  ]
- },
- {
-  "code": "BUSA90124",
-  "name": "Implementation of Strategy",
-  "offered": [
-   "summer_term",
-   "may"
-  ]
- },
- {
-  "code": "BUSA90201",
-  "name": "Managerial Project",
-  "offered": [
-   "summer_term",
-   "april",
-   "may",
-   "june"
-  ]
- },
- {
-  "code": "BUSA90228",
-  "name": "Operations",
-  "offered": [
-   "summer_term"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "BUSA90274",
   "name": "Negotiations",
   "offered": [
    "summer_term"
-  ]
- },
- {
-  "code": "BUSA90473",
-  "name": "Business Practicum",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "BUSA90480",
-  "name": "Leadership",
-  "offered": [
-   "summer_term",
-   "march",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90481",
-  "name": "Managerial Ethics & Business Environment",
-  "offered": [
-   "summer_term",
-   "april",
-   "march",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90487",
-  "name": "General Management 3",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "BUSA90490",
-  "name": "Integrative Business Capstone",
-  "offered": [
-   "summer_term",
-   "june",
-   "winter_term",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90508",
-  "name": "Executive Management 4",
-  "offered": [
-   "summer_term",
-   "november"
-  ]
- },
- {
-  "code": "BUSA90511",
-  "name": "Executive Management 7",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "BUSA90520",
-  "name": "Data Wrangling and Visualisation",
-  "offered": [
-   "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "BUSA90525",
-  "name": "Business and Economics Internship",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHEM10004",
-  "name": "Chemistry 2",
-  "offered": [
-   "summer_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHEM20019",
-  "name": "Practical Chemistry 2",
-  "offered": [
-   "summer_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHEM30013",
-  "name": "Chemical Research Project",
-  "offered": [
-   "summer_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHEN90023",
-  "name": "Chemical Engineering Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHEN90026",
-  "name": "Chemical Engineering Minor Research Proj",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHEN90028",
-  "name": "Chemical Engineering Internship",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CHEN90030",
-  "name": "Chemical Engineering Minor Thesis",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CLAS10006",
-  "name": "Latin 1",
-  "offered": [
-   "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "CLAS10007",
-  "name": "Latin 2",
-  "offered": [
-   "summer_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "CLAS20021",
-  "name": "Intensive Beginners Latin",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "CLAS30004",
-  "name": "Intensive Beginners Latin",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "COMP10001",
-  "name": "Foundations of Computing",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP30013",
-  "name": "Advanced Studies in Computing",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90005",
-  "name": "Advanced Studies in Computing",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90055",
-  "name": "Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "COMP90059",
-  "name": "Introduction to Programming",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "CRIM90030",
-  "name": "Criminology & Sociology Internship Pt 1",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON10003",
-  "name": "Introductory Macroeconomics",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ECON20002",
-  "name": "Intermediate Microeconomics",
-  "offered": [
-   "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "ECON20003",
-  "name": "Quantitative Methods 2",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC10051",
-  "name": "Sports Coaching: Theory and Practice",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "EDUC10057",
-  "name": "Wellbeing, Motivation and Performance",
-  "offered": [
-   "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "EDUC90422",
-  "name": "Foundations of English Teaching",
-  "offered": [
-   "summer_term",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90504",
-  "name": "Leadership in Educational Settings",
-  "offered": [
-   "summer_term",
-   "june",
-   "june"
-  ]
- },
- {
-  "code": "EDUC90972",
-  "name": "Active Pedagogies",
-  "offered": [
-   "summer_term"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "EDUC90974",
@@ -575,43 +23,27 @@
   "offered": [
    "summer_term",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ELEN90083",
-  "name": "Electrical Engineering Research Project",
+  "code": "MGMT90146",
+  "name": "Strategic Management",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ENGR20004",
-  "name": "Engineering Mechanics",
+  "code": "NURS90126",
+  "name": "Intensive Care Nursing 1",
   "offered": [
    "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENGR90033",
-  "name": "Internship",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "ENST90006",
-  "name": "Environmental Research Review (12.5)",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "ENST90007",
@@ -620,80 +52,179 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ERTH90032",
-  "name": "Interpretation of Satellite Images",
+  "code": "COMP30013",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90508",
+  "name": "Executive Management 4",
+  "offered": [
+   "summer_term",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90487",
+  "name": "General Management 3",
   "offered": [
    "summer_term"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90005",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90031",
+  "name": "Spatial Information Research Project D",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90228",
+  "name": "Operations",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90013",
+  "name": "Brand Management",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIEN90003",
+  "name": "Biochemical Engineering Minor Thesis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90013",
+  "name": "Spatial Information Research Project C",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90043",
+  "name": "Spatial IT Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90201",
+  "name": "Managerial Project",
+  "offered": [
+   "summer_term",
+   "january",
+   "april",
+   "may",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "IBUS90004",
+  "name": "Cross Cultural Management and Teamwork",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90031",
+  "name": "Adult Psychopathology",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT90039",
+  "name": "Green Infrastructure for Liveable Cities",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90004",
+  "name": "Accounting for Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "ERTH90033",
   "name": "Geology from Geophysics",
   "offered": [
    "summer_term"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "EURO20007",
-  "name": "A Taste of Europe: Melbourne Intensive",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "EURO30006",
-  "name": "A Taste of Europe: Melbourne Intensive",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "FINA20026",
-  "name": "Painting Techniques",
+  "code": "MUSI20108",
+  "name": "MCM Chinese Music Ensemble",
   "offered": [
    "summer_term",
-   "february",
    "semester_1",
-   "winter_term",
-   "june",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA20033",
-  "name": "Introduction to Printmaking Processes",
+  "code": "ENGR90033",
+  "name": "Internship",
   "offered": [
    "summer_term",
-   "march",
-   "april",
-   "june",
-   "september"
-  ]
- },
- {
-  "code": "FINA20036",
-  "name": "Under Camera Animation",
-  "offered": [
-   "summer_term",
-   "february",
-   "winter_term",
-   "june"
-  ]
- },
- {
-  "code": "FINA20044",
-  "name": "Art and the Botanical",
-  "offered": [
-   "summer_term",
-   "february",
    "semester_1",
-   "winter_term",
-   "june",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "FINA20045",
@@ -705,16 +236,130 @@
    "winter_term",
    "june",
    "september"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FNCE10002",
-  "name": "Principles of Finance",
+  "code": "HPSC20015",
+  "name": "Astronomy in World History",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10017",
+  "name": "Riffs: Guitar Cultures & Practice 1",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "AIND20012",
+  "name": "Ancient & Contemporary Indigenous Arts 2",
+  "offered": [
+   "summer_term",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20036",
+  "name": "Under Camera Animation",
+  "offered": [
+   "summer_term",
+   "february",
+   "winter_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT20001",
+  "name": "Organisational Behaviour",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS20021",
+  "name": "Intensive Beginners Latin",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10004",
+  "name": "German 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10023",
+  "name": "Music Language 1: the Diatonic World",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR20004",
+  "name": "Engineering Mechanics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20002",
+  "name": "Intermediate Microeconomics",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20005",
+  "name": "Statistics",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10003",
+  "name": "Introductory Macroeconomics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20003",
+  "name": "Quantitative Methods 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "FNCE20005",
@@ -723,97 +368,8 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
- },
- {
-  "code": "FNCE30009",
-  "name": "Ethics in Finance",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "FOOD90042",
-  "name": "Special Studies in Food",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "FREN20018",
-  "name": "Intensive French 3 and 4",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "GEOG90022",
-  "name": "International Internship in Environment",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOG90028",
-  "name": "Geography Practical",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOL20001",
-  "name": "Geology of Southeast Australia",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "GEOL20004",
-  "name": "Field Mapping and Sedimentary Geology",
-  "offered": [
-   "summer_term",
-   "june"
-  ]
- },
- {
-  "code": "GEOL90045",
-  "name": "Exploration Skills Mapping",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "GEOL90050",
-  "name": "Field Geology of New Zealand",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "GEOM90010",
-  "name": "Spatial Information Research Project A",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90013",
-  "name": "Spatial Information Research Project C",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "GEOM90020",
@@ -823,269 +379,27 @@
    "semester_1",
    "winter_term",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "GEOM90023",
-  "name": "Spatial Information Research Project B",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90031",
-  "name": "Spatial Information Research Project D",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90043",
-  "name": "Spatial IT Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90044",
-  "name": "Geographic Information Systems",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "GERM10004",
-  "name": "German 1",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term"
-  ]
- },
- {
-  "code": "GERM10005",
-  "name": "German 2",
+  "code": "MUSI30046",
+  "name": "Music Language 3: Modern Directions",
   "offered": [
    "summer_term",
    "semester_2"
-  ]
- },
- {
-  "code": "HIST20087",
-  "name": "City Visions: Melbourne Intensive",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "HORT90039",
-  "name": "Green Infrastructure for Liveable Cities",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "HPSC20002",
-  "name": "A History of Nature",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "HPSC20015",
-  "name": "Astronomy in World History",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "IBUS90004",
-  "name": "Cross Cultural Management and Teamwork",
-  "offered": [
-   "summer_term",
-   "june",
-   "november"
-  ]
- },
- {
-  "code": "INDG90002",
-  "name": "Enacting Influence",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "ISLM90008",
-  "name": "Islam and Politics: Interfaith Relations",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "ISYS90079",
-  "name": "Health IT Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "JOUR90011",
-  "name": "Data Journalism",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "JOUR90017",
-  "name": "Journalism Project (Extended) Part 1",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "LAWS50023",
-  "name": "Legal Method and Reasoning",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "LAWS50055",
-  "name": "Advocacy",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "LAWS50058",
-  "name": "Melbourne University Law Review",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "LAWS50060",
-  "name": "Melbourne Journal of International Law",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "LAWS50131",
-  "name": "Negotiations",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "MAST10006",
-  "name": "Calculus 2",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST10007",
-  "name": "Linear Algebra",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST20005",
-  "name": "Statistics",
-  "offered": [
-   "summer_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST20029",
-  "name": "Engineering Mathematics",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST90079",
-  "name": "AMSI Summer School",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "MAST90108",
-  "name": "Data Science Research Project Pt1",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MAST90109",
-  "name": "Data Science Research Project Pt2",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MGMT20001",
-  "name": "Organisational Behaviour",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MGMT30017",
   "name": "Global Management Consulting",
   "offered": [
    "summer_term",
+   "june",
    "november"
-  ]
- },
- {
-  "code": "MGMT30019",
-  "name": "The Future of Work",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "MGMT90037",
-  "name": "Conflict and Negotiation",
-  "offered": [
-   "summer_term",
-   "winter_term",
-   "november"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "MGMT90141",
@@ -1094,7 +408,25 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90274",
+  "name": "Negotiations",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90974",
+  "name": "Teaching Critical and Creative Thinking",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "MGMT90146",
@@ -1103,125 +435,191 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90252",
-  "name": "Enterprise Skills Intensive",
+  "code": "ENST90007",
+  "name": "Environmental Research Project (25)",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP30013",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90487",
+  "name": "General Management 3",
   "offered": [
    "summer_term"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MGMT90256",
-  "name": "Supply Chain Frameworks",
+  "code": "COMP90005",
+  "name": "Advanced Studies in Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90126",
+  "name": "Intensive Care Nursing 1",
   "offered": [
    "summer_term",
    "june"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MKTG10001",
-  "name": "Principles of Marketing",
+  "code": "BUSA90508",
+  "name": "Executive Management 4",
+  "offered": [
+   "summer_term",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIEN90003",
+  "name": "Biochemical Engineering Minor Thesis",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MKTG20009",
-  "name": "Global Marketing",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "MKTG90004",
-  "name": "Marketing Management",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MKTG90037",
-  "name": "Managing for Value Creation",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MREN90005",
-  "name": "Materials Engineering Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT20010",
-  "name": "Arts Internship",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT20014",
-  "name": "Community Volunteering - Global",
-  "offered": [
-   "summer_term",
-   "june"
-  ]
- },
- {
-  "code": "MULT30015",
-  "name": "Independent Research Project",
+  "code": "GEOM90013",
+  "name": "Spatial Information Research Project C",
   "offered": [
    "summer_term",
    "semester_1",
    "winter_term",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MULT30019",
-  "name": "Arts Internship",
+  "code": "GEOM90031",
+  "name": "Spatial Information Research Project D",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI10017",
-  "name": "Riffs: Guitar Cultures & Practice 1",
+  "code": "BUSA90228",
+  "name": "Operations",
   "offered": [
-   "summer_term",
-   "semester_1"
-  ]
+   "summer_term"
+  ],
+  "online": false
  },
  {
-  "code": "MUSI10023",
-  "name": "Music Language 1: the Diatonic World",
+  "code": "BUSA90013",
+  "name": "Brand Management",
   "offered": [
    "summer_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90043",
+  "name": "Spatial IT Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20061",
-  "name": "Music Language 2: Chromaticism & Beyond",
+  "code": "BUSA90201",
+  "name": "Managerial Project",
   "offered": [
    "summer_term",
+   "january",
+   "april",
+   "may",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "IBUS90004",
+  "name": "Cross Cultural Management and Teamwork",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20045",
+  "name": "Introduction to Screenprinting",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "winter_term",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT90004",
+  "name": "Accounting for Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "HORT90039",
+  "name": "Green Infrastructure for Liveable Cities",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ERTH90033",
+  "name": "Geology from Geophysics",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90031",
+  "name": "Adult Psychopathology",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
  },
  {
   "code": "MUSI20108",
@@ -1230,85 +628,227 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20135",
-  "name": "Chinese Music Ensemble 1",
+  "code": "ENGR90033",
+  "name": "Internship",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20143",
-  "name": "World Music Choir",
+  "code": "AIND20012",
+  "name": "Ancient & Contemporary Indigenous Arts 2",
   "offered": [
    "summer_term",
-   "semester_1",
-   "semester_2"
-  ]
+   "winter_term"
+  ],
+  "online": false
  },
  {
-  "code": "MUSI20198",
-  "name": "Music History 2: C19th Music and Ideas",
+  "code": "FINA20036",
+  "name": "Under Camera Animation",
   "offered": [
    "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "MUSI30046",
-  "name": "Music Language 3: Modern Directions",
-  "offered": [
-   "summer_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "MUSI30249",
-  "name": "Music History 3:Impressionism to Present",
-  "offered": [
-   "summer_term",
-   "semester_1"
-  ]
- },
- {
-  "code": "NURS90012",
-  "name": "Psychopharmacology",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "NURS90076",
-  "name": "Applied Pathophysiology",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "NURS90077",
-  "name": "Specialist Mental Health Nursing",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "NURS90124",
-  "name": "Mental Health & Recovery",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "NURS90126",
-  "name": "Intensive Care Nursing 1",
-  "offered": [
-   "summer_term",
+   "february",
+   "winter_term",
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10017",
+  "name": "Riffs: Guitar Cultures & Practice 1",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI10023",
+  "name": "Music Language 1: the Diatonic World",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC20015",
+  "name": "Astronomy in World History",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ENGR20004",
+  "name": "Engineering Mechanics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20002",
+  "name": "Intermediate Microeconomics",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT20001",
+  "name": "Organisational Behaviour",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS20021",
+  "name": "Intensive Beginners Latin",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10004",
+  "name": "German 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20005",
+  "name": "Statistics",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON10003",
+  "name": "Introductory Macroeconomics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ECON20003",
+  "name": "Quantitative Methods 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM20019",
+  "name": "Practical Chemistry 2",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90044",
+  "name": "Geographic Information Systems",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90023",
+  "name": "Chemical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90473",
+  "name": "Business Practicum",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE90018",
+  "name": "Science Research Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90037",
+  "name": "Conflict and Negotiation",
+  "offered": [
+   "summer_term",
+   "winter_term",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90108",
+  "name": "Data Science Research Project Pt1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE30003",
+  "name": "Science Research Project Abroad",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOG90022",
+  "name": "International Internship in Environment",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "ORAL30003",
@@ -1321,14 +861,164 @@
    "june",
    "june",
    "august"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PHIL20045",
-  "name": "Freedom and Equality Across Borders",
+  "code": "ELEN90083",
+  "name": "Electrical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30015",
+  "name": "Independent Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90153",
+  "name": "Complex Building Energy Modelling",
   "offered": [
    "summer_term"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90143",
+  "name": "Master of Architecture Studio D",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI90076",
+  "name": "Industry Internship",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90142",
+  "name": "Master of Architecture Studio C",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "LAWS50131",
+  "name": "Negotiations",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90077",
+  "name": "Specialist Mental Health Nursing",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "INDG90002",
+  "name": "Enacting Influence",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "BIOM30003",
+  "name": "Biomedical Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90059",
+  "name": "Introduction to Programming",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARCH30004",
+  "name": "Environmental Design in Housing",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20014",
+  "name": "Community Volunteering - Global",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10057",
+  "name": "Wellbeing, Motivation and Performance",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20010",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE30009",
+  "name": "Ethics in Finance",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT10001",
+  "name": "Accounting Reports and Analysis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "PHYC10004",
@@ -1336,56 +1026,25 @@
   "offered": [
    "summer_term",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PLAN90003",
-  "name": "City Leadership",
+  "code": "EURO20007",
+  "name": "A Taste of Europe: Melbourne Intensive",
   "offered": [
    "summer_term"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "PSYC90011",
-  "name": "Introduction to Assessment and Diagnosis",
+  "code": "CLAS10006",
+  "name": "Latin 1",
   "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "PSYC90031",
-  "name": "Adult Psychopathology",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "PSYC90097",
-  "name": "Mind, Brain & Behaviour 1",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "PSYC90098",
-  "name": "Mind, Brain & Behaviour 2",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "PSYC90114",
-  "name": "Professional Psychology Skills 2",
-  "offered": [
-   "summer_term"
-  ]
- },
- {
-  "code": "PUBL90026",
-  "name": "Publishing and Writing Summer School",
-  "offered": [
-   "summer_term"
-  ]
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
  },
  {
   "code": "SCIE30001",
@@ -1394,25 +1053,68 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE30002",
-  "name": "Science and Technology Internship",
+  "code": "HIST20087",
+  "name": "City Visions: Melbourne Intensive",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20135",
+  "name": "Chinese Music Ensemble 1",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE30003",
-  "name": "Science Research Project Abroad",
+  "code": "MKTG90004",
+  "name": "Marketing Management",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90097",
+  "name": "Mind, Brain & Behaviour 1",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "BOTA90005",
+  "name": "Flora of Victoria",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90098",
+  "name": "Mind, Brain & Behaviour 2",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "PLAN90003",
+  "name": "City Leadership",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
  },
  {
   "code": "SCIE90017",
@@ -1421,16 +1123,641 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SCIE90018",
-  "name": "Science Research Internship",
+  "code": "MAST90079",
+  "name": "AMSI Summer School",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90504",
+  "name": "Leadership in Educational Settings",
+  "offered": [
+   "summer_term",
+   "june",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30022",
+  "name": "Special Studies",
   "offered": [
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90026",
+  "name": "Chemical Engineering Minor Research Proj",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90378",
+  "name": "DF_Lab: Designing Making",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90306",
+  "name": "MUP Independent Study",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM90008",
+  "name": "Islam and Politics: Interfaith Relations",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MREN90005",
+  "name": "Materials Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90037",
+  "name": "Managing for Value Creation",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30019",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE30002",
+  "name": "Science and Technology Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90076",
+  "name": "Applied Pathophysiology",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30249",
+  "name": "Music History 3:Impressionism to Present",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC20002",
+  "name": "A History of Nature",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT10002",
+  "name": "Introductory Financial Accounting",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE10002",
+  "name": "Principles of Finance",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BLAW20003",
+  "name": "Consumer Law",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT20002",
+  "name": "Intermediate Financial Accounting",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20029",
+  "name": "Engineering Mathematics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM30013",
+  "name": "Chemical Research Project",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG20009",
+  "name": "Global Marketing",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI20143",
+  "name": "World Music Choir",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC10051",
+  "name": "Sports Coaching: Theory and Practice",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP10001",
+  "name": "Foundations of Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BOTA30006",
+  "name": "Field Botany",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT30019",
+  "name": "The Future of Work",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MREN90005",
+  "name": "Materials Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90378",
+  "name": "DF_Lab: Designing Making",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ISLM90008",
+  "name": "Islam and Politics: Interfaith Relations",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG90037",
+  "name": "Managing for Value Creation",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEN90026",
+  "name": "Chemical Engineering Minor Research Proj",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90480",
+  "name": "Leadership",
+  "offered": [
+   "summer_term",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90306",
+  "name": "MUP Independent Study",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90115",
+  "name": "Master of Architecture Studio E",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30022",
+  "name": "Special Studies",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90490",
+  "name": "Integrative Business Capstone",
+  "offered": [
+   "summer_term",
+   "june",
+   "winter_term",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90422",
+  "name": "Foundations of English Teaching",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90011",
+  "name": "Introduction to Assessment and Diagnosis",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "AGRI30041",
+  "name": "Industry Internship",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC90504",
+  "name": "Leadership in Educational Settings",
+  "offered": [
+   "summer_term",
+   "june",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90307",
+  "name": "MSD Vocational Placement",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "may",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30019",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "SCIE30002",
+  "name": "Science and Technology Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "NURS90076",
+  "name": "Applied Pathophysiology",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "MUSI30249",
+  "name": "Music History 3:Impressionism to Present",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT20002",
+  "name": "Intermediate Financial Accounting",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "MKTG20009",
+  "name": "Global Marketing",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST20029",
+  "name": "Engineering Mathematics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC20002",
+  "name": "A History of Nature",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS30004",
+  "name": "Intensive Beginners Latin",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST10007",
+  "name": "Linear Algebra",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ACCT10002",
+  "name": "Introductory Financial Accounting",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FNCE10002",
+  "name": "Principles of Finance",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BLAW20003",
+  "name": "Consumer Law",
+  "offered": [
+   "summer_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "CHEM30013",
+  "name": "Chemical Research Project",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GERM10005",
+  "name": "German 2",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90020",
+  "name": "Spatial Information Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIEN90001",
+  "name": "Biochemical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90018",
+  "name": "Journalism Project (Extended) Part 2",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90511",
+  "name": "Executive Management 7",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90030",
+  "name": "Criminology & Sociology Internship Pt 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH90032",
+  "name": "Interpretation of Satellite Images",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90011",
+  "name": "Data Journalism",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90012",
+  "name": "Psychopharmacology",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90028",
+  "name": "Geography Practical",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90412",
+  "name": "R_Lab: Made by Robots",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90109",
+  "name": "Data Science Research Project Pt2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90124",
+  "name": "Implementation of Strategy",
+  "offered": [
+   "summer_term",
+   "may"
+  ],
+  "online": true
  },
  {
   "code": "SCIE90027",
@@ -1439,27 +1766,606 @@
    "summer_term",
    "semester_1",
    "semester_2"
-  ]
+  ],
+  "online": true
  },
  {
-  "code": "SCWK90049",
-  "name": "Supervised Field Placement 1B",
+  "code": "BUSA90520",
+  "name": "Data Wrangling and Visualisation",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
   "offered": [
    "summer_term",
    "april",
+   "march",
    "june",
-   "october"
-  ]
+   "september"
+  ],
+  "online": true
  },
  {
-  "code": "SCWK90051",
-  "name": "Supervised Field Placement 2B",
+  "code": "CHEN90030",
+  "name": "Chemical Engineering Minor Thesis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90042",
+  "name": "Special Studies in Food",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50023",
+  "name": "Legal Method and Reasoning",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90972",
+  "name": "Active Pedagogies",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90079",
+  "name": "Health IT Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT90004",
+  "name": "Accounting for Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH90033",
+  "name": "Geology from Geophysics",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20108",
+  "name": "MCM Chinese Music Ensemble",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR90033",
+  "name": "Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20045",
+  "name": "Introduction to Screenprinting",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "winter_term",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC20015",
+  "name": "Astronomy in World History",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10017",
+  "name": "Riffs: Guitar Cultures & Practice 1",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "AIND20012",
+  "name": "Ancient & Contemporary Indigenous Arts 2",
+  "offered": [
+   "summer_term",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20036",
+  "name": "Under Camera Animation",
+  "offered": [
+   "summer_term",
+   "february",
+   "winter_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT20001",
+  "name": "Organisational Behaviour",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS20021",
+  "name": "Intensive Beginners Latin",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM10004",
+  "name": "German 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI10023",
+  "name": "Music Language 1: the Diatonic World",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENGR20004",
+  "name": "Engineering Mechanics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON20002",
+  "name": "Intermediate Microeconomics",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST20005",
+  "name": "Statistics",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON10003",
+  "name": "Introductory Macroeconomics",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ECON20003",
+  "name": "Quantitative Methods 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE20005",
+  "name": "Corporate Financial Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90520",
+  "name": "Data Wrangling and Visualisation",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90481",
+  "name": "Managerial Ethics & Business Environment",
   "offered": [
    "summer_term",
    "april",
+   "march",
    "june",
-   "october"
-  ]
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FOOD90042",
+  "name": "Special Studies in Food",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90030",
+  "name": "Chemical Engineering Minor Thesis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50023",
+  "name": "Legal Method and Reasoning",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90972",
+  "name": "Active Pedagogies",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISYS90079",
+  "name": "Health IT Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90020",
+  "name": "Spatial Information Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIEN90001",
+  "name": "Biochemical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90018",
+  "name": "Journalism Project (Extended) Part 2",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90511",
+  "name": "Executive Management 7",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "CRIM90030",
+  "name": "Criminology & Sociology Internship Pt 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH90032",
+  "name": "Interpretation of Satellite Images",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90011",
+  "name": "Data Journalism",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90012",
+  "name": "Psychopharmacology",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90028",
+  "name": "Geography Practical",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90412",
+  "name": "R_Lab: Made by Robots",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90109",
+  "name": "Data Science Research Project Pt2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90124",
+  "name": "Implementation of Strategy",
+  "offered": [
+   "summer_term",
+   "may"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90027",
+  "name": "Ecosystem Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PUBL90026",
+  "name": "Publishing and Writing Summer School",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90222",
+  "name": "Ex_Lab: Timber Furniture",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90277",
+  "name": "Humanitarian Construction",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90025",
+  "name": "Journalism Project Part 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90055",
+  "name": "Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90050",
+  "name": "Field Geology of New Zealand",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50055",
+  "name": "Advocacy",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90256",
+  "name": "Supply Chain Frameworks",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEM10004",
+  "name": "Chemistry 2",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI30046",
+  "name": "Music Language 3: Modern Directions",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30017",
+  "name": "Global Management Consulting",
+  "offered": [
+   "summer_term",
+   "june",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST10006",
+  "name": "Calculus 2",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL20004",
+  "name": "Field Mapping and Sedimentary Geology",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA20004",
+  "name": "Flora of Victoria",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10007",
+  "name": "Latin 2",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20026",
+  "name": "Painting Techniques",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20033",
+  "name": "Introduction to Printmaking Processes",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "june",
+   "september"
+  ],
+  "online": true
  },
  {
   "code": "THTR30042",
@@ -1469,6 +2375,926 @@
    "february",
    "winter_term",
    "june"
-  ]
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20018",
+  "name": "Intensive French 3 and 4",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOL10008",
+  "name": "Introductory Biology: Life's Machinery",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20061",
+  "name": "Music Language 2: Chromaticism & Beyond",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE20005",
+  "name": "Corporate Financial Decision Making",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90044",
+  "name": "Geographic Information Systems",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90023",
+  "name": "Chemical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90473",
+  "name": "Business Practicum",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90018",
+  "name": "Science Research Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90037",
+  "name": "Conflict and Negotiation",
+  "offered": [
+   "summer_term",
+   "winter_term",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90108",
+  "name": "Data Science Research Project Pt1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE30003",
+  "name": "Science Research Project Abroad",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOG90022",
+  "name": "International Internship in Environment",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ORAL30003",
+  "name": "Oral Health Therapy Research Int'l",
+  "offered": [
+   "summer_term",
+   "february",
+   "march",
+   "may",
+   "june",
+   "june",
+   "august"
+  ],
+  "online": true
+ },
+ {
+  "code": "ELEN90083",
+  "name": "Electrical Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30015",
+  "name": "Independent Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90153",
+  "name": "Complex Building Energy Modelling",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90143",
+  "name": "Master of Architecture Studio D",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI90076",
+  "name": "Industry Internship",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90142",
+  "name": "Master of Architecture Studio C",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50131",
+  "name": "Negotiations",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90077",
+  "name": "Specialist Mental Health Nursing",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG90002",
+  "name": "Enacting Influence",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM30003",
+  "name": "Biomedical Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90059",
+  "name": "Introduction to Programming",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH30004",
+  "name": "Environmental Design in Housing",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20014",
+  "name": "Community Volunteering - Global",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10057",
+  "name": "Wellbeing, Motivation and Performance",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20010",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30009",
+  "name": "Ethics in Finance",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT10001",
+  "name": "Accounting Reports and Analysis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10004",
+  "name": "Physics 2: Physical Science & Technology",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO20007",
+  "name": "A Taste of Europe: Melbourne Intensive",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10006",
+  "name": "Latin 1",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE30001",
+  "name": "Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20087",
+  "name": "City Visions: Melbourne Intensive",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20135",
+  "name": "Chinese Music Ensemble 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90004",
+  "name": "Marketing Management",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90097",
+  "name": "Mind, Brain & Behaviour 1",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA90005",
+  "name": "Flora of Victoria",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90098",
+  "name": "Mind, Brain & Behaviour 2",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "PLAN90003",
+  "name": "City Leadership",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90017",
+  "name": "Science and Technology Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MAST90079",
+  "name": "AMSI Summer School",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "JOUR90017",
+  "name": "Journalism Project (Extended) Part 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ENST90006",
+  "name": "Environmental Research Review (12.5)",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90051",
+  "name": "Supervised Field Placement 2B",
+  "offered": [
+   "summer_term",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90010",
+  "name": "Spatial Information Research Project A",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90045",
+  "name": "Exploration Skills Mapping",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCWK90049",
+  "name": "Supervised Field Placement 1B",
+  "offered": [
+   "summer_term",
+   "april",
+   "june",
+   "october"
+  ],
+  "online": true
+ },
+ {
+  "code": "NURS90124",
+  "name": "Mental Health & Recovery",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90525",
+  "name": "Business and Economics Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50060",
+  "name": "Melbourne Journal of International Law",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90023",
+  "name": "Spatial Information Research Project B",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "LAWS50058",
+  "name": "Melbourne University Law Review",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90028",
+  "name": "Chemical Engineering Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20045",
+  "name": "Freedom and Equality Across Borders",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE90066",
+  "name": "Special Topics in Finance C",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO30006",
+  "name": "A Taste of Europe: Melbourne Intensive",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG10001",
+  "name": "Principles of Marketing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ERTH20001",
+  "name": "Dangerous Earth",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL20001",
+  "name": "Geology of Southeast Australia",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20198",
+  "name": "Music History 2: C19th Music and Ideas",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20143",
+  "name": "World Music Choir",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10051",
+  "name": "Sports Coaching: Theory and Practice",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP10001",
+  "name": "Foundations of Computing",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BOTA30006",
+  "name": "Field Botany",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT30019",
+  "name": "The Future of Work",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MREN90005",
+  "name": "Materials Engineering Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90378",
+  "name": "DF_Lab: Designing Making",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ISLM90008",
+  "name": "Islam and Politics: Interfaith Relations",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MKTG90037",
+  "name": "Managing for Value Creation",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "CHEN90026",
+  "name": "Chemical Engineering Minor Research Proj",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90480",
+  "name": "Leadership",
+  "offered": [
+   "summer_term",
+   "march",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90306",
+  "name": "MUP Independent Study",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90115",
+  "name": "Master of Architecture Studio E",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30022",
+  "name": "Special Studies",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90490",
+  "name": "Integrative Business Capstone",
+  "offered": [
+   "summer_term",
+   "june",
+   "winter_term",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90422",
+  "name": "Foundations of English Teaching",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90011",
+  "name": "Introduction to Assessment and Diagnosis",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "AGRI30041",
+  "name": "Industry Internship",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC90504",
+  "name": "Leadership in Educational Settings",
+  "offered": [
+   "summer_term",
+   "june",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90307",
+  "name": "MSD Vocational Placement",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "may",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "INDG90002",
+  "name": "Enacting Influence",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "BIOM30003",
+  "name": "Biomedical Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90059",
+  "name": "Introduction to Programming",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARCH30004",
+  "name": "Environmental Design in Housing",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20014",
+  "name": "Community Volunteering - Global",
+  "offered": [
+   "summer_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "HIST20087",
+  "name": "City Visions: Melbourne Intensive",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC10057",
+  "name": "Wellbeing, Motivation and Performance",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "FNCE30009",
+  "name": "Ethics in Finance",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MUSI20135",
+  "name": "Chinese Music Ensemble 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ACCT10001",
+  "name": "Accounting Reports and Analysis",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHYC10004",
+  "name": "Physics 2: Physical Science & Technology",
+  "offered": [
+   "summer_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO20007",
+  "name": "A Taste of Europe: Melbourne Intensive",
+  "offered": [
+   "summer_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10006",
+  "name": "Latin 1",
+  "offered": [
+   "summer_term",
+   "semester_1"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE30001",
+  "name": "Science Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20010",
+  "name": "Arts Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "semester_2"
+  ],
+  "online": true
  }
 ]

--- a/subject-utils/subject-lists/subjects_2021_winter_term.json
+++ b/subject-utils/subject-lists/subjects_2021_winter_term.json
@@ -1,173 +1,41 @@
 [
  {
-  "code": "ABPL30063",
-  "name": "AA Visiting School Undergraduate",
+  "code": "GEOM90020",
+  "name": "Spatial Information Research Project",
   "offered": [
-   "winter_term"
-  ]
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "ABPL90319",
   "name": "GIS In Planning, Design & Development",
   "offered": [
    "winter_term"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL90386",
-  "name": "AA Visiting School Graduate",
+  "code": "MCEN90049",
+  "name": "Helicopter Design",
   "offered": [
    "winter_term"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "ABPL90404",
-  "name": "Place Making for The Built Environment",
+  "code": "THTR30042",
+  "name": "Hashtag Cyberstar",
   "offered": [
+   "summer_term",
    "february",
-   "winter_term"
-  ]
- },
- {
-  "code": "AIND20012",
-  "name": "Ancient & Contemporary Indigenous Arts 2",
-  "offered": [
-   "summer_term",
-   "winter_term"
-  ]
- },
- {
-  "code": "AMGT90029",
-  "name": "Applied Research Methods",
-  "offered": [
-   "february",
-   "winter_term"
-  ]
- },
- {
-  "code": "ARTS90026",
-  "name": "Interdisciplinary Industry Project 1",
-  "offered": [
-   "semester_1",
    "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "ARTS90027",
-  "name": "Interdisciplinary Industry Project 2",
-  "offered": [
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "BUSA90490",
-  "name": "Integrative Business Capstone",
-  "offered": [
-   "summer_term",
-   "june",
-   "winter_term",
-   "september"
-  ]
- },
- {
-  "code": "BUSA90513",
-  "name": "Industry Studies in America",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "BUSA90525",
-  "name": "Business and Economics Internship",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "BUSA90527",
-  "name": "Digital Product Management",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "BUSA90529",
-  "name": "Building Entrepreneurial Ventures",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "CLAS10004",
-  "name": "Ancient Greek 1",
-  "offered": [
-   "semester_1",
-   "winter_term"
-  ]
- },
- {
-  "code": "CLAS20035",
-  "name": "Intensive Ancient Greek 1",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "CLAS30045",
-  "name": "Intensive Ancient Greek 1",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "COMP90050",
-  "name": "Advanced Database Systems",
-  "offered": [
-   "semester_1",
-   "winter_term"
-  ]
- },
- {
-  "code": "DNCE20040",
-  "name": "Travelling Studio",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "EDUC30072",
-  "name": "Positive Leadership and Careers",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "EDUC30076",
-  "name": "Wakanda: African Futures in Education",
-  "offered": [
-   "march",
-   "winter_term"
-  ]
- },
- {
-  "code": "EDUC91017",
-  "name": "Education Randomised Controlled Trials",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "EVSC90014",
-  "name": "Environmental Risk Assessment",
-  "offered": [
-   "winter_term"
-  ]
+   "june"
+  ],
+  "online": false
  },
  {
   "code": "FINA20026",
@@ -179,37 +47,103 @@
    "winter_term",
    "june",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "FINA20035",
-  "name": "Drawing with Anatomy",
+  "code": "EDUC30072",
+  "name": "Positive Leadership and Careers",
   "offered": [
-   "winter_term",
-   "june"
-  ]
+   "winter_term"
+  ],
+  "online": false
  },
  {
-  "code": "FINA20036",
-  "name": "Under Camera Animation",
+  "code": "CLAS10004",
+  "name": "Ancient Greek 1",
   "offered": [
-   "summer_term",
-   "february",
-   "winter_term",
-   "june"
-  ]
+   "semester_1",
+   "winter_term"
+  ],
+  "online": false
  },
  {
-  "code": "FINA20044",
-  "name": "Art and the Botanical",
+  "code": "HPSC30037",
+  "name": "Thinking about Science: Past and Present",
   "offered": [
-   "summer_term",
-   "february",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL10008",
+  "name": "Italian 1 (Intensive)",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "THTR20043",
+  "name": "Design and the Moving Image",
+  "offered": [
+   "june",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT20011",
+  "name": "Business Negotiations",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90014",
+  "name": "Business Risk Management",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90037",
+  "name": "Online Community Management",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE20040",
+  "name": "Travelling Studio",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90026",
+  "name": "Interdisciplinary Industry Project 1",
+  "offered": [
    "semester_1",
    "winter_term",
-   "june",
    "semester_2"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90013",
+  "name": "Spatial Information Research Project C",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
  },
  {
   "code": "FINA20045",
@@ -221,226 +155,8 @@
    "winter_term",
    "june",
    "september"
-  ]
- },
- {
-  "code": "FLTV30022",
-  "name": "Making Movies 3 Practical Production",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "FREN10004",
-  "name": "French 1",
-  "offered": [
-   "semester_1",
-   "winter_term"
-  ]
- },
- {
-  "code": "FREN20020",
-  "name": "In the Heart of the Loire Valley",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "FREN30018",
-  "name": "In the Heart of the Loire Valley",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "GDES30004",
-  "name": "Design Visualisation: Analogue",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "GEOL30009",
-  "name": "Advanced Field Geology",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "GEOL90043",
-  "name": "Fundamentals of Geological CO2 Storage",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "GEOM90010",
-  "name": "Spatial Information Research Project A",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90013",
-  "name": "Spatial Information Research Project C",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90020",
-  "name": "Spatial Information Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "GEOM90023",
-  "name": "Spatial Information Research Project B",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "GERM10004",
-  "name": "German 1",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term"
-  ]
- },
- {
-  "code": "HPSC30037",
-  "name": "Thinking about Science: Past and Present",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "ITAL10008",
-  "name": "Italian 1 (Intensive)",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "KORE30001",
-  "name": "Korean Politics and Society",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "MAST90007",
-  "name": "Statistics for Research Workers",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "MCEN90049",
-  "name": "Helicopter Design",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "MECM90031",
-  "name": "Audiovisual Communication",
-  "offered": [
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "MECM90037",
-  "name": "Online Community Management",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "MGMT20011",
-  "name": "Business Negotiations",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "MGMT90037",
-  "name": "Conflict and Negotiation",
-  "offered": [
-   "summer_term",
-   "winter_term",
-   "november"
-  ]
- },
- {
-  "code": "MULT20013",
-  "name": "Australia Now",
-  "offered": [
-   "february",
-   "winter_term"
-  ]
- },
- {
-  "code": "MULT30015",
-  "name": "Independent Research Project",
-  "offered": [
-   "summer_term",
-   "semester_1",
-   "winter_term",
-   "semester_2"
-  ]
- },
- {
-  "code": "MULT90014",
-  "name": "Business Risk Management",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "PAED90005",
-  "name": "Child Public Health",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "PERF30001",
-  "name": "Public Event Design",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "PHIL20046",
-  "name": "Feminism",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "PSYC90103",
-  "name": "Psychology of Advertising",
-  "offered": [
-   "winter_term"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "SCIE90013",
@@ -449,43 +165,25 @@
    "semester_1",
    "winter_term",
    "semester_2"
-  ]
+  ],
+  "online": false
  },
  {
-  "code": "SPAN10001",
-  "name": "Spanish 1",
+  "code": "ABPL90404",
+  "name": "Place Making for The Built Environment",
   "offered": [
-   "semester_1",
+   "february",
    "winter_term"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "SPAN20025",
   "name": "Realities and Fictions of Argentina",
   "offered": [
    "winter_term"
-  ]
- },
- {
-  "code": "SPAN30020",
-  "name": "Realities and Fictions of Argentina",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "THTR10007",
-  "name": "The Actors Process",
-  "offered": [
-   "winter_term"
-  ]
- },
- {
-  "code": "THTR20022",
-  "name": "Improvisation: Text, Space and Action",
-  "offered": [
-   "winter_term"
-  ]
+  ],
+  "online": false
  },
  {
   "code": "THTR20043",
@@ -493,7 +191,38 @@
   "offered": [
    "june",
    "winter_term"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS10004",
+  "name": "Ancient Greek 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20026",
+  "name": "Painting Techniques",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "ITAL10008",
+  "name": "Italian 1 (Intensive)",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
  },
  {
   "code": "THTR30042",
@@ -503,13 +232,984 @@
    "february",
    "winter_term",
    "june"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT20011",
+  "name": "Business Negotiations",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "HPSC30037",
+  "name": "Thinking about Science: Past and Present",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "PERF30001",
+  "name": "Public Event Design",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90527",
+  "name": "Digital Product Management",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30063",
+  "name": "AA Visiting School Undergraduate",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90010",
+  "name": "Spatial Information Research Project A",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOM90023",
+  "name": "Spatial Information Research Project B",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90529",
+  "name": "Building Entrepreneurial Ventures",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "GDES30004",
+  "name": "Design Visualisation: Analogue",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "EVSC90014",
+  "name": "Environmental Risk Assessment",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MAST90007",
+  "name": "Statistics for Research Workers",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MECM90031",
+  "name": "Audiovisual Communication",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90525",
+  "name": "Business and Economics Internship",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "DNCE20038",
+  "name": "Global Atelier: Travelling Studio",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20044",
+  "name": "Art and the Botanical",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "KORE30001",
+  "name": "Korean Politics and Society",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL30009",
+  "name": "Advanced Field Geology",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
  },
  {
   "code": "VETS90083",
   "name": "Selection & Interpretation of Lab Tests",
   "offered": [
    "winter_term"
-  ]
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL30070",
+  "name": "Venice Studio",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90490",
+  "name": "Integrative Business Capstone",
+  "offered": [
+   "summer_term",
+   "june",
+   "winter_term",
+   "september"
+  ],
+  "online": false
+ },
+ {
+  "code": "ARTS90027",
+  "name": "Interdisciplinary Industry Project 2",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "AMGT90029",
+  "name": "Applied Research Methods",
+  "offered": [
+   "february",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "GEOL90043",
+  "name": "Fundamentals of Geological CO2 Storage",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90386",
+  "name": "AA Visiting School Graduate",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "ABPL90429",
+  "name": "Venice Studio",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "SPAN30020",
+  "name": "Realities and Fictions of Argentina",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "EURO40002",
+  "name": "Seminars in Languages and Linguistics A",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN30018",
+  "name": "In the Heart of the Loire Valley",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS30045",
+  "name": "Intensive Ancient Greek 1",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT20013",
+  "name": "Australia Now",
+  "offered": [
+   "february",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "CLAS20035",
+  "name": "Intensive Ancient Greek 1",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "FLTV30022",
+  "name": "Making Movies 3 Practical Production",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC30076",
+  "name": "Wakanda: African Futures in Education",
+  "offered": [
+   "march",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "FINA20035",
+  "name": "Drawing with Anatomy",
+  "offered": [
+   "winter_term",
+   "june"
+  ],
+  "online": false
+ },
+ {
+  "code": "PAED90005",
+  "name": "Child Public Health",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "EDUC91017",
+  "name": "Education Randomised Controlled Trials",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MGMT90037",
+  "name": "Conflict and Negotiation",
+  "offered": [
+   "summer_term",
+   "winter_term",
+   "november"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT30015",
+  "name": "Independent Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": false
+ },
+ {
+  "code": "BUSA90513",
+  "name": "Industry Studies in America",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "COMP90050",
+  "name": "Advanced Database Systems",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "PSYC90103",
+  "name": "Psychology of Advertising",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "PHIL20046",
+  "name": "Feminism",
+  "offered": [
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "FREN10004",
+  "name": "French 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": false
+ },
+ {
+  "code": "MULT90014",
+  "name": "Business Risk Management",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MECM90037",
+  "name": "Online Community Management",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "DNCE20040",
+  "name": "Travelling Studio",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90026",
+  "name": "Interdisciplinary Industry Project 1",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90013",
+  "name": "Spatial Information Research Project C",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "SCIE90013",
+  "name": "Communication for Research Scientists",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90404",
+  "name": "Place Making for The Built Environment",
+  "offered": [
+   "february",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN20025",
+  "name": "Realities and Fictions of Argentina",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20045",
+  "name": "Introduction to Screenprinting",
+  "offered": [
+   "summer_term",
+   "march",
+   "april",
+   "winter_term",
+   "june",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN20020",
+  "name": "In the Heart of the Loire Valley",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR10007",
+  "name": "The Actors Process",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "AIND20012",
+  "name": "Ancient & Contemporary Indigenous Arts 2",
+  "offered": [
+   "summer_term",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20036",
+  "name": "Under Camera Animation",
+  "offered": [
+   "summer_term",
+   "february",
+   "winter_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "GERM10004",
+  "name": "German 1",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN10001",
+  "name": "Spanish 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR20022",
+  "name": "Improvisation: Text, Space and Action",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MCEN90049",
+  "name": "Helicopter Design",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOM90020",
+  "name": "Spatial Information Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90319",
+  "name": "GIS In Planning, Design & Development",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC30072",
+  "name": "Positive Leadership and Careers",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20026",
+  "name": "Painting Techniques",
+  "offered": [
+   "summer_term",
+   "february",
+   "semester_1",
+   "winter_term",
+   "june",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC30072",
+  "name": "Positive Leadership and Careers",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS10004",
+  "name": "Ancient Greek 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "HPSC30037",
+  "name": "Thinking about Science: Past and Present",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ITAL10008",
+  "name": "Italian 1 (Intensive)",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "THTR20043",
+  "name": "Design and the Moving Image",
+  "offered": [
+   "june",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT20011",
+  "name": "Business Negotiations",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90513",
+  "name": "Industry Studies in America",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "PAED90005",
+  "name": "Child Public Health",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90037",
+  "name": "Conflict and Negotiation",
+  "offered": [
+   "summer_term",
+   "winter_term",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30015",
+  "name": "Independent Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91017",
+  "name": "Education Randomised Controlled Trials",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90050",
+  "name": "Advanced Database Systems",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90103",
+  "name": "Psychology of Advertising",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN10004",
+  "name": "French 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20046",
+  "name": "Feminism",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "PERF30001",
+  "name": "Public Event Design",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90527",
+  "name": "Digital Product Management",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90529",
+  "name": "Building Entrepreneurial Ventures",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30063",
+  "name": "AA Visiting School Undergraduate",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "KORE30001",
+  "name": "Korean Politics and Society",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL30009",
+  "name": "Advanced Field Geology",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "VETS90083",
+  "name": "Selection & Interpretation of Lab Tests",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL30070",
+  "name": "Venice Studio",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90490",
+  "name": "Integrative Business Capstone",
+  "offered": [
+   "summer_term",
+   "june",
+   "winter_term",
+   "september"
+  ],
+  "online": true
+ },
+ {
+  "code": "ARTS90027",
+  "name": "Interdisciplinary Industry Project 2",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "AMGT90029",
+  "name": "Applied Research Methods",
+  "offered": [
+   "february",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "GEOL90043",
+  "name": "Fundamentals of Geological CO2 Storage",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90386",
+  "name": "AA Visiting School Graduate",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "ABPL90429",
+  "name": "Venice Studio",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "SPAN30020",
+  "name": "Realities and Fictions of Argentina",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "EURO40002",
+  "name": "Seminars in Languages and Linguistics A",
+  "offered": [
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN30018",
+  "name": "In the Heart of the Loire Valley",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS30045",
+  "name": "Intensive Ancient Greek 1",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT20013",
+  "name": "Australia Now",
+  "offered": [
+   "february",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "CLAS20035",
+  "name": "Intensive Ancient Greek 1",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "FLTV30022",
+  "name": "Making Movies 3 Practical Production",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC30076",
+  "name": "Wakanda: African Futures in Education",
+  "offered": [
+   "march",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "FINA20035",
+  "name": "Drawing with Anatomy",
+  "offered": [
+   "winter_term",
+   "june"
+  ],
+  "online": true
+ },
+ {
+  "code": "PAED90005",
+  "name": "Child Public Health",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "EDUC91017",
+  "name": "Education Randomised Controlled Trials",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "MGMT90037",
+  "name": "Conflict and Negotiation",
+  "offered": [
+   "summer_term",
+   "winter_term",
+   "november"
+  ],
+  "online": true
+ },
+ {
+  "code": "MULT30015",
+  "name": "Independent Research Project",
+  "offered": [
+   "summer_term",
+   "semester_1",
+   "winter_term",
+   "semester_2"
+  ],
+  "online": true
+ },
+ {
+  "code": "BUSA90513",
+  "name": "Industry Studies in America",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "COMP90050",
+  "name": "Advanced Database Systems",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "PSYC90103",
+  "name": "Psychology of Advertising",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "PHIL20046",
+  "name": "Feminism",
+  "offered": [
+   "winter_term"
+  ],
+  "online": true
+ },
+ {
+  "code": "FREN10004",
+  "name": "French 1",
+  "offered": [
+   "semester_1",
+   "winter_term"
+  ],
+  "online": true
  }
 ]


### PR DESCRIPTION
Changed `subjectListScraper.ts` to first scrape all online subjects, then scrape all offline subjects, as according to the handbook. `SubjectInfo` now stores a boolean attribute `online` (In addition to `code, name, subjectPeriods`) to note whether the subject is online or in-person. 

Then when the JSON file is written it will contain this new boolean! 

:)