### PR TITLE
Added timetable fetcher that can get through 2FA.

### DIFF
--- a/subject-utils/timetable.py
+++ b/subject-utils/timetable.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Jan 16 16:23:12 2023
+
+@author: stevenp115
+"""
+
+""" How to use:
+1. Create a text file of the form (make sure there is no trailing newline):  
+    username
+    password
+    secret_to_unimelb_login_auth
+2. Call the program as follows:
+    python timetable.py [PATH TO LOGIN TEXT FILE] [YEAR] [SUBJECTS separated by spaces]
+    
+    Example: python timetable.py login_details.txt 2023 MAST10009 FNCE10002 MAST20222 MAST10008
+    
+"""
+
+
+## Fetch login credentials from text file.
+
+import time
+from selenium import webdriver
+from pyotp import *
+import sys
+with open(sys.argv[1], 'r') as fp:
+    details = fp.readlines()
+    username = details[0].strip()
+    password = details[1].strip()
+    secret = details[2].strip()
+
+## Initialise subjects list and year.
+subjects = sys.argv[3:]
+YEAR = int(sys.argv[2])
+init_url = f"https://sws.unimelb.edu.au/{YEAR}/Reports/List.aspx?objects={subjects[0]}&weeks=1-52&days=1-7&periods=1-56&template=module_by_group_list"
+
+## Input your chrome driver path here.
+
+DRIVER_PATH = ##### ENTER YOUR OWN CHROMEDRIVER PATH HERE 
+
+options = webdriver.ChromeOptions()
+driver = webdriver.Chrome(DRIVER_PATH)
+driver.get(init_url)  # Go to the first timetable page (with login).
+time.sleep(0.5)
+
+# Input login credentials.
+driver.find_element_by_id('okta-signin-username').send_keys(username)
+driver.find_element_by_id('okta-signin-password').send_keys(password)
+driver.find_element_by_id('okta-signin-submit').click()
+
+# Give the browser some loading time then fetch/input auth code.
+time.sleep(4)
+totp = TOTP(secret)
+code = totp.now()
+driver.find_element_by_xpath(
+    '/html/body/div[2]/div/div[2]/div/div/form/div[1]/div[2]/div[1]/div[2]/span/input').send_keys(code)
+driver.find_element_by_xpath(
+    '/html/body/div[2]/div/div[2]/div/div/form/div[2]/input').click()
+
+time.sleep(2)
+html_source = driver.page_source  # Get first html.
+with open(f"{subjects[0]}.html", 'w', encoding='utf-8') as fp:
+    fp.write(html_source)
+
+### Now loop over the remaining subjects:
+for subject in subjects[1:]:
+    start_time = time.perf_counter()
+    driver.get(
+        f"https://sws.unimelb.edu.au/{YEAR}/Reports/List.aspx?objects={subject}&weeks=1-52&days=1-7&periods=1-56&template=module_by_group_list")
+    time.sleep(2)
+    html_source = driver.page_source
+    with open(f"{subject}.html", 'w', encoding='utf-8') as fp:
+        fp.write(html_source)
+    end_time = time.perf_counter()
+    print(
+        f"Subject '{subject}' scraped. Time taken: {round(end_time-start_time, 3)} s")

--- a/subject-utils/timetable.py
+++ b/subject-utils/timetable.py
@@ -11,36 +11,54 @@ Created on Mon Jan 16 16:23:12 2023
     password
     secret_to_unimelb_login_auth
 2. Call the program as follows:
-    python timetable.py [PATH TO LOGIN TEXT FILE] [YEAR] [SUBJECTS separated by spaces]
-    
-    Example: python timetable.py login_details.txt 2023 MAST10009 FNCE10002 MAST20222 MAST10008
+    python timetable.py [PATH TO LOGIN TEXT FILE] [YEAR] [Subject json files separated by commas]
     
 """
 
 
-## Fetch login credentials from text file.
+# Get subject data from json(s). We take the set union of all subjects.
 
 import time
 from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.chrome.options import Options
+
+options = Options()
+options.add_argument('--headless')
+options.add_argument('--disable-gpu')
+
 from pyotp import *
 import sys
+import json
+
+subjects = set()
+for json_file in sys.argv[3:]:
+    with open(json_file, 'r') as fp:
+        subject_data = json.load(fp)
+        subjects.update([subj['code'] for subj in subject_data])
+
+print(f"{len(subjects)} subjects loaded.")
+subjects = list(subjects)
+## Fetch login credentials from text file.
+
 with open(sys.argv[1], 'r') as fp:
     details = fp.readlines()
     username = details[0].strip()
     password = details[1].strip()
     secret = details[2].strip()
 
-## Initialise subjects list and year.
-subjects = sys.argv[3:]
+## Initialise year.
 YEAR = int(sys.argv[2])
 init_url = f"https://sws.unimelb.edu.au/{YEAR}/Reports/List.aspx?objects={subjects[0]}&weeks=1-52&days=1-7&periods=1-56&template=module_by_group_list"
 
 ## Input your chrome driver path here.
 
-DRIVER_PATH = ##### ENTER YOUR OWN CHROMEDRIVER PATH HERE 
+DRIVER_PATH = [[ENTER YOUR OWN CHROME DRIVER PATH HERE]]
 
-options = webdriver.ChromeOptions()
-driver = webdriver.Chrome(DRIVER_PATH)
+driver = webdriver.Chrome(DRIVER_PATH, chrome_options=options)
+
 driver.get(init_url)  # Go to the first timetable page (with login).
 time.sleep(0.5)
 
@@ -64,14 +82,21 @@ with open(f"{subjects[0]}.html", 'w', encoding='utf-8') as fp:
     fp.write(html_source)
 
 ### Now loop over the remaining subjects:
-for subject in subjects[1:]:
+
+def scrape_timetable(subject, global_start_time):
     start_time = time.perf_counter()
     driver.get(
         f"https://sws.unimelb.edu.au/{YEAR}/Reports/List.aspx?objects={subject}&weeks=1-52&days=1-7&periods=1-56&template=module_by_group_list")
-    time.sleep(2)
+    WebDriverWait(driver, 5).until(EC.visibility_of_element_located((By.ID, "g-global-menu-logo")))
+    time.sleep(0.1) # Just a bit extra.
     html_source = driver.page_source
     with open(f"{subject}.html", 'w', encoding='utf-8') as fp:
         fp.write(html_source)
     end_time = time.perf_counter()
     print(
-        f"Subject '{subject}' scraped. Time taken: {round(end_time-start_time, 3)} s")
+        f"Subject '{subject}' scraped || Time taken: {round(end_time-start_time, 3)} s || Total time elapsed: {round(end_time-global_start_time, 3)} s")
+
+global_start_time = time.perf_counter()
+
+for subject in subjects[1:]:
+    scrape_timetable(subject, global_start_time)


### PR DESCRIPTION
I can't see any way of possibly doing this in TypeScript. This python script allows you to fetch the timetable data for any number of subjects, and also gets through the Google Authenticator 2FA. Getting through 2FA is a bit of a messy process so you will need to do some stuff beforehand.

**NOTE:** This will need to be run locally as you need to provide a file including your login/authentication details.

1. Download the following Python modules: Selenium, Pyotp.
2. Make sure you have chromedriver.
3. Make sure you have Google Authentication as the primary authenticator for your unimelb account, and save the "secret code" (this can be converted from the OTP URL even after setting up Authentication).
4. Locally store a file with 3 lines: your username, password, and secret key.
5. Where the chromedriver line in the python code is, put the path to your ChromeDriver (Line 40).

That's all. To run the python script, run it like "python timetable.py [PATH TO LOGIN TEXT FILE] [YEAR] [SUBJECTS separated by spaces]", for example, "python timetable.py login_details.txt 2023 FNCE10002 MAST10008". It will save the HTML of the timetable info for each subject. Run time is about 2-3 seconds per subject.

Currently it just saves the HTML in the same folder as this script - this can be changed on Line 73.